### PR TITLE
Performance indexes migration + paired pgTAP tests

### DIFF
--- a/supabase/migrations/00005_performance_indexes.sql
+++ b/supabase/migrations/00005_performance_indexes.sql
@@ -1,0 +1,47 @@
+-- ============================================================================
+-- 00005_performance_indexes.sql
+--
+-- Performance indexes (issue #17). See docs/system-design.md §8.1.
+--
+-- Slug indexes (per-table unique on user_id+slug) are already created by
+-- 00001 and 00002 and are not recreated here. This migration adds:
+--   - Temporal sort/range indexes on events and periods
+--   - GIN indexes on the four search_vector columns
+--   - GIN index on characters.aliases (array)
+--   - BTREE index on characters.character_type for type-filtering
+--   - Junction-table reverse FK indexes (for queries that filter by the
+--     non-leading column of a composite PK)
+--   - Parent self-reference indexes for fractal nesting traversal
+--
+-- Note: idx_event_chars_event is redundant with the event_characters PK
+-- (event_id, character_id) whose leading column already indexes event_id.
+-- Included per spec §8.1 literal for AC compliance; flagged in #73.
+-- ============================================================================
+
+-- Temporal ordering and range
+CREATE INDEX idx_events_sort           ON events (sort_order_years);
+CREATE INDEX idx_events_timeline_sort  ON events (timeline_id, sort_order_years);
+CREATE INDEX idx_events_range          ON events (sort_order_years, sort_order_end);
+CREATE INDEX idx_periods_sort          ON periods (sort_order_start);
+
+-- Full-text search (GIN on tsvector)
+CREATE INDEX idx_events_search     ON events     USING GIN (search_vector);
+CREATE INDEX idx_timelines_search  ON timelines  USING GIN (search_vector);
+CREATE INDEX idx_characters_search ON characters USING GIN (search_vector);
+CREATE INDEX idx_stories_search    ON stories    USING GIN (search_vector);
+
+-- Character lookups
+CREATE INDEX idx_characters_type    ON characters (character_type);
+CREATE INDEX idx_characters_aliases ON characters USING GIN (aliases);
+
+-- Junction table reverse FK lookups
+CREATE INDEX idx_event_chars_char       ON event_characters (character_id);
+CREATE INDEX idx_event_chars_event      ON event_characters (event_id);
+CREATE INDEX idx_char_rels_char         ON character_relationships (character_id);
+CREATE INDEX idx_char_rels_related      ON character_relationships (related_character_id);
+CREATE INDEX idx_timeline_events_event  ON timeline_events (event_id);
+
+-- Parent self-reference lookups (fractal nesting traversal)
+CREATE INDEX idx_events_parent     ON events (parent_event_id);
+CREATE INDEX idx_periods_parent    ON periods (parent_period_id);
+CREATE INDEX idx_categories_parent ON categories (parent_category_id);

--- a/supabase/tests/database/00005_performance_indexes_test.sql
+++ b/supabase/tests/database/00005_performance_indexes_test.sql
@@ -1,0 +1,91 @@
+-- pgTAP tests for 00005_performance_indexes.sql (issue #17 — performance indexes)
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(31);
+
+-- ============================================================================
+-- 18 new indexes from 00005 exist
+-- ============================================================================
+
+-- Temporal ordering and range
+select has_index('public', 'events',  'idx_events_sort',          'idx_events_sort exists');
+select has_index('public', 'events',  'idx_events_timeline_sort', 'idx_events_timeline_sort exists');
+select has_index('public', 'events',  'idx_events_range',         'idx_events_range exists');
+select has_index('public', 'periods', 'idx_periods_sort',         'idx_periods_sort exists');
+
+-- Full-text search GIN
+select has_index('public', 'events',     'idx_events_search',     'idx_events_search exists');
+select has_index('public', 'timelines',  'idx_timelines_search',  'idx_timelines_search exists');
+select has_index('public', 'characters', 'idx_characters_search', 'idx_characters_search exists');
+select has_index('public', 'stories',    'idx_stories_search',    'idx_stories_search exists');
+
+-- Character lookups
+select has_index('public', 'characters', 'idx_characters_type',    'idx_characters_type exists');
+select has_index('public', 'characters', 'idx_characters_aliases', 'idx_characters_aliases exists');
+
+-- Junction table reverse FK
+select has_index('public', 'event_characters',        'idx_event_chars_char',      'idx_event_chars_char exists');
+select has_index('public', 'event_characters',        'idx_event_chars_event',     'idx_event_chars_event exists');
+select has_index('public', 'character_relationships', 'idx_char_rels_char',        'idx_char_rels_char exists');
+select has_index('public', 'character_relationships', 'idx_char_rels_related',     'idx_char_rels_related exists');
+select has_index('public', 'timeline_events',         'idx_timeline_events_event', 'idx_timeline_events_event exists');
+
+-- Parent self-reference
+select has_index('public', 'events',     'idx_events_parent',     'idx_events_parent exists');
+select has_index('public', 'periods',    'idx_periods_parent',    'idx_periods_parent exists');
+select has_index('public', 'categories', 'idx_categories_parent', 'idx_categories_parent exists');
+
+-- ============================================================================
+-- The 5 GIN indexes use the gin access method
+-- ============================================================================
+select is(
+  (select am.amname from pg_index i
+     join pg_class c on c.oid = i.indexrelid
+     join pg_am am on am.oid = c.relam
+     where c.relname = 'idx_events_search'),
+  'gin', 'idx_events_search uses GIN access method'
+);
+select is(
+  (select am.amname from pg_index i
+     join pg_class c on c.oid = i.indexrelid
+     join pg_am am on am.oid = c.relam
+     where c.relname = 'idx_timelines_search'),
+  'gin', 'idx_timelines_search uses GIN access method'
+);
+select is(
+  (select am.amname from pg_index i
+     join pg_class c on c.oid = i.indexrelid
+     join pg_am am on am.oid = c.relam
+     where c.relname = 'idx_characters_search'),
+  'gin', 'idx_characters_search uses GIN access method'
+);
+select is(
+  (select am.amname from pg_index i
+     join pg_class c on c.oid = i.indexrelid
+     join pg_am am on am.oid = c.relam
+     where c.relname = 'idx_stories_search'),
+  'gin', 'idx_stories_search uses GIN access method'
+);
+select is(
+  (select am.amname from pg_index i
+     join pg_class c on c.oid = i.indexrelid
+     join pg_am am on am.oid = c.relam
+     where c.relname = 'idx_characters_aliases'),
+  'gin', 'idx_characters_aliases uses GIN access method'
+);
+
+-- ============================================================================
+-- AC: slug indexes from 00001/00002 still exist (verify, don't recreate)
+-- ============================================================================
+select has_index('public', 'profiles',   'profiles_username_idx',   'profiles_username_idx still present');
+select has_index('public', 'characters', 'characters_slug_idx',     'characters_slug_idx still present');
+select has_index('public', 'timelines',  'timelines_slug_idx',      'timelines_slug_idx still present');
+select has_index('public', 'periods',    'periods_slug_idx',        'periods_slug_idx still present');
+select has_index('public', 'events',     'events_slug_idx',         'events_slug_idx still present');
+select has_index('public', 'stories',    'stories_slug_idx',        'stories_slug_idx still present');
+select has_index('public', 'categories', 'categories_slug_idx',     'categories_slug_idx still present');
+select has_index('public', 'media',      'media_slug_idx',          'media_slug_idx still present');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Adds 00005_performance_indexes.sql with 18 performance indexes across temporal sorting, full-text search, character lookups, junction table reverse FKs, and fractal nesting traversal. Includes the paired pgTAP test file 00005_performance_indexes_test.sql (31 assertions) following the convention established in #78.

Closes #17

## Changes

**New file:** 00005_performance_indexes.sql

### Indexes created (18)

| Category | Index name | Table | Type | Columns |
|---|---|---|---|---|
| Temporal sort | `idx_events_sort` | `events` | BTREE | `sort_order_years` |
| Temporal sort | `idx_events_timeline_sort` | `events` | BTREE | `(timeline_id, sort_order_years)` |
| Temporal range | `idx_events_range` | `events` | BTREE | `(sort_order_years, sort_order_end)` |
| Temporal sort | `idx_periods_sort` | `periods` | BTREE | `sort_order_start` |
| Full-text search | `idx_events_search` | `events` | GIN | `search_vector` |
| Full-text search | `idx_timelines_search` | `timelines` | GIN | `search_vector` |
| Full-text search | `idx_characters_search` | `characters` | GIN | `search_vector` |
| Full-text search | `idx_stories_search` | `stories` | GIN | `search_vector` |
| Character lookup | `idx_characters_type` | `characters` | BTREE | `character_type` |
| Character lookup | `idx_characters_aliases` | `characters` | GIN | `aliases` (TEXT[]) |
| Junction reverse FK | `idx_event_chars_char` | `event_characters` | BTREE | `character_id` |
| Junction reverse FK | `idx_event_chars_event` | `event_characters` | BTREE | `event_id` |
| Junction reverse FK | `idx_char_rels_char` | `character_relationships` | BTREE | `character_id` |
| Junction reverse FK | `idx_char_rels_related` | `character_relationships` | BTREE | `related_character_id` |
| Junction reverse FK | `idx_timeline_events_event` | `timeline_events` | BTREE | `event_id` |
| Fractal nesting | `idx_events_parent` | `events` | BTREE | `parent_event_id` |
| Fractal nesting | `idx_periods_parent` | `periods` | BTREE | `parent_period_id` |
| Fractal nesting | `idx_categories_parent` | `categories` | BTREE | `parent_category_id` |

**Not recreated:** the 8 per-user slug unique indexes (`events_slug_idx`, etc.) already exist from migrations 00001/00002 and are left untouched.

**Spec note:** `idx_event_chars_event` is technically redundant — the `event_characters` composite PK `(event_id, character_id)` already indexes `event_id` as its leading column. It is included per the literal spec requirement in `system-design.md §8.1`; the redundancy is flagged in #73.

---

**New file:** 00005_performance_indexes_test.sql

31 assertions:

- **18** — each new index from this migration exists (`has_index`)
- **5** — GIN indexes (`idx_events_search`, `idx_timelines_search`, `idx_characters_search`, `idx_stories_search`, `idx_characters_aliases`) use the `gin` access method (verified via `pg_index`/`pg_am`)
- **8** — slug indexes from migrations 00001/00002 are still present (regression guard against accidental drops)

## Acceptance Criteria

- [x] All 18 indexes created per `system-design.md §8.1`
- [x] GIN indexes used for `tsvector` columns (`search_vector`) and `TEXT[]` column (`aliases`)
- [x] BTREE indexes for sort columns and junction FK lookups
- [x] Slug indexes from prior migrations verified present (not recreated)
- [x] `pnpm run db:test` reports 0 failures _(requires running local Supabase stack)_
- [ ] Indexes verified with EXPLAIN ANALYZE on sample queries _(deferred — no query harness yet)_

## Dependencies

Depends on #13 (core tables) and #14 (junction tables) — all indexed tables must exist before this migration runs.