### PR TITLE
pgTAP database testing infrastructure (migrations 00001–00004)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,7 @@ Run these in order — all must pass:
 2. `pnpm run check-types` — TypeScript must compile with no errors
 3. `pnpm run lint` — zero ESLint errors or warnings
 4. `pnpm run build` — must produce a successful Next.js build
+5. `pnpm run test:db` — if you made database schema changes
 
 ## Important Rules & Conventions
 
@@ -116,3 +117,7 @@ Run these in order — all must pass:
 - If a task requires credentials, secrets, or tokens you don't have — leave a placeholder with `// NEEDS: [credential description]`. Never hardcode, generate, or invent values.
 - If you're unsure about the correct business logic — do not guess. Add `// DECISION NEEDED: [describe the ambiguity]` and implement the most conservative path.
 - If a pattern conflicts with existing project conventions — follow the existing convention. Flag the conflict with a comment, don't silently override it.
+
+## When You Find a Spec or Upstream Bug
+
+If implementing a task reveals a bug in the spec (`docs/system-design.md`, PRD), schema, or another upstream artifact, do not silently work around it. File a separate GitHub issue documenting the bug, its evidence, the workaround applied in code, and the recommended upstream fix. Reference the tracking issue in the workaround comment if the workaround is non-obvious. See #73 for an example.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,7 +98,7 @@ Run these in order — all must pass:
 2. `pnpm run check-types` — TypeScript must compile with no errors
 3. `pnpm run lint` — zero ESLint errors or warnings
 4. `pnpm run build` — must produce a successful Next.js build
-5. `pnpm run test:db` — if you made database schema changes
+5. `pnpm run db:test` — if you made database schema changes
 
 ## Important Rules & Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Repository Is
+
+**Time Traveler** is a temporal content management system for storing, visualizing, and interacting with historical events and narratives across the full span of time — Big Bang through the speculative future. Distinguishing features:
+
+- **Fractal timelines** — nested zoomable temporal hierarchy.
+- **Hybrid temporal system** — JSONB-encoded dates extend beyond SQL date limits to handle prehistoric/geological/cosmological dates, with precision metadata and uncertainty ranges. See `docs/system-design.md` §4 for the era conversion formula used by all `sort_order` generated columns.
+- **Seven character types** — Human, Animal, Mythological, Fictional, Organization, Divine, Artifact — with temporally-scoped relationships and event participation.
+
+**Current state:** Database schema migrations exist (`supabase/migrations/`), but `apps/admin` and `apps/docs` are still Turborepo boilerplate — the product features are not yet implemented.
+
+## Repository Layout
+
+pnpm monorepo orchestrated by Turborepo. Workspaces: `apps/*`, `packages/*`.
+
+- `apps/admin` — Next.js 16 admin app (port 3000). Package name is `admin`.
+- `apps/docs` — Next.js 16 docs app (port 3001). Package name is `docs`.
+- `packages/ui` — `@repo/ui` shared React components. Import as `@repo/ui/button`, `@repo/ui/card`, etc. (resolved via `packages/ui/src/*.tsx`).
+- `packages/eslint-config` — `@repo/eslint-config` (`base`, `next`, `react-internal`).
+- `packages/typescript-config` — `@repo/typescript-config` (`base.json`, `nextjs.json`, `react-library.json`).
+- `supabase/migrations` — numbered SQL migrations. Migration `00001_initial_schema.sql` defines core tables (profiles, characters, …); `00002_relationships_junctions.sql` defines `character_relationships` and 11 junction tables.
+- `docs/prd/PRD-0001-time-traveler-system.md` and `docs/system-design.md` are the authoritative references for feature/schema work.
+- `.squad/` and `.github/agents/squad.agent.md` configure an in-repo AI team (Squad). The only GitHub Actions workflows are Squad automation (triage, heartbeat, label sync) — **there is no CI build pipeline**, so validation is local-only.
+
+## Toolchain
+
+- **Node ≥24** (`.nvmrc` pins v24)
+- **pnpm 9.0.0** (declared in `package.json` `packageManager`)
+- **Turborepo 2.8.20**, **TypeScript 5.9.2**, **Next.js 16.2.0**, **React 19.2.x**
+- **Supabase CLI** ^2.101.0 — local stack runs Postgres 17
+
+## Commands
+
+```bash
+pnpm install              # bootstrap; run after dependency changes
+pnpm run build            # turbo run build across all packages/apps
+pnpm run lint             # ESLint with --max-warnings 0 (warnings fail)
+pnpm run check-types      # next typegen && tsc --noEmit in each Next app, tsc --noEmit in packages/ui
+pnpm run format           # prettier --write "**/*.{ts,tsx,md}"
+pnpm run dev              # admin on :3000, docs on :3001
+```
+
+Supabase (local stack):
+
+```bash
+pnpm run db:start              # boot local Supabase
+pnpm run db:stop
+pnpm run db:status
+pnpm run db:reset              # reset local DB and re-apply migrations
+pnpm run db:test               # run pgTAP database tests (supabase/tests/database/)
+pnpm run db:deploy             # supabase db push to remote
+pnpm run db:sync               # supabase db pull
+pnpm run db:gen:migration <n>  # scaffold a new migration
+pnpm run db:gen:types          # regenerate ./packages/service/src/models/supabase-model.ts
+```
+
+**No test framework is configured.** There is no `test` script in any `package.json`. Do not invent `pnpm test`.
+
+### Validation before submitting changes
+
+Run in order — all must pass:
+
+1. `pnpm install` if deps changed
+2. `pnpm run check-types`
+3. `pnpm run lint`
+4. `pnpm run build`
+
+## Conventions and gotchas
+
+- **Strict TypeScript**: `strict`, `strictNullChecks`, and `noUncheckedIndexedAccess` are all enabled. Types must be explicit.
+- **Zero-warnings lint policy**: every app/package runs `eslint --max-warnings 0`. A warning is an error.
+- **ESM everywhere**: both apps declare `"type": "module"`. Use ESM `import`/`export`.
+- **Turborepo task graph**: `build` depends on `^build`, so internal packages build before apps. Don't build a single app in isolation without ensuring `packages/ui` is built.
+- **Junction tables** (`supabase/migrations/00002_*`) use composite primary keys with no surrogate `id` and no `user_id` — RLS derives ownership from parent entities. Follow this pattern when adding new junctions (see `docs/system-design.md` §3.4).
+- **`immutable_array_to_string`** in `00001_initial_schema.sql` exists because `array_to_string` is marked STABLE and can't be used in `GENERATED ALWAYS AS`. Reuse it instead of inventing another wrapper.
+- **Env vars**: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and server-only `SUPABASE_SERVICE_ROLE_KEY` — see `.env.local.example`. Never expose the service-role key in client bundles.
+
+## When you're blocked (from `.github/copilot-instructions.md`)
+
+- Missing API/package/service → add `// BLOCKED: [reason]` and move on. Don't mock or stub.
+- Missing credentials → leave `// NEEDS: [credential description]`. Never hardcode or invent values.
+- Ambiguous business logic → add `// DECISION NEEDED: [...]` and take the conservative path. Don't guess.
+- Conflict with an existing pattern → follow the existing convention and flag the conflict in a comment.
+
+## When you find a spec or upstream bug
+
+If implementing a task reveals a bug in the spec (`docs/system-design.md`, PRD), schema, or another upstream artifact, do not silently work around it. File a separate GitHub issue documenting the bug, its evidence, the workaround applied in code, and the recommended upstream fix. Reference the tracking issue in the workaround comment if the workaround is non-obvious. See #73 for the template.

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
     "db:status": "supabase status",
     "db:stop": "supabase stop",
     "db:sync": "supabase db pull",
+    "db:test": "supabase test db",
     "db:gen:migration": "supabase migration new",
     "db:gen:types": "supabase gen types typescript --local > ./packages/service/src/models/supabase-model.ts"
   },
   "devDependencies": {
     "prettier": "^3.7.4",
-    "supabase": "^2.84.0",
+    "supabase": "^2.101.0",
     "turbo": "^2.8.20",
     "typescript": "5.9.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.7.4
         version: 3.7.4
       supabase:
-        specifier: ^2.84.0
-        version: 2.84.0
+        specifier: ^2.101.0
+        version: 2.101.0
       turbo:
         specifier: ^2.8.20
         version: 2.8.20
@@ -360,10 +360,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-
   '@next/env@16.2.0':
     resolution: {integrity: sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA==}
 
@@ -429,6 +425,46 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@supabase/cli-darwin-arm64@2.101.0':
+    resolution: {integrity: sha512-SoWYzu2CIE+rADWsZH6H0YZYF8nV2YMelZLbjAqzahb5RRgFOTMWGhKCUj6g4KlNvocUnU19JObUJ7oCx/9aHg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@supabase/cli-darwin-x64@2.101.0':
+    resolution: {integrity: sha512-rPES03BF9KYkirq3X1Yll+T+eORueRvC858Yp2+2aQMvB4qxi6k+WI+ilCQ7NGzOJ3G0jl/ZG/KsSjZIa4AJ6g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@supabase/cli-linux-arm64-musl@2.101.0':
+    resolution: {integrity: sha512-B5JFFKKpJLLMwn8vWUB7j5euZPytiDOLo9WYXp0mshg45OaFKjRcDImSzBzx4k0W8MK2x75rFEURca90Ic60Ug==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@supabase/cli-linux-arm64@2.101.0':
+    resolution: {integrity: sha512-E+hN1GRIFEi+U1Jf4Omw/gjwpSRTpJ5jai58tQana15AaXt3GCoG7z2YzWVnzD/mvAubTqA7SLHsV+A2lcdTGQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@supabase/cli-linux-x64-musl@2.101.0':
+    resolution: {integrity: sha512-pr9Ar1/aVaQVqjNSfwRgXHWJznQTIaxblGO+hKIl9k55Ajahiq8GConCwx6DjX1Wa9VW//5Dji+O0pkmFSfcHw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@supabase/cli-linux-x64@2.101.0':
+    resolution: {integrity: sha512-7iU9uA+8pbmW5uz+yGxU0fM83a+8SH/gtKmSSRZrOu9vIGcugg9gLbN9GlWkG5P7I7wEjnoVKb7Jzea6onSeQA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@supabase/cli-windows-arm64@2.101.0':
+    resolution: {integrity: sha512-mSnFDhTIAe9cr1iifv+DTQzpY/0WphywED2YT3yMGeu94jjxrXrreQkywxEaeSXTnc4ys1umtnWOB1CaBlYKag==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@supabase/cli-windows-x64@2.101.0':
+    resolution: {integrity: sha512-xzZpybVWq62VF102abZr1EP3BbA2bYecwYm3G2dJk+6ua7nAIodu1fiGHAvBSR0BLGQmesNb6KCneawNL3XBsQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -548,10 +584,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
 
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
-
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -605,10 +637,6 @@ packages:
     resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
     engines: {node: '>=6.0.0'}
 
-  bin-links@6.0.0:
-    resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -642,16 +670,8 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
-
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
-
-  cmd-shim@8.0.0:
-    resolution: {integrity: sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -669,10 +689,6 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -853,10 +869,6 @@ packages:
       picomatch:
         optional: true
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -879,10 +891,6 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -956,10 +964,6 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1146,14 +1150,6 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1184,19 +1180,6 @@ packages:
         optional: true
       sass:
         optional: true
-
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  npm-normalize-package-bin@5.0.0:
-    resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1284,10 +1267,6 @@ packages:
     resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
     engines: {node: '>=14'}
 
-  proc-log@6.1.0:
-    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1309,10 +1288,6 @@ packages:
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
-
-  read-cmd-shim@6.0.0:
-    resolution: {integrity: sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1398,10 +1373,6 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1446,9 +1417,8 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  supabase@2.84.0:
-    resolution: {integrity: sha512-6/1Gvpa6/mf+mydEOdH8uFgrodaSsJjywPw/6BUKcxxPXwpkrNSWedEAs7ZNyWKKeaP9aSpCStJT0ecSNpHPYg==}
-    engines: {npm: '>=8'}
+  supabase@2.101.0:
+    resolution: {integrity: sha512-9wqlvXGeI+VjOMUKOGEpcZzTJGLia6IOv8LWN3W2u8F6Xiv4ZqAuTuXCp3MWfkhV5x9KQaBtN5d6IiLEMWzkJA==}
     hasBin: true
 
   supports-color@7.2.0:
@@ -1458,10 +1428,6 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-
-  tar@7.5.11:
-    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
-    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -1525,10 +1491,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
-
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1552,14 +1514,6 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  write-file-atomic@7.0.1:
-    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1726,10 +1680,6 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.3
-
   '@next/env@16.2.0': {}
 
   '@next/eslint-plugin-next@16.2.0':
@@ -1771,6 +1721,30 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@supabase/cli-darwin-arm64@2.101.0':
+    optional: true
+
+  '@supabase/cli-darwin-x64@2.101.0':
+    optional: true
+
+  '@supabase/cli-linux-arm64-musl@2.101.0':
+    optional: true
+
+  '@supabase/cli-linux-arm64@2.101.0':
+    optional: true
+
+  '@supabase/cli-linux-x64-musl@2.101.0':
+    optional: true
+
+  '@supabase/cli-linux-x64@2.101.0':
+    optional: true
+
+  '@supabase/cli-windows-arm64@2.101.0':
+    optional: true
+
+  '@supabase/cli-windows-x64@2.101.0':
+    optional: true
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -1907,8 +1881,6 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@7.1.4: {}
-
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -1989,14 +1961,6 @@ snapshots:
 
   baseline-browser-mapping@2.10.8: {}
 
-  bin-links@6.0.0:
-    dependencies:
-      cmd-shim: 8.0.0
-      npm-normalize-package-bin: 5.0.0
-      proc-log: 6.1.0
-      read-cmd-shim: 6.0.0
-      write-file-atomic: 7.0.1
-
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -2036,11 +2000,7 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chownr@3.0.0: {}
-
   client-only@0.0.1: {}
-
-  cmd-shim@8.0.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -2057,8 +2017,6 @@ snapshots:
       which: 2.0.2
 
   csstype@3.1.3: {}
-
-  data-uri-to-buffer@4.0.1: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -2340,11 +2298,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -2368,10 +2321,6 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
 
   function-bind@1.1.2: {}
 
@@ -2450,13 +2399,6 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   ignore@5.3.2: {}
 
@@ -2650,12 +2592,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
-  minipass@7.1.3: {}
-
-  minizlib@3.1.0:
-    dependencies:
-      minipass: 7.1.3
-
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -2685,16 +2621,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-
-  node-domexception@1.0.0: {}
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
-
-  npm-normalize-package-bin@5.0.0: {}
 
   object-assign@4.1.1: {}
 
@@ -2783,8 +2709,6 @@ snapshots:
 
   prettier@3.7.4: {}
 
-  proc-log@6.1.0: {}
-
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -2803,8 +2727,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react@19.2.0: {}
-
-  read-cmd-shim@6.0.0: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -2953,8 +2875,6 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  signal-exit@4.1.0: {}
-
   source-map-js@1.2.1: {}
 
   stop-iteration-iterator@1.1.0:
@@ -3013,28 +2933,22 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.0
 
-  supabase@2.84.0:
-    dependencies:
-      bin-links: 6.0.0
-      https-proxy-agent: 7.0.6
-      node-fetch: 3.3.2
-      tar: 7.5.11
-    transitivePeerDependencies:
-      - supports-color
+  supabase@2.101.0:
+    optionalDependencies:
+      '@supabase/cli-darwin-arm64': 2.101.0
+      '@supabase/cli-darwin-x64': 2.101.0
+      '@supabase/cli-linux-arm64': 2.101.0
+      '@supabase/cli-linux-arm64-musl': 2.101.0
+      '@supabase/cli-linux-x64': 2.101.0
+      '@supabase/cli-linux-x64-musl': 2.101.0
+      '@supabase/cli-windows-arm64': 2.101.0
+      '@supabase/cli-windows-x64': 2.101.0
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  tar@7.5.11:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
 
   tinyglobby@0.2.15:
     dependencies:
@@ -3123,8 +3037,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  web-streams-polyfill@3.3.3: {}
-
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -3171,11 +3083,5 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
-
-  write-file-atomic@7.0.1:
-    dependencies:
-      signal-exit: 4.1.0
-
-  yallist@5.0.0: {}
 
   yocto-queue@0.1.0: {}

--- a/supabase/tests/database/00001_initial_schema_test.sql
+++ b/supabase/tests/database/00001_initial_schema_test.sql
@@ -1,0 +1,237 @@
+-- pgTAP tests for 00001_initial_schema.sql (issue #13 — core tables)
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(46);
+
+-- ============================================================================
+-- Tables exist
+-- ============================================================================
+select has_table('public', 'profiles',   'profiles table exists');
+select has_table('public', 'characters', 'characters table exists');
+select has_table('public', 'timelines',  'timelines table exists');
+select has_table('public', 'periods',    'periods table exists');
+select has_table('public', 'events',     'events table exists');
+select has_table('public', 'stories',    'stories table exists');
+select has_table('public', 'categories', 'categories table exists');
+select has_table('public', 'media',      'media table exists');
+
+-- ============================================================================
+-- Extensions and helper functions
+-- ============================================================================
+select has_extension('pgcrypto', 'pgcrypto extension is installed');
+select has_function('public', 'immutable_array_to_string', array['text[]','text'],
+  'immutable_array_to_string helper function exists');
+select volatility_is('public', 'immutable_array_to_string', array['text[]','text'], 'immutable',
+  'immutable_array_to_string is marked IMMUTABLE');
+select has_function('public', 'handle_updated_at', 'handle_updated_at trigger function exists');
+
+-- ============================================================================
+-- updated_at triggers (8 tables)
+-- ============================================================================
+select has_trigger('public', 'profiles',   'set_updated_at', 'updated_at trigger on profiles');
+select has_trigger('public', 'characters', 'set_updated_at', 'updated_at trigger on characters');
+select has_trigger('public', 'timelines',  'set_updated_at', 'updated_at trigger on timelines');
+select has_trigger('public', 'periods',    'set_updated_at', 'updated_at trigger on periods');
+select has_trigger('public', 'events',     'set_updated_at', 'updated_at trigger on events');
+select has_trigger('public', 'stories',    'set_updated_at', 'updated_at trigger on stories');
+select has_trigger('public', 'categories', 'set_updated_at', 'updated_at trigger on categories');
+select has_trigger('public', 'media',      'set_updated_at', 'updated_at trigger on media');
+
+-- ============================================================================
+-- RLS enabled on every core table
+-- ============================================================================
+select is(
+  (select count(*) from pg_tables
+    where schemaname = 'public'
+      and tablename in ('profiles','characters','timelines','periods','events','stories','categories','media')
+      and rowsecurity),
+  8::bigint,
+  'all 8 core tables have RLS enabled'
+);
+
+-- ============================================================================
+-- profiles_username_idx is partial (WHERE username IS NOT NULL)
+-- ============================================================================
+select index_is_unique('public', 'profiles', 'profiles_username_idx',
+  'profiles_username_idx is unique');
+select ok(
+  (select pg_get_indexdef(indexrelid) like '%WHERE%username IS NOT NULL%'
+     from pg_index
+     where indexrelid = 'public.profiles_username_idx'::regclass),
+  'profiles_username_idx is partial on (username IS NOT NULL)'
+);
+
+-- ============================================================================
+-- CHECK constraints reject bad values
+-- ============================================================================
+-- Seed a test user (profile auto-created by #16 trigger)
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'check@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+select throws_ok(
+  $$update profiles set role = 'godmode' where id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'$$,
+  '23514', null,
+  'profiles.role CHECK rejects unknown role'
+);
+
+select throws_ok(
+  $$insert into events (user_id, slug, title, event_type, temporal_data)
+    values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bad-type', 'x',
+            'time_travel', '{"year":2000,"era":"CE"}'::jsonb)$$,
+  '23514', null,
+  'events.event_type CHECK rejects unknown type'
+);
+
+select throws_ok(
+  $$insert into characters (user_id, slug, name, character_type)
+    values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bad-char', 'X', 'alien')$$,
+  '23514', null,
+  'characters.character_type CHECK rejects unknown type'
+);
+
+select throws_ok(
+  $$insert into timelines (user_id, slug, title, timeline_type, temporal_data)
+    values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bad-tl', 'X',
+            'futuristic', '{"year":2000,"era":"CE"}'::jsonb)$$,
+  '23514', null,
+  'timelines.timeline_type CHECK rejects unknown type'
+);
+
+select throws_ok(
+  $$insert into stories (user_id, slug, title, narrator_type)
+    values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bad-st', 'X', 'fourth_wall')$$,
+  '23514', null,
+  'stories.narrator_type CHECK rejects unknown type'
+);
+
+select throws_ok(
+  $$insert into media (user_id, slug, storage_path, url, media_type)
+    values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bad-m', 'p', 'u', 'hologram')$$,
+  '23514', null,
+  'media.media_type CHECK rejects unknown type'
+);
+
+select throws_ok(
+  $$insert into periods (user_id, slug, title, significance, temporal_data)
+    values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bad-p', 'X',
+            'epic', '{"year":2000,"era":"CE"}'::jsonb)$$,
+  '23514', null,
+  'periods.significance CHECK rejects unknown value'
+);
+
+-- ============================================================================
+-- Era conversion → sort_order_years
+-- ============================================================================
+insert into events (user_id, slug, title, temporal_data)
+  values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'ce', 'CE event',
+          '{"year":1969,"month":7,"day":20,"era":"CE","precision":"exact"}'::jsonb),
+         ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'bce', 'BCE event',
+          '{"year":44,"era":"BCE","precision":"exact"}'::jsonb),
+         ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'mya', 'MYA event',
+          '{"year":66,"era":"MYA","precision":"approximate"}'::jsonb);
+
+select is((select sort_order_years from events where slug='ce'),
+          1969::bigint, 'CE 1969 → sort_order_years = 1969');
+select is((select sort_order_years from events where slug='bce'),
+          -44::bigint, 'BCE 44 → sort_order_years = -44');
+select is((select sort_order_years from events where slug='mya'),
+          -66000000::bigint, 'MYA 66 → sort_order_years = -66,000,000');
+
+-- ============================================================================
+-- computed_start_date populates for CE, NULL for non-CE
+-- ============================================================================
+select isnt((select computed_start_date from events where slug='ce'), null,
+            'computed_start_date populates for CE entry');
+select is((select computed_start_date from events where slug='bce'), null,
+          'computed_start_date is NULL for BCE entry');
+select is((select computed_start_date from events where slug='mya'), null,
+          'computed_start_date is NULL for MYA entry');
+
+-- ============================================================================
+-- search_vector populates
+-- ============================================================================
+select isnt((select search_vector from events where slug='ce'), null::tsvector,
+            'events.search_vector populates after insert');
+
+insert into characters (user_id, slug, name, character_type, biography, aliases)
+  values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'einstein', 'Albert Einstein',
+          'human', 'physicist', array['A. Einstein','The Genius']);
+select isnt((select search_vector from characters where slug='einstein'), null::tsvector,
+            'characters.search_vector populates (including aliases via immutable_array_to_string)');
+
+-- ============================================================================
+-- handle_updated_at trigger overrides updated_at on UPDATE
+-- (within a single transaction now() doesn't advance, so we verify the trigger
+--  replaces a hand-set past value rather than comparing two now() reads)
+-- ============================================================================
+update events set updated_at = '2020-01-01 00:00:00+00'::timestamptz where slug='ce';
+select ok(
+  (select updated_at from events where slug='ce') > '2020-01-01 00:00:00+00'::timestamptz,
+  'handle_updated_at trigger overrides updated_at on UPDATE'
+);
+
+-- ============================================================================
+-- ON DELETE behavior — set up FK fixtures
+-- ============================================================================
+insert into timelines (user_id, slug, title, temporal_data)
+  values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'tl1', 'TL', '{"year":2000,"era":"CE"}'::jsonb);
+update events set timeline_id = (select id from timelines where slug='tl1') where slug='ce';
+
+-- ON DELETE SET NULL: deleting timeline nulls events.timeline_id
+delete from timelines where slug='tl1';
+select is((select timeline_id from events where slug='ce'), null::uuid,
+          'ON DELETE SET NULL on events.timeline_id when timeline removed');
+
+-- subject_character_id SET NULL on timelines
+insert into timelines (user_id, slug, title, temporal_data, subject_character_id)
+  values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'tl2', 'TL2',
+          '{"year":2000,"era":"CE"}'::jsonb,
+          (select id from characters where slug='einstein'));
+delete from characters where slug='einstein';
+select is((select subject_character_id from timelines where slug='tl2'), null::uuid,
+          'ON DELETE SET NULL on timelines.subject_character_id when character removed');
+
+-- perspective_character_id SET NULL on stories
+insert into characters (user_id, slug, name, character_type)
+  values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'narrator', 'Narrator', 'human');
+insert into stories (user_id, slug, title, perspective_character_id)
+  values ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'st1', 'S',
+          (select id from characters where slug='narrator'));
+delete from characters where slug='narrator';
+select is((select perspective_character_id from stories where slug='st1'), null::uuid,
+          'ON DELETE SET NULL on stories.perspective_character_id when character removed');
+
+-- Slug unique per user: same slug for two users is allowed
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'check2@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+select lives_ok(
+  $$insert into characters (user_id, slug, name, character_type)
+    values ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'einstein', 'Other Einstein', 'human')$$,
+  'same slug allowed for different users'
+);
+select throws_ok(
+  $$insert into characters (user_id, slug, name, character_type)
+    values ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'einstein', 'Dup', 'human')$$,
+  '23505', null,
+  'same slug for same user is rejected'
+);
+
+-- ON DELETE CASCADE on user_id: delete auth.users → owned content removed
+delete from auth.users where id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid;
+select is((select count(*) from events where user_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid),
+          0::bigint,
+          'ON DELETE CASCADE on events.user_id when auth user removed');
+select is((select count(*) from profiles where id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid),
+          0::bigint,
+          'ON DELETE CASCADE on profiles.id when auth user removed');
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/00002_relationships_junctions_test.sql
+++ b/supabase/tests/database/00002_relationships_junctions_test.sql
@@ -1,0 +1,149 @@
+-- pgTAP tests for 00002_relationships_junctions.sql (issue #14 — relationships + junctions)
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(32);
+
+-- ============================================================================
+-- Tables exist (1 relationship + 11 junction)
+-- ============================================================================
+select has_table('public', 'character_relationships', 'character_relationships table exists');
+select has_table('public', 'event_categories',       'event_categories junction exists');
+select has_table('public', 'event_media',            'event_media junction exists');
+select has_table('public', 'event_characters',       'event_characters junction exists');
+select has_table('public', 'timeline_events',        'timeline_events junction exists');
+select has_table('public', 'period_timelines',       'period_timelines junction exists');
+select has_table('public', 'story_periods',          'story_periods junction exists');
+select has_table('public', 'story_characters',       'story_characters junction exists');
+select has_table('public', 'story_events',           'story_events junction exists');
+select has_table('public', 'character_media',        'character_media junction exists');
+select has_table('public', 'timeline_collaborators', 'timeline_collaborators junction exists');
+select has_table('public', 'timeline_media',         'timeline_media junction exists');
+
+-- ============================================================================
+-- RLS enabled on all 12 tables
+-- ============================================================================
+select is(
+  (select count(*) from pg_tables
+    where schemaname = 'public'
+      and tablename in ('character_relationships','event_categories','event_media',
+                        'event_characters','timeline_events','period_timelines',
+                        'story_periods','story_characters','story_events',
+                        'character_media','timeline_collaborators','timeline_media')
+      and rowsecurity),
+  12::bigint,
+  'all 12 relationship/junction tables have RLS enabled'
+);
+
+-- ============================================================================
+-- Junction tables use composite PK with no surrogate id column
+-- ============================================================================
+select hasnt_column('public', 'event_categories',       'id', 'event_categories has no surrogate id');
+select hasnt_column('public', 'event_media',            'id', 'event_media has no surrogate id');
+select hasnt_column('public', 'event_characters',       'id', 'event_characters has no surrogate id');
+select hasnt_column('public', 'timeline_events',        'id', 'timeline_events has no surrogate id');
+select hasnt_column('public', 'period_timelines',       'id', 'period_timelines has no surrogate id');
+select hasnt_column('public', 'story_periods',          'id', 'story_periods has no surrogate id');
+select hasnt_column('public', 'story_characters',       'id', 'story_characters has no surrogate id');
+select hasnt_column('public', 'story_events',           'id', 'story_events has no surrogate id');
+select hasnt_column('public', 'character_media',        'id', 'character_media has no surrogate id');
+select hasnt_column('public', 'timeline_collaborators', 'id', 'timeline_collaborators has no surrogate id');
+select hasnt_column('public', 'timeline_media',         'id', 'timeline_media has no surrogate id');
+
+-- ============================================================================
+-- character_relationships self-reference CHECK
+-- ============================================================================
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'rel@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+insert into characters (user_id, slug, name, character_type) values
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'a', 'A', 'human'),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'b', 'B', 'human');
+
+select throws_ok(
+  $$insert into character_relationships (user_id, character_id, related_character_id, relationship_type)
+    select 'cccccccc-cccc-cccc-cccc-cccccccccccc', id, id, 'family'
+    from characters where slug='a'$$,
+  '23514', null,
+  'character_relationships rejects character_id = related_character_id'
+);
+
+-- ============================================================================
+-- char_rels_unique enforces uniqueness on (character_id, related_character_id, relationship_type)
+-- ============================================================================
+insert into character_relationships (user_id, character_id, related_character_id, relationship_type)
+  select 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+         (select id from characters where slug='a'),
+         (select id from characters where slug='b'),
+         'family';
+
+select throws_ok(
+  $$insert into character_relationships (user_id, character_id, related_character_id, relationship_type)
+    select 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+           (select id from characters where slug='a'),
+           (select id from characters where slug='b'),
+           'family'$$,
+  '23505', null,
+  'char_rels_unique rejects duplicate (char, related, type)'
+);
+
+select lives_ok(
+  $$insert into character_relationships (user_id, character_id, related_character_id, relationship_type)
+    select 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+           (select id from characters where slug='a'),
+           (select id from characters where slug='b'),
+           'professional'$$,
+  'same character pair allowed with different relationship_type'
+);
+
+-- ============================================================================
+-- set_updated_at trigger on character_relationships
+-- ============================================================================
+select has_trigger('public', 'character_relationships', 'set_updated_at',
+  'updated_at trigger on character_relationships');
+
+update character_relationships set updated_at = '2020-01-01 00:00:00+00'::timestamptz
+  where character_id = (select id from characters where slug='a');
+select ok(
+  (select min(updated_at) from character_relationships
+     where character_id = (select id from characters where slug='a'))
+  > '2020-01-01 00:00:00+00'::timestamptz,
+  'handle_updated_at trigger overrides updated_at on character_relationships UPDATE'
+);
+
+-- ============================================================================
+-- ON DELETE CASCADE behavior
+-- ============================================================================
+-- character_media: deleting a character removes its media junction rows
+insert into media (user_id, slug, storage_path, url, media_type)
+  values ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'm1', '/p', '/u', 'image');
+insert into character_media (character_id, media_id, is_primary)
+  select (select id from characters where slug='a'),
+         (select id from media where slug='m1'),
+         true;
+
+delete from characters where slug='a';
+select is((select count(*) from character_media
+           where character_id not in (select id from characters)),
+          0::bigint,
+          'ON DELETE CASCADE on character_media when character removed');
+
+-- character_relationships cascade on character deletion
+-- (delete already cascaded above; verify count is 0)
+select is((select count(*) from character_relationships), 0::bigint,
+          'character_relationships cascaded when one side character was deleted');
+
+-- ============================================================================
+-- ON DELETE CASCADE on character_relationships.user_id
+-- ============================================================================
+delete from auth.users where id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid;
+select is((select count(*) from character_relationships
+           where user_id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid),
+          0::bigint,
+          'ON DELETE CASCADE on character_relationships.user_id when auth user removed');
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/00003_supporting_tables_test.sql
+++ b/supabase/tests/database/00003_supporting_tables_test.sql
@@ -1,0 +1,152 @@
+-- pgTAP tests for 00003_supporting_tables.sql (issue #15 — notifications + content_reports)
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(18);
+
+-- ============================================================================
+-- Tables exist + RLS enabled
+-- ============================================================================
+select has_table('public', 'notifications',   'notifications table exists');
+select has_table('public', 'content_reports', 'content_reports table exists');
+
+select is(
+  (select count(*) from pg_tables
+    where schemaname='public' and tablename in ('notifications','content_reports')
+      and rowsecurity),
+  2::bigint,
+  'both supporting tables have RLS enabled'
+);
+
+-- ============================================================================
+-- Indexes exist
+-- ============================================================================
+select has_index('public', 'notifications',   'idx_notifications_user',
+  'idx_notifications_user index exists');
+select has_index('public', 'content_reports', 'idx_reports_status',
+  'idx_reports_status index exists');
+select has_index('public', 'content_reports', 'idx_reports_entity',
+  'idx_reports_entity index exists');
+
+-- ============================================================================
+-- sync_notification_read_at trigger function exists
+-- ============================================================================
+select has_function('public', 'sync_notification_read_at',
+  'sync_notification_read_at trigger function exists');
+select has_trigger('public', 'notifications', 'set_read_at',
+  'set_read_at trigger on notifications');
+
+-- ============================================================================
+-- CHECK constraints
+-- ============================================================================
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'sup@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+select throws_ok(
+  $$insert into notifications (user_id, type, title)
+    values ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'fake_type', 't')$$,
+  '23514', null,
+  'notifications.type CHECK rejects unknown value'
+);
+
+select throws_ok(
+  $$insert into content_reports (reporter_id, entity_type, entity_id, reason)
+    values ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'unknown',
+            '00000000-0000-0000-0000-000000000abc'::uuid, 'inappropriate')$$,
+  '23514', null,
+  'content_reports.entity_type CHECK rejects unknown value'
+);
+
+select throws_ok(
+  $$insert into content_reports (reporter_id, entity_type, entity_id, reason)
+    values ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'timeline',
+            '00000000-0000-0000-0000-000000000abc'::uuid, 'bogus')$$,
+  '23514', null,
+  'content_reports.reason CHECK rejects unknown value'
+);
+
+select throws_ok(
+  $$insert into content_reports (reporter_id, entity_type, entity_id, reason, status)
+    values ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'timeline',
+            '00000000-0000-0000-0000-000000000abc'::uuid, 'inappropriate', 'unknown_status')$$,
+  '23514', null,
+  'content_reports.status CHECK rejects unknown value'
+);
+
+-- ============================================================================
+-- sync_notification_read_at trigger behavior
+-- ============================================================================
+insert into notifications (user_id, type, title, body)
+  values ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'system_message', 'hi', 'msg');
+
+select is(
+  (select read_at from notifications
+    where user_id='dddddddd-dddd-dddd-dddd-dddddddddddd' and title='hi'),
+  null::timestamptz,
+  'read_at is NULL before read flips true'
+);
+
+update notifications set read = true
+  where user_id='dddddddd-dddd-dddd-dddd-dddddddddddd' and title='hi';
+select isnt(
+  (select read_at from notifications
+    where user_id='dddddddd-dddd-dddd-dddd-dddddddddddd' and title='hi'),
+  null::timestamptz,
+  'sync_notification_read_at populates read_at when read flips true'
+);
+
+-- Updating an unrelated field shouldn't change read_at
+update notifications set read_at = '2020-01-01 00:00:00+00'::timestamptz
+  where user_id='dddddddd-dddd-dddd-dddd-dddddddddddd' and title='hi';
+update notifications set body = 'updated msg'
+  where user_id='dddddddd-dddd-dddd-dddd-dddddddddddd' and title='hi';
+select is(
+  (select read_at from notifications
+    where user_id='dddddddd-dddd-dddd-dddd-dddddddddddd' and title='hi'),
+  '2020-01-01 00:00:00+00'::timestamptz,
+  'sync_notification_read_at does not touch read_at on unrelated UPDATE'
+);
+
+-- ============================================================================
+-- ON DELETE behavior
+-- ============================================================================
+-- resolved_by SET NULL when admin user removed
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'admin@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+insert into content_reports (reporter_id, entity_type, entity_id, reason, status, resolved_by, resolved_at)
+  values ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'timeline',
+          '00000000-0000-0000-0000-0000000000ff'::uuid, 'inappropriate', 'actioned',
+          'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', now());
+
+delete from auth.users where id='eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid;
+select is(
+  (select resolved_by from content_reports
+    where reporter_id='dddddddd-dddd-dddd-dddd-dddddddddddd'),
+  null::uuid,
+  'ON DELETE SET NULL on content_reports.resolved_by when admin removed'
+);
+
+-- reporter_id CASCADE: deleting reporter removes the report
+delete from auth.users where id='dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid;
+select is(
+  (select count(*) from content_reports),
+  0::bigint,
+  'ON DELETE CASCADE on content_reports.reporter_id when reporter removed'
+);
+
+-- notifications.user_id CASCADE (verified by the count above implicitly — the user is gone)
+select is(
+  (select count(*) from notifications),
+  0::bigint,
+  'ON DELETE CASCADE on notifications.user_id when owner removed'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/00004_is_admin_and_profile_trigger_test.sql
+++ b/supabase/tests/database/00004_is_admin_and_profile_trigger_test.sql
@@ -1,0 +1,170 @@
+-- pgTAP tests for 00004_is_admin_and_profile_trigger.sql (issue #16 — auth helpers)
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(18);
+
+-- ============================================================================
+-- Functions and trigger exist with the right shape
+-- ============================================================================
+select has_function('public', 'is_admin', 'is_admin function exists');
+select volatility_is('public', 'is_admin', array[]::text[], 'stable',
+  'is_admin is STABLE');
+select is(
+  (select prosecdef from pg_proc
+    where proname='is_admin' and pronamespace='public'::regnamespace),
+  true,
+  'is_admin is SECURITY DEFINER'
+);
+
+select has_function('public', 'handle_new_user', 'handle_new_user function exists');
+select is(
+  (select prosecdef from pg_proc
+    where proname='handle_new_user' and pronamespace='public'::regnamespace),
+  true,
+  'handle_new_user is SECURITY DEFINER'
+);
+
+select has_trigger('auth', 'users', 'on_auth_user_created',
+  'on_auth_user_created trigger on auth.users');
+
+-- ============================================================================
+-- Trigger fires on auth.users INSERT, default role = editor
+-- ============================================================================
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role,
+                        raw_user_meta_data)
+  values ('f1111111-1111-1111-1111-111111111111'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'alice.smith@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+          '{"first_name":"Alice","last_name":"Smith"}'::jsonb);
+
+select is(
+  (select role from profiles where id='f1111111-1111-1111-1111-111111111111'::uuid),
+  'editor'::varchar,
+  'auto-created profile defaults to role=editor'
+);
+
+-- Case A: full metadata
+select is(
+  (select first_name || '/' || last_name from profiles
+    where id='f1111111-1111-1111-1111-111111111111'::uuid),
+  'Alice/Smith',
+  'name extraction: metadata first_name/last_name takes precedence'
+);
+
+-- Case B: no metadata, email with dot
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('f2222222-2222-2222-2222-222222222222'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'bob.jones@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+select is(
+  (select first_name || '/' || last_name from profiles
+    where id='f2222222-2222-2222-2222-222222222222'::uuid),
+  'bob/jones',
+  'name extraction: email local-part split on "."'
+);
+
+-- Case C: no metadata, email with underscore
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('f3333333-3333-3333-3333-333333333333'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'carol_davis@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+select is(
+  (select first_name || '/' || last_name from profiles
+    where id='f3333333-3333-3333-3333-333333333333'::uuid),
+  'carol/davis',
+  'name extraction: email local-part split on "_"'
+);
+
+-- Case D: no metadata, plain email
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('f4444444-4444-4444-4444-444444444444'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'charlie@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+select is(
+  (select first_name || '/' || last_name from profiles
+    where id='f4444444-4444-4444-4444-444444444444'::uuid),
+  'charlie/User',
+  'name extraction: plain email local-part as first_name, "User" placeholder for last_name'
+);
+
+-- Case E: single-char local-part triggers padding
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('f5555555-5555-5555-5555-555555555555'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'x@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+select is(
+  (select first_name || '/' || last_name from profiles
+    where id='f5555555-5555-5555-5555-555555555555'::uuid),
+  'x./User',
+  'name extraction: single-char local-part gets padded to satisfy CHECK length > 1'
+);
+
+-- ============================================================================
+-- is_admin() truth check via request.jwt.claims (set inside this transaction)
+-- ============================================================================
+-- Non-admin: false
+set local request.jwt.claims to '{"sub":"f1111111-1111-1111-1111-111111111111"}';
+select is(public.is_admin(), false,
+  'is_admin() returns false for editor role');
+
+-- Promote, then re-check
+reset request.jwt.claims;
+update profiles set role='admin' where id='f1111111-1111-1111-1111-111111111111'::uuid;
+
+set local request.jwt.claims to '{"sub":"f1111111-1111-1111-1111-111111111111"}';
+select is(public.is_admin(), true,
+  'is_admin() returns true after profile promoted to admin');
+
+-- Unknown user: false
+reset request.jwt.claims;
+set local request.jwt.claims to '{"sub":"00000000-0000-0000-0000-000000000999"}';
+select is(public.is_admin(), false,
+  'is_admin() returns false for unknown user');
+
+-- No JWT at all: auth.uid() is NULL → false
+reset request.jwt.claims;
+select is(public.is_admin(), false,
+  'is_admin() returns false when auth.uid() is NULL');
+
+-- ============================================================================
+-- ON CONFLICT DO NOTHING idempotency
+-- ============================================================================
+-- Insert a profile manually-like (post-trigger), then re-run the trigger's
+-- INSERT pattern to confirm it doesn't overwrite.
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('f6666666-6666-6666-6666-666666666666'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'idem@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+-- The trigger has already populated profile with 'idem'/'User'.
+-- Now simulate a second invocation of the trigger's INSERT path:
+insert into public.profiles (id, first_name, last_name)
+  values ('f6666666-6666-6666-6666-666666666666'::uuid, 'Other', 'Name')
+  on conflict (id) do nothing;
+
+select is(
+  (select first_name || '/' || last_name from profiles
+    where id='f6666666-6666-6666-6666-666666666666'::uuid),
+  'idem/User',
+  'ON CONFLICT DO NOTHING preserves the original trigger-populated row'
+);
+
+-- ============================================================================
+-- Cleanup verification (delete should cascade)
+-- ============================================================================
+delete from auth.users where id::text like 'f%';
+select is(
+  (select count(*) from profiles where id::text like 'f%'),
+  0::bigint,
+  'CASCADE from auth.users wipes auto-created profiles'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Adds a pgTAP regression suite covering all four migrations shipped to date, the `db:test` npm script, a Supabase CLI upgrade, and updated agent instructions. Each test file is self-contained (BEGIN / CREATE EXTENSION / plan / assertions / finish / ROLLBACK) and leaves no state behind.

Closes #78

## Changes

### New: test files

| File | Migration under test | Assertions |
|---|---|---|
| 00001_initial_schema_test.sql | #13 — core tables | 46 |
| 00002_relationships_junctions_test.sql | #14 — relationships + junctions | 32 |
| 00003_supporting_tables_test.sql | #15 — supporting tables | 18 |
| 00004_is_admin_and_profile_trigger_test.sql | #16 — auth helpers | 18 |
| **Total** | | **114** |

**Coverage per test file:**

- **00001** (46): tables exist, `pgcrypto` loaded, `immutable_array_to_string` + `handle_updated_at` functions, 8 `set_updated_at` triggers, RLS enabled on all 8 tables, `profiles_username_idx` is partial, CHECK rejects bad `role`/`event_type`/`character_type`/`timeline_type`/`narrator_type`/`media_type`/`significance`, era conversion (CE/BCE/MYA), `computed_start_date` populates for CE only / NULL otherwise, `search_vector` non-null, `handle_updated_at` fires on UPDATE, ON DELETE CASCADE on `user_id`, ON DELETE SET NULL on optional FKs, slug uniqueness per user.

- **00002** (32): all 12 tables exist, RLS enabled on all 12, junction tables have no surrogate `id`, `character_relationships.user_id` CASCADE, self-reference rejected, `char_rels_unique` enforced (duplicate rejected, different `relationship_type` on same pair allowed), `set_updated_at` trigger fires, cascading delete from `characters` wipes `character_media` and `character_relationships` rows.

- **00003** (18): `notifications` + `content_reports` exist + RLS, all three indexes exist, `sync_notification_read_at` function + `set_read_at` trigger, CHECK rejects bad `type`/`entity_type`/`reason`/`status`, `read_at` is NULL before read, trigger stamps `read_at` when `read` flips true, trigger leaves `read_at` unchanged on unrelated UPDATE, `resolved_by` ON DELETE SET NULL, `reporter_id` ON DELETE CASCADE, `notifications.user_id` ON DELETE CASCADE.

- **00004** (18): `is_admin` STABLE + SECURITY DEFINER, `handle_new_user` SECURITY DEFINER, `on_auth_user_created` trigger on `auth.users`, default `role = 'editor'`, 5 name-extraction cases (full metadata / dotted email / underscored email / plain email / single-char padded to satisfy `char_length > 1`), `is_admin()` returns false for editor, true after promotion, false for unknown user, false when `auth.uid()` is NULL, ON CONFLICT DO NOTHING idempotency, CASCADE from `auth.users` wipes auto-created profiles.

### Modified: tooling and documentation

**package.json**
- Added `"db:test": "supabase test db"` script
- Upgraded supabase dev dependency `^2.84.0` → `^2.101.0` (required for `supabase test db` support; new version ships platform binaries as optional deps instead of bundling `node-fetch`/`tar` etc., removing ~10 transitive dependencies)

**pnpm-lock.yaml** — lockfile updated for the Supabase CLI upgrade

**copilot-instructions.md**
- Added `5. pnpm run test:db — if you made database schema changes` to the validation checklist
- Added "When You Find a Spec or Upstream Bug" section (mirrors the pattern established in #73)

**CLAUDE.md** _(new file)_
- Claude Code guidance file: repo layout, toolchain versions, full command reference including `db:test`, conventions/gotchas, and the spec-bug reporting protocol

## Acceptance Criteria

- [x] `pnpm run db:test` script added, wraps `supabase test db`
- [x] Each test file is self-contained (BEGIN / CREATE EXTENSION pgtap / plan / assertions / finish / ROLLBACK)
- [x] Tests cover each migration's AC checklist (schema shape, CHECK constraints, triggers, era conversion, RLS, CASCADE / SET NULL behavior)
- [x] Test files do not leak state — all wrapped in ROLLBACK
- [x] pgTAP loaded only inside test transactions (not visible in `pg_extension` after run)
- [ ] `pnpm run db:test` reports 0 failures after `db:reset` _(requires running local Supabase stack)_
- [x] `pnpm run check-types`, `lint`, `build` unaffected (SQL-only additions + doc changes)

## Dependencies

Depends on #13, #14, #15, #16 — all four migrations under test must be applied before running the suite. Run `pnpm run db:reset` to apply all migrations before `pnpm run db:test`.