### PR TITLE
Add `is_admin()` helper function + profile auto-creation trigger

### DIFF
--- a/supabase/migrations/00004_is_admin_and_profile_trigger.sql
+++ b/supabase/migrations/00004_is_admin_and_profile_trigger.sql
@@ -1,0 +1,78 @@
+-- ============================================================================
+-- 00004_is_admin_and_profile_trigger.sql
+--
+-- Auth helpers (issue #16):
+--   1. is_admin() — SECURITY DEFINER predicate used by RLS policies (#19) to
+--      grant admin override. Reads profiles.role for auth.uid().
+--   2. on_auth_user_created trigger — creates a profiles row whenever Supabase
+--      Auth creates an auth.users row, extracting names from raw_user_meta_data
+--      with email-local-part and literal fallbacks.
+--
+-- Both functions are SECURITY DEFINER with empty search_path and fully-qualified
+-- table references (Supabase security best practice; spec §3.2 omits the
+-- search_path hardening — see #73).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE id = auth.uid()
+      AND role = 'admin'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  meta JSONB := COALESCE(NEW.raw_user_meta_data, '{}'::jsonb);
+  email_local TEXT := split_part(COALESCE(NEW.email, ''), '@', 1);
+  email_first TEXT;
+  email_last  TEXT;
+  fn TEXT;
+  ln TEXT;
+BEGIN
+  IF email_local ~ '[._]' THEN
+    email_first := split_part(regexp_replace(email_local, '[._]', '.', 'g'), '.', 1);
+    email_last  := split_part(regexp_replace(email_local, '[._]', '.', 'g'), '.', 2);
+  ELSE
+    email_first := email_local;
+    email_last  := NULL;
+  END IF;
+
+  fn := COALESCE(
+    NULLIF(meta->>'first_name', ''),
+    NULLIF(meta->>'given_name', ''),
+    NULLIF(email_first, ''),
+    'New'
+  );
+  ln := COALESCE(
+    NULLIF(meta->>'last_name', ''),
+    NULLIF(meta->>'family_name', ''),
+    NULLIF(email_last, ''),
+    'User'
+  );
+
+  IF char_length(fn) < 2 THEN fn := fn || '.'; END IF;
+  IF char_length(ln) < 2 THEN ln := ln || '.'; END IF;
+
+  INSERT INTO public.profiles (id, first_name, last_name)
+    VALUES (NEW.id, fn, ln)
+    ON CONFLICT (id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();


### PR DESCRIPTION
## Summary

Adds 00004_is_admin_and_profile_trigger.sql with two auth helper objects: the `is_admin()` SECURITY DEFINER predicate used by RLS policies, and the `handle_new_user()` trigger that automatically creates a `profiles` row when a user signs up via Supabase Auth.

Closes #16 

## Changes

**New file:** 00004_is_admin_and_profile_trigger.sql

### `public.is_admin()` → `BOOLEAN`

- `LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ''`
- Returns `TRUE` if `profiles.role = 'admin'` for `auth.uid()`
- Fully-qualified table reference (`public.profiles`) — required because `search_path` is locked to `''`
- Consumed by RLS policies in #19 for admin-override clauses across all tables

### `public.handle_new_user()` trigger function

- `LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''`
- Fires AFTER INSERT on `auth.users` via the `on_auth_user_created` trigger
- Name resolution priority (first and last independently):
  1. `raw_user_meta_data` keys: `first_name` / `given_name`, then `last_name` / `family_name`
  2. Email local-part split on `.` or `_` separators
  3. Literal fallbacks: `'New'` / `'User'`
- Single-character fragments are padded with `.` to satisfy the `profiles` `char_length > 1` CHECK constraint
- `INSERT … ON CONFLICT (id) DO NOTHING` — idempotent; safe against duplicate triggers
- Inserts with default `role = 'editor'` (inherited from column default)

### Security hardening note

Both functions use `SET search_path = ''` with fully-qualified references — this follows Supabase SECURITY DEFINER best practice. The spec (`system-design.md §3.2`) omits this hardening; the discrepancy is tracked in #73.

## Acceptance Criteria

- [x] `is_admin()` function created and returns correct boolean
- [x] Profile trigger fires on new user signup (`on_auth_user_created` AFTER INSERT on `auth.users`)
- [x] New profile row created with correct defaults (`role = 'editor'`)
- [x] `is_admin()` works correctly in RLS policy contexts (SECURITY DEFINER reads `profiles` regardless of caller's RLS context)

## Dependencies

Depends on #13 — `public.profiles` table (and its `role` column and `char_length` CHECK constraints) must exist before this migration runs.