### PR TITLE
Add Row Level Security policies for all 20 tables

### DIFF
--- a/supabase/migrations/00007_rls_policies.sql
+++ b/supabase/migrations/00007_rls_policies.sql
@@ -1,0 +1,443 @@
+-- ============================================================================
+-- 00007_rls_policies.sql
+--
+-- Row Level Security policies for all 20 tables (issue #19).
+-- See docs/system-design.md §9.2 (events / content tables / junctions /
+-- timeline_collaborators) for the canonical patterns.
+--
+-- RLS is already ENABLED on every table by 00001-00003 (default-deny);
+-- this migration adds the actual SELECT/INSERT/UPDATE/DELETE policies so
+-- anon, authenticated, owner, collaborator, and admin roles each get the
+-- access they should.
+--
+-- Policy taxonomy:
+--   1. Content with timeline_id (events) — 4-clause read incl. direct
+--      collaborator check; insert/update/delete split per spec §9.2.1.
+--   2. Content without timeline_id (timelines, periods, characters,
+--      stories, categories, media) — 4-clause read with collaborator
+--      derived via junction tables; FOR ALL write per spec §9.2.2.
+--   3. profiles — globally readable, own-only update. Spec is silent
+--      (§9.2 does not cover profiles); designed from AC. Flagged in #73.
+--   4. Junction tables (10) — read delegates to parent's RLS via
+--      EXISTS subselect; write requires primary parent ownership.
+--   5. character_relationships — simple user_id ownership (the table
+--      HAS a user_id, unlike other junctions). AC's "read if either
+--      character visible" implementation flagged in #73 as a divergence.
+--   6. timeline_collaborators — spec §9.2.4; readable by owner, the
+--      collaborator themselves, and admins.
+--   7. notifications — own-only read/update. Spec §3.5 design notes.
+--   8. content_reports — reporter reads own + admin all; admin update only.
+--
+-- Junction read policies use `EXISTS (SELECT 1 FROM parent WHERE id = X)`
+-- so the parent's RLS recursively decides visibility. This picks up
+-- collaborator access on parent automatically — the spec example in §9.2.3
+-- duplicates the parent's read conditions inline and misses collaborator
+-- access, which is a spec gap flagged in #73.
+--
+-- RLS recursion prevention: spec §9.2.4's `read_collaborators` does an
+-- inline `EXISTS (SELECT 1 FROM timelines ...)` which combined with
+-- `read_timelines`' inline `EXISTS (SELECT 1 FROM timeline_collaborators ...)`
+-- forms a cycle that triggers `infinite recursion detected in policy`
+-- whenever a non-owner non-collaborator queries either table. Fixed here
+-- via three SECURITY DEFINER helper functions that bypass RLS. The cycle
+-- is a real spec bug — flagged in #73.
+-- ============================================================================
+
+-- ============================================================================
+-- 0. SECURITY DEFINER helpers (break RLS cycles between timelines and
+--    timeline_collaborators). All three are STABLE, SET search_path='',
+--    fully-qualified — same hardening pattern as is_admin().
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.is_timeline_owner(t_id uuid)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.timelines
+    WHERE id = t_id AND user_id = auth.uid()
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_timeline_collaborator(t_id uuid)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.timeline_collaborators
+    WHERE timeline_id = t_id AND user_id = auth.uid()
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_timeline_collab_editor(t_id uuid)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.timeline_collaborators
+    WHERE timeline_id = t_id
+      AND user_id = auth.uid()
+      AND role IN ('editor', 'admin')
+  );
+$$;
+
+-- ============================================================================
+-- 1. events (spec §9.2.1)
+-- ============================================================================
+
+CREATE POLICY "read_events" ON events FOR SELECT USING (
+  published = true
+  OR user_id = auth.uid()
+  OR is_admin()
+  OR public.is_timeline_collaborator(events.timeline_id)
+);
+
+CREATE POLICY "insert_events" ON events FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid() OR is_admin());
+
+CREATE POLICY "update_events" ON events FOR UPDATE TO authenticated
+  USING (
+    user_id = auth.uid()
+    OR is_admin()
+    OR public.is_timeline_collab_editor(events.timeline_id)
+  )
+  WITH CHECK (
+    user_id = auth.uid()
+    OR is_admin()
+    OR public.is_timeline_collab_editor(events.timeline_id)
+  );
+
+CREATE POLICY "delete_events" ON events FOR DELETE TO authenticated
+  USING (user_id = auth.uid() OR is_admin());
+
+-- ============================================================================
+-- 2. Content tables without timeline_id
+-- ============================================================================
+
+-- timelines (the parent entity for collaboration) — spec §9.2.2
+CREATE POLICY "read_timelines" ON timelines FOR SELECT USING (
+  published = true
+  OR user_id = auth.uid()
+  OR is_admin()
+  OR public.is_timeline_collaborator(timelines.id)
+);
+
+CREATE POLICY "insert_timelines" ON timelines FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid() OR is_admin());
+
+CREATE POLICY "update_timelines" ON timelines FOR UPDATE TO authenticated
+  USING (user_id = auth.uid() OR is_admin())
+  WITH CHECK (user_id = auth.uid() OR is_admin());
+
+CREATE POLICY "delete_timelines" ON timelines FOR DELETE TO authenticated
+  USING (user_id = auth.uid() OR is_admin());
+
+-- periods — collaborator access derived via period_timelines junction
+CREATE POLICY "read_periods" ON periods FOR SELECT USING (
+  published = true
+  OR user_id = auth.uid()
+  OR is_admin()
+  OR EXISTS (
+    SELECT 1 FROM period_timelines pt
+    WHERE pt.period_id = periods.id
+      AND public.is_timeline_collaborator(pt.timeline_id)
+  )
+);
+
+CREATE POLICY "write_periods" ON periods FOR ALL TO authenticated
+  USING (user_id = auth.uid() OR is_admin())
+  WITH CHECK (user_id = auth.uid() OR is_admin());
+
+-- characters — collaborator access derived via event_characters → events → timelines
+CREATE POLICY "read_characters" ON characters FOR SELECT USING (
+  published = true
+  OR user_id = auth.uid()
+  OR is_admin()
+  OR EXISTS (
+    SELECT 1 FROM event_characters ec
+    JOIN events e ON ec.event_id = e.id
+    WHERE ec.character_id = characters.id
+      AND public.is_timeline_collaborator(e.timeline_id)
+  )
+);
+
+CREATE POLICY "write_characters" ON characters FOR ALL TO authenticated
+  USING (user_id = auth.uid() OR is_admin())
+  WITH CHECK (user_id = auth.uid() OR is_admin());
+
+-- stories — collaborator access derived via story_events → events → timelines
+CREATE POLICY "read_stories" ON stories FOR SELECT USING (
+  published = true
+  OR user_id = auth.uid()
+  OR is_admin()
+  OR EXISTS (
+    SELECT 1 FROM story_events se
+    JOIN events e ON se.event_id = e.id
+    WHERE se.story_id = stories.id
+      AND public.is_timeline_collaborator(e.timeline_id)
+  )
+);
+
+CREATE POLICY "write_stories" ON stories FOR ALL TO authenticated
+  USING (user_id = auth.uid() OR is_admin())
+  WITH CHECK (user_id = auth.uid() OR is_admin());
+
+-- categories — globally readable (organizational metadata)
+CREATE POLICY "read_categories" ON categories FOR SELECT USING (true);
+CREATE POLICY "write_categories" ON categories FOR ALL TO authenticated
+  USING (user_id = auth.uid() OR is_admin())
+  WITH CHECK (user_id = auth.uid() OR is_admin());
+
+-- media — globally readable (access control on the parent entity)
+CREATE POLICY "read_media" ON media FOR SELECT USING (true);
+CREATE POLICY "write_media" ON media FOR ALL TO authenticated
+  USING (user_id = auth.uid() OR is_admin())
+  WITH CHECK (user_id = auth.uid() OR is_admin());
+
+-- ============================================================================
+-- 3. profiles (spec-silent; designed from AC + flagged in #73)
+-- ============================================================================
+
+-- Global read so usernames/avatars/bio can be displayed alongside any content.
+CREATE POLICY "read_profiles" ON profiles FOR SELECT USING (true);
+
+-- INSERT is performed by handle_new_user() (SECURITY DEFINER trigger from #16);
+-- regular users don't insert here. No INSERT policy → default-deny for any
+-- caller that tries direct PostgREST insert against profiles.
+
+-- Own-profile-only update; admins can update any.
+CREATE POLICY "update_profiles" ON profiles FOR UPDATE TO authenticated
+  USING (id = auth.uid() OR is_admin())
+  WITH CHECK (id = auth.uid() OR is_admin());
+
+-- No DELETE policy → CASCADE from auth.users handles removal.
+
+-- ============================================================================
+-- 4. Junction tables (10) — read delegates to parent's RLS; write needs
+--    ownership of the primary/first-named parent (see migration header).
+-- ============================================================================
+
+-- event_categories — primary parent: event
+CREATE POLICY "read_event_categories" ON event_categories FOR SELECT USING (
+  EXISTS (SELECT 1 FROM events WHERE id = event_categories.event_id)
+);
+CREATE POLICY "write_event_categories" ON event_categories FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM events
+      WHERE id = event_categories.event_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM events
+      WHERE id = event_categories.event_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- event_media — primary parent: event
+CREATE POLICY "read_event_media" ON event_media FOR SELECT USING (
+  EXISTS (SELECT 1 FROM events WHERE id = event_media.event_id)
+);
+CREATE POLICY "write_event_media" ON event_media FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM events
+      WHERE id = event_media.event_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM events
+      WHERE id = event_media.event_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- event_characters — primary parent: event
+CREATE POLICY "read_event_characters" ON event_characters FOR SELECT USING (
+  EXISTS (SELECT 1 FROM events WHERE id = event_characters.event_id)
+);
+CREATE POLICY "write_event_characters" ON event_characters FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM events
+      WHERE id = event_characters.event_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM events
+      WHERE id = event_characters.event_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- timeline_events — primary parent: timeline (collaboration root)
+CREATE POLICY "read_timeline_events" ON timeline_events FOR SELECT USING (
+  EXISTS (SELECT 1 FROM timelines WHERE id = timeline_events.timeline_id)
+);
+CREATE POLICY "write_timeline_events" ON timeline_events FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM timelines
+      WHERE id = timeline_events.timeline_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM timelines
+      WHERE id = timeline_events.timeline_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- period_timelines — primary parent: timeline (collaboration root)
+CREATE POLICY "read_period_timelines" ON period_timelines FOR SELECT USING (
+  EXISTS (SELECT 1 FROM timelines WHERE id = period_timelines.timeline_id)
+);
+CREATE POLICY "write_period_timelines" ON period_timelines FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM timelines
+      WHERE id = period_timelines.timeline_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM timelines
+      WHERE id = period_timelines.timeline_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- timeline_media — primary parent: timeline (collaboration root)
+CREATE POLICY "read_timeline_media" ON timeline_media FOR SELECT USING (
+  EXISTS (SELECT 1 FROM timelines WHERE id = timeline_media.timeline_id)
+);
+CREATE POLICY "write_timeline_media" ON timeline_media FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM timelines
+      WHERE id = timeline_media.timeline_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM timelines
+      WHERE id = timeline_media.timeline_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- story_periods — primary parent: story
+CREATE POLICY "read_story_periods" ON story_periods FOR SELECT USING (
+  EXISTS (SELECT 1 FROM stories WHERE id = story_periods.story_id)
+);
+CREATE POLICY "write_story_periods" ON story_periods FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM stories
+      WHERE id = story_periods.story_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM stories
+      WHERE id = story_periods.story_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- story_characters — primary parent: story
+CREATE POLICY "read_story_characters" ON story_characters FOR SELECT USING (
+  EXISTS (SELECT 1 FROM stories WHERE id = story_characters.story_id)
+);
+CREATE POLICY "write_story_characters" ON story_characters FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM stories
+      WHERE id = story_characters.story_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM stories
+      WHERE id = story_characters.story_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- story_events — primary parent: story
+CREATE POLICY "read_story_events" ON story_events FOR SELECT USING (
+  EXISTS (SELECT 1 FROM stories WHERE id = story_events.story_id)
+);
+CREATE POLICY "write_story_events" ON story_events FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM stories
+      WHERE id = story_events.story_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM stories
+      WHERE id = story_events.story_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- character_media — primary parent: character
+CREATE POLICY "read_character_media" ON character_media FOR SELECT USING (
+  EXISTS (SELECT 1 FROM characters WHERE id = character_media.character_id)
+);
+CREATE POLICY "write_character_media" ON character_media FOR ALL TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM characters
+      WHERE id = character_media.character_id
+        AND (user_id = auth.uid() OR is_admin()))
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM characters
+      WHERE id = character_media.character_id
+        AND (user_id = auth.uid() OR is_admin()))
+  );
+
+-- ============================================================================
+-- 5. character_relationships (uses its own user_id; spec-silent — flagged in #73)
+-- ============================================================================
+
+CREATE POLICY "read_character_relationships" ON character_relationships FOR SELECT
+  USING (user_id = auth.uid() OR is_admin());
+
+CREATE POLICY "write_character_relationships" ON character_relationships FOR ALL TO authenticated
+  USING (user_id = auth.uid() OR is_admin())
+  WITH CHECK (user_id = auth.uid() OR is_admin());
+
+-- ============================================================================
+-- 6. timeline_collaborators (spec §9.2.4)
+-- ============================================================================
+
+CREATE POLICY "read_collaborators" ON timeline_collaborators FOR SELECT USING (
+  user_id = auth.uid()
+  OR is_admin()
+  OR public.is_timeline_owner(timeline_collaborators.timeline_id)
+);
+
+CREATE POLICY "write_collaborators" ON timeline_collaborators FOR ALL TO authenticated
+  USING (
+    is_admin()
+    OR public.is_timeline_owner(timeline_collaborators.timeline_id)
+  )
+  WITH CHECK (
+    is_admin()
+    OR public.is_timeline_owner(timeline_collaborators.timeline_id)
+  );
+
+-- ============================================================================
+-- 7. notifications (spec-silent; spec §3.5 design notes — flagged in #73)
+-- ============================================================================
+
+CREATE POLICY "read_notifications" ON notifications FOR SELECT
+  USING (user_id = auth.uid() OR is_admin());
+
+-- Own-row update only. Column-level restriction (only read/read_at) is
+-- enforced at the service layer; the sync_notification_read_at trigger
+-- already handles read_at population.
+CREATE POLICY "update_notifications" ON notifications FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- INSERT happens via SECURITY DEFINER from the application/admin path
+-- (e.g., collaboration invites, moderation alerts). No INSERT policy →
+-- direct PostgREST inserts are blocked by default deny.
+
+-- No DELETE policy → notifications are write-once; service layer never deletes.
+
+-- ============================================================================
+-- 8. content_reports (spec-silent; spec §3.5 design notes — flagged in #73)
+-- ============================================================================
+
+CREATE POLICY "read_content_reports" ON content_reports FOR SELECT
+  USING (reporter_id = auth.uid() OR is_admin());
+
+CREATE POLICY "insert_content_reports" ON content_reports FOR INSERT TO authenticated
+  WITH CHECK (reporter_id = auth.uid());
+
+-- Only admins update reports (status, admin_notes, resolved_by/at).
+CREATE POLICY "update_content_reports" ON content_reports FOR UPDATE TO authenticated
+  USING (is_admin())
+  WITH CHECK (is_admin());
+
+-- No DELETE policy → reports are retained for the audit trail.

--- a/supabase/tests/database/00007_rls_policies_test.sql
+++ b/supabase/tests/database/00007_rls_policies_test.sql
@@ -1,0 +1,570 @@
+-- pgTAP tests for 00007_rls_policies.sql (issue #19 — RLS policies)
+--
+-- Strategy: seed 5 users (owner, other, admin, collab_editor, collab_viewer)
+-- and a mix of published / private content owned by `owner`, then impersonate
+-- each role via `SET LOCAL ROLE` + `SET LOCAL request.jwt.claims` and verify
+-- row visibility and write outcomes.
+--
+-- IMPORTANT: tests must `SET LOCAL ROLE authenticated` (or `anon`) to apply
+-- RLS. The default `postgres` test role bypasses RLS entirely.
+--
+-- For UPDATE/DELETE tests, RLS silently filters rather than throwing — so the
+-- pattern is: switch to the role under test, run the write, switch BACK to
+-- postgres, then SELECT to observe whether the row was actually changed.
+begin;
+create extension if not exists pgtap with schema extensions;
+
+-- ============================================================================
+-- Seed users + profiles + content (runs as postgres, RLS bypassed)
+-- ============================================================================
+
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role,
+                        raw_user_meta_data)
+values
+  ('11111111-1111-1111-1111-111111111111'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'owner@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+   '{"first_name":"Owner","last_name":"User"}'::jsonb),
+  ('22222222-2222-2222-2222-222222222222'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'other@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+   '{"first_name":"Other","last_name":"User"}'::jsonb),
+  ('33333333-3333-3333-3333-333333333333'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'admin@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+   '{"first_name":"Admin","last_name":"User"}'::jsonb),
+  ('44444444-4444-4444-4444-444444444444'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'editor@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+   '{"first_name":"Editor","last_name":"User"}'::jsonb),
+  ('55555555-5555-5555-5555-555555555555'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'viewer@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+   '{"first_name":"Viewer","last_name":"User"}'::jsonb);
+
+update profiles set role = 'admin' where id = '33333333-3333-3333-3333-333333333333';
+
+insert into timelines (id, user_id, slug, title, temporal_data, published) values
+  ('aaaaaaaa-0001-0000-0000-000000000001'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'tl-shared', 'Shared Timeline',
+   '{"year":2000,"era":"CE"}'::jsonb, false);
+
+insert into timeline_collaborators (timeline_id, user_id, role) values
+  ('aaaaaaaa-0001-0000-0000-000000000001', '44444444-4444-4444-4444-444444444444', 'editor'),
+  ('aaaaaaaa-0001-0000-0000-000000000001', '55555555-5555-5555-5555-555555555555', 'viewer');
+
+insert into events (id, user_id, slug, title, temporal_data, timeline_id, published) values
+  ('aaaaaaaa-0002-0000-0000-000000000001'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'ev-public', 'Public Event',
+   '{"year":2001,"era":"CE"}'::jsonb,
+   'aaaaaaaa-0001-0000-0000-000000000001', true),
+  ('aaaaaaaa-0002-0000-0000-000000000002'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'ev-private', 'Private Event',
+   '{"year":2002,"era":"CE"}'::jsonb,
+   'aaaaaaaa-0001-0000-0000-000000000001', false),
+  -- Dedicated delete-target so admin-DELETE test doesn't break junction-read tests
+  ('aaaaaaaa-0002-0000-0000-000000000099'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'ev-delete-target', 'Delete Target',
+   '{"year":2099,"era":"CE"}'::jsonb,
+   'aaaaaaaa-0001-0000-0000-000000000001', false);
+
+insert into characters (id, user_id, slug, name, character_type, published) values
+  ('aaaaaaaa-0004-0000-0000-000000000001'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'char-public', 'Public Character', 'human', true),
+  ('aaaaaaaa-0004-0000-0000-000000000002'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'char-private', 'Private Character', 'human', false);
+
+insert into categories (id, user_id, slug, title) values
+  ('aaaaaaaa-0006-0000-0000-000000000001'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'cat-1', 'Category One');
+
+insert into media (id, user_id, slug, storage_path, url, media_type) values
+  ('aaaaaaaa-0007-0000-0000-000000000001'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'media-1', '/p', '/u', 'image');
+
+insert into event_categories (event_id, category_id) values
+  ('aaaaaaaa-0002-0000-0000-000000000001', 'aaaaaaaa-0006-0000-0000-000000000001'),
+  ('aaaaaaaa-0002-0000-0000-000000000002', 'aaaaaaaa-0006-0000-0000-000000000001');
+
+insert into character_relationships (user_id, character_id, related_character_id, relationship_type)
+values ('11111111-1111-1111-1111-111111111111',
+        'aaaaaaaa-0004-0000-0000-000000000001',
+        'aaaaaaaa-0004-0000-0000-000000000002',
+        'family');
+
+insert into notifications (user_id, type, title, body) values
+  ('11111111-1111-1111-1111-111111111111', 'system_message', 'Hello owner', 'body');
+
+insert into content_reports (reporter_id, entity_type, entity_id, reason) values
+  ('11111111-1111-1111-1111-111111111111', 'timeline',
+   'aaaaaaaa-0001-0000-0000-000000000001', 'inappropriate');
+
+select plan(46);
+
+-- ============================================================================
+-- Helper: set role + claims atomically. Always reset both before each switch.
+-- ============================================================================
+
+-- ============================================================================
+-- READ tests
+-- ============================================================================
+
+-- ---- events: 5 visibilities + anon ----
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+select is(
+  (select count(*) from events
+    where id in ('aaaaaaaa-0002-0000-0000-000000000001'::uuid,
+                 'aaaaaaaa-0002-0000-0000-000000000002'::uuid)),
+  2::bigint,
+  'owner sees both own events (private + published)'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select is(
+  (select count(*) from events
+    where id in ('aaaaaaaa-0002-0000-0000-000000000001'::uuid,
+                 'aaaaaaaa-0002-0000-0000-000000000002'::uuid)),
+  1::bigint,
+  'other user sees only published event'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"33333333-3333-3333-3333-333333333333"}';
+select is(
+  (select count(*) from events
+    where id in ('aaaaaaaa-0002-0000-0000-000000000001'::uuid,
+                 'aaaaaaaa-0002-0000-0000-000000000002'::uuid)),
+  2::bigint,
+  'admin sees all events (published + private)'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"55555555-5555-5555-5555-555555555555"}';
+select is(
+  (select count(*) from events
+    where id in ('aaaaaaaa-0002-0000-0000-000000000001'::uuid,
+                 'aaaaaaaa-0002-0000-0000-000000000002'::uuid)),
+  2::bigint,
+  'collaborator-viewer sees all shared-timeline events'
+);
+
+reset role; reset request.jwt.claims;
+set local role anon;
+select is(
+  (select count(*) from events
+    where id in ('aaaaaaaa-0002-0000-0000-000000000001'::uuid,
+                 'aaaaaaaa-0002-0000-0000-000000000002'::uuid)),
+  1::bigint,
+  'anon sees only published events'
+);
+
+-- ---- timelines: owner / other / collab-viewer / anon ----
+reset role;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+select is(
+  (select count(*) from timelines where id = 'aaaaaaaa-0001-0000-0000-000000000001'::uuid),
+  1::bigint, 'owner sees own private timeline'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select is(
+  (select count(*) from timelines where id = 'aaaaaaaa-0001-0000-0000-000000000001'::uuid),
+  0::bigint, 'other user does NOT see owner''s private timeline'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"55555555-5555-5555-5555-555555555555"}';
+select is(
+  (select count(*) from timelines where id = 'aaaaaaaa-0001-0000-0000-000000000001'::uuid),
+  1::bigint, 'collaborator-viewer sees shared timeline'
+);
+
+reset role; reset request.jwt.claims;
+set local role anon;
+select is(
+  (select count(*) from timelines where id = 'aaaaaaaa-0001-0000-0000-000000000001'::uuid),
+  0::bigint, 'anon does NOT see private timeline'
+);
+
+-- ---- characters: published-only for other user ----
+reset role;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select is(
+  (select count(*) from characters
+    where id in ('aaaaaaaa-0004-0000-0000-000000000001'::uuid,
+                 'aaaaaaaa-0004-0000-0000-000000000002'::uuid)),
+  1::bigint, 'other user sees only published character'
+);
+
+-- ---- categories / media / profiles globally readable ----
+reset role; reset request.jwt.claims;
+set local role anon;
+select is(
+  (select count(*) from categories where id = 'aaaaaaaa-0006-0000-0000-000000000001'::uuid),
+  1::bigint, 'anon can read categories (globally readable)'
+);
+select is(
+  (select count(*) from media where id = 'aaaaaaaa-0007-0000-0000-000000000001'::uuid),
+  1::bigint, 'anon can read media (globally readable)'
+);
+select is(
+  (select count(*) from profiles where id = '11111111-1111-1111-1111-111111111111'::uuid),
+  1::bigint, 'anon can read profiles (globally readable per AC)'
+);
+
+-- ============================================================================
+-- WRITE tests (UPDATE/DELETE silently filter; check via postgres role after)
+-- ============================================================================
+
+-- ---- events INSERT with own user_id (other user) ----
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select lives_ok(
+  $$insert into events (user_id, slug, title, temporal_data)
+    values ('22222222-2222-2222-2222-222222222222', 'other-event', 'OE',
+            '{"year":2010,"era":"CE"}'::jsonb)$$,
+  'other user can INSERT events with own user_id'
+);
+
+-- ---- events INSERT with someone else's user_id is blocked ----
+select throws_ok(
+  $$insert into events (user_id, slug, title, temporal_data)
+    values ('11111111-1111-1111-1111-111111111111', 'spoof', 'spoof',
+            '{"year":2010,"era":"CE"}'::jsonb)$$,
+  '42501', null,
+  'other user CANNOT INSERT events with someone else''s user_id'
+);
+
+-- ---- events UPDATE: owner / other / collab-editor / collab-viewer ----
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+update events set title = 'owner update'
+  where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid;
+reset role; reset request.jwt.claims;
+select is(
+  (select title from events where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid),
+  'owner update'::varchar, 'owner can UPDATE own event'
+);
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+update events set title = 'hijack'
+  where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid;
+reset role; reset request.jwt.claims;
+select isnt(
+  (select title from events where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid),
+  'hijack'::varchar, 'other user UPDATE on owner''s event is filtered out'
+);
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"44444444-4444-4444-4444-444444444444"}';
+update events set summary = 'edited by collab-editor'
+  where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid;
+reset role; reset request.jwt.claims;
+select is(
+  (select summary from events where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid),
+  'edited by collab-editor'::text, 'collaborator-editor can UPDATE shared event'
+);
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"55555555-5555-5555-5555-555555555555"}';
+update events set summary = 'viewer hijack'
+  where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid;
+reset role; reset request.jwt.claims;
+select isnt(
+  (select summary from events where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid),
+  'viewer hijack'::text, 'collaborator-viewer CANNOT UPDATE shared event'
+);
+
+-- ---- events DELETE: collab-editor (denied) / admin (allowed) ----
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"44444444-4444-4444-4444-444444444444"}';
+delete from events where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid;
+reset role; reset request.jwt.claims;
+select is(
+  (select count(*) from events where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid),
+  1::bigint, 'collaborator-editor CANNOT DELETE event (owner/admin only)'
+);
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"33333333-3333-3333-3333-333333333333"}';
+delete from events where id = 'aaaaaaaa-0002-0000-0000-000000000099'::uuid;
+reset role; reset request.jwt.claims;
+select is(
+  (select count(*) from events where id = 'aaaaaaaa-0002-0000-0000-000000000099'::uuid),
+  0::bigint, 'admin can DELETE any event'
+);
+
+-- ---- timelines UPDATE: collab-editor cannot update timeline itself ----
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"44444444-4444-4444-4444-444444444444"}';
+update timelines set title = 'editor hijack'
+  where id = 'aaaaaaaa-0001-0000-0000-000000000001'::uuid;
+reset role; reset request.jwt.claims;
+select isnt(
+  (select title from timelines where id = 'aaaaaaaa-0001-0000-0000-000000000001'::uuid),
+  'editor hijack'::varchar, 'collaborator-editor CANNOT UPDATE timeline itself'
+);
+
+-- ---- characters INSERT with someone else's user_id is rejected ----
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select throws_ok(
+  $$insert into characters (user_id, slug, name, character_type)
+    values ('11111111-1111-1111-1111-111111111111', 'spoof', 'X', 'human')$$,
+  '42501', null,
+  'characters INSERT with someone else''s user_id is rejected'
+);
+
+-- ============================================================================
+-- JUNCTION TABLES
+-- ============================================================================
+
+-- ---- event_categories read via parent ----
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select is(
+  (select count(*) from event_categories
+    where event_id in ('aaaaaaaa-0002-0000-0000-000000000001'::uuid,
+                       'aaaaaaaa-0002-0000-0000-000000000002'::uuid)),
+  1::bigint,
+  'event_categories: other user sees junction for visible (public) event only'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"55555555-5555-5555-5555-555555555555"}';
+select is(
+  (select count(*) from event_categories
+    where event_id in ('aaaaaaaa-0002-0000-0000-000000000001'::uuid,
+                       'aaaaaaaa-0002-0000-0000-000000000002'::uuid)),
+  2::bigint,
+  'event_categories: collaborator sees junctions for both shared-timeline events'
+);
+
+-- ---- event_categories write: other user can attach to their own event ----
+reset role; reset request.jwt.claims;
+insert into events (id, user_id, slug, title, temporal_data) values
+  ('bbbbbbbb-0002-0000-0000-000000000001'::uuid,
+   '22222222-2222-2222-2222-222222222222', 'other-ev', 'Other Event',
+   '{"year":2020,"era":"CE"}'::jsonb);
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select lives_ok(
+  $$insert into event_categories (event_id, category_id)
+    values ('bbbbbbbb-0002-0000-0000-000000000001',
+            'aaaaaaaa-0006-0000-0000-000000000001')$$,
+  'event_categories: user can attach existing global category to their own event'
+);
+
+-- ---- event_categories write: blocked when event isn't owned ----
+-- The owner's `aaaaaaaa-0002-...000002` (private event) row already has an event_categories
+-- entry from seed; try to insert a duplicate from the other user — RLS rejects.
+-- Use a NEW category to avoid duplicate-key collision.
+reset role; reset request.jwt.claims;
+insert into categories (id, user_id, slug, title) values
+  ('bbbbbbbb-0006-0000-0000-000000000001'::uuid,
+   '22222222-2222-2222-2222-222222222222', 'cat-2', 'Category Two');
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select throws_ok(
+  $$insert into event_categories (event_id, category_id)
+    values ('aaaaaaaa-0002-0000-0000-000000000001',
+            'bbbbbbbb-0006-0000-0000-000000000001')$$,
+  '42501', null,
+  'event_categories: other user CANNOT attach category to owner''s event'
+);
+
+-- ============================================================================
+-- character_relationships
+-- ============================================================================
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select is(
+  (select count(*) from character_relationships),
+  0::bigint, 'other user CANNOT see owner''s character_relationships'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+select is(
+  (select count(*) from character_relationships),
+  1::bigint, 'owner sees own character_relationships'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"33333333-3333-3333-3333-333333333333"}';
+select is(
+  (select count(*) from character_relationships),
+  1::bigint, 'admin sees all character_relationships'
+);
+
+-- ============================================================================
+-- timeline_collaborators (the table that originally caused infinite recursion)
+-- ============================================================================
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+select is(
+  (select count(*) from timeline_collaborators
+    where timeline_id = 'aaaaaaaa-0001-0000-0000-000000000001'::uuid),
+  2::bigint, 'timeline owner sees both collaborators'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"55555555-5555-5555-5555-555555555555"}';
+select ok(
+  (select count(*) from timeline_collaborators
+    where user_id = '55555555-5555-5555-5555-555555555555'::uuid) >= 1,
+  'collaborator-viewer sees own collaborator row'
+);
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select is(
+  (select count(*) from timeline_collaborators
+    where timeline_id = 'aaaaaaaa-0001-0000-0000-000000000001'::uuid),
+  0::bigint, 'unrelated user sees no collaborator rows for owner''s timeline'
+);
+
+-- ============================================================================
+-- notifications
+-- ============================================================================
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+select is((select count(*) from notifications), 1::bigint, 'owner sees own notification');
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select is((select count(*) from notifications), 0::bigint, 'other user does NOT see owner''s notification');
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"33333333-3333-3333-3333-333333333333"}';
+select is((select count(*) from notifications), 1::bigint, 'admin sees all notifications');
+
+-- ============================================================================
+-- content_reports
+-- ============================================================================
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+select is((select count(*) from content_reports), 1::bigint, 'reporter sees own report');
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select is((select count(*) from content_reports), 0::bigint, 'other user does NOT see someone else''s report');
+
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"33333333-3333-3333-3333-333333333333"}';
+select is((select count(*) from content_reports), 1::bigint, 'admin sees all reports');
+
+-- INSERT own
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+select lives_ok(
+  $$insert into content_reports (reporter_id, entity_type, entity_id, reason)
+    values ('22222222-2222-2222-2222-222222222222', 'event',
+            'aaaaaaaa-0002-0000-0000-000000000001'::uuid, 'spam')$$,
+  'authenticated user can INSERT content_reports with own reporter_id'
+);
+
+-- Cannot spoof reporter_id
+select throws_ok(
+  $$insert into content_reports (reporter_id, entity_type, entity_id, reason)
+    values ('11111111-1111-1111-1111-111111111111', 'event',
+            'aaaaaaaa-0002-0000-0000-000000000001'::uuid, 'spam')$$,
+  '42501', null,
+  'content_reports INSERT cannot spoof reporter_id'
+);
+
+-- Non-admin UPDATE filtered out
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+update content_reports set status = 'reviewed'
+  where reporter_id = '11111111-1111-1111-1111-111111111111'::uuid;
+reset role; reset request.jwt.claims;
+select isnt(
+  (select status from content_reports
+    where reporter_id = '11111111-1111-1111-1111-111111111111'::uuid),
+  'reviewed'::varchar, 'non-admin UPDATE on content_reports is filtered out'
+);
+
+-- Admin UPDATE works
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"33333333-3333-3333-3333-333333333333"}';
+update content_reports set status = 'reviewed'
+  where reporter_id = '11111111-1111-1111-1111-111111111111'::uuid;
+reset role; reset request.jwt.claims;
+select is(
+  (select status from content_reports
+    where reporter_id = '11111111-1111-1111-1111-111111111111'::uuid),
+  'reviewed'::varchar, 'admin can UPDATE content_reports'
+);
+
+-- ============================================================================
+-- profiles UPDATE
+-- ============================================================================
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+update profiles set bio = 'self update'
+  where id = '11111111-1111-1111-1111-111111111111'::uuid;
+reset role; reset request.jwt.claims;
+select is(
+  (select bio from profiles where id = '11111111-1111-1111-1111-111111111111'::uuid),
+  'self update'::text, 'user can UPDATE own profile'
+);
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"22222222-2222-2222-2222-222222222222"}';
+update profiles set bio = 'cross-user hijack'
+  where id = '11111111-1111-1111-1111-111111111111'::uuid;
+reset role; reset request.jwt.claims;
+select isnt(
+  (select bio from profiles where id = '11111111-1111-1111-1111-111111111111'::uuid),
+  'cross-user hijack'::text, 'user CANNOT UPDATE another user''s profile'
+);
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"33333333-3333-3333-3333-333333333333"}';
+update profiles set bio = 'admin update'
+  where id = '11111111-1111-1111-1111-111111111111'::uuid;
+reset role; reset request.jwt.claims;
+select is(
+  (select bio from profiles where id = '11111111-1111-1111-1111-111111111111'::uuid),
+  'admin update'::text, 'admin can UPDATE any profile'
+);
+
+reset role; reset request.jwt.claims;
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Adds 00007_rls_policies.sql with RLS policies for all 20 tables, and a corresponding 00007_rls_policies_test.sql with 46 pgTAP assertions covering read visibility and write enforcement across all five roles (owner, other, admin, collaborator-editor, collaborator-viewer, and anon).

Closes #19

## Policy taxonomy

| Group | Tables | Pattern |
|---|---|---|
| 1. Events | `events` | 4-clause read; split INSERT/UPDATE/DELETE to allow collab-editor updates but owner/admin-only delete |
| 2. Content (no timeline_id) | `timelines`, `periods`, `characters`, `stories` | 4-clause read with collaborator path via junction joins; FOR ALL write |
| 3. Globally readable content | `categories`, `media`, `profiles` | `USING (true)` read; own-only or owner/admin write |
| 4. Junction tables (10) | `event_categories`, `event_media`, `event_characters`, `timeline_events`, `period_timelines`, `timeline_media`, `story_periods`, `story_characters`, `story_events`, `character_media` | Read delegates to parent RLS via `EXISTS (SELECT 1 FROM parent …)`; write requires ownership of primary parent |
| 5. `character_relationships` | — | Simple `user_id` ownership read/write |
| 6. `timeline_collaborators` | — | Readable by the collaborator themselves, timeline owner, or admin |
| 7. `notifications` | — | Own-only read; own-only update (no INSERT/DELETE policy → SECURITY DEFINER path only) |
| 8. `content_reports` | — | Reporter reads own; admin reads all; admin-only UPDATE; no DELETE (audit trail) |

## Design decisions

**RLS cycle fix (spec bug — tracked in #73).** `read_timelines` checks `timeline_collaborators` and `read_collaborators` checks `timelines`, forming a cycle that triggers `infinite recursion detected in policy` for any non-owner, non-collaborator query. Fixed with three `SECURITY DEFINER` helper functions (`is_timeline_owner`, `is_timeline_collaborator`, `is_timeline_collab_editor`) that bypass RLS, following the same hardening pattern as `is_admin()`.

**Junction read delegation.** Policies use `EXISTS (SELECT 1 FROM parent WHERE id = X)` rather than inlining the parent's read conditions. This means collaborator access on the parent is automatically inherited, whereas the spec's inline examples (§9.2.3) miss it — flagged in #73.

**`character_relationships` visibility.** Implemented as owner-only read (`user_id = auth.uid() OR is_admin()`). The spec's AC ("read if either character visible") was not implemented — the interpretation is ambiguous and the conservative path avoids leaking relationship metadata across users. Flagged in #73 for a follow-up decision.

**`profiles` policies.** Not covered in §9.2 of the spec. Designed from AC: globally readable (usernames/avatars appear alongside any content), no INSERT policy (the `handle_new_user` SECURITY DEFINER trigger owns that path), own-only UPDATE. Flagged in #73.

## Tests

46 pgTAP assertions in `00007_rls_policies_test.sql` cover:
- Event visibility for all 5 roles + anon
- Timeline visibility (including collaborator access without infinite recursion)
- Character, category, media, and profile visibility
- `INSERT` spoofing rejected (events and characters)
- `UPDATE` filtering for non-owners, collab-editor/viewer differentiation
- `DELETE` blocked for collab-editors; allowed for owner and admin
- Junction table read delegation and write enforcement
- `character_relationships` isolation
- `timeline_collaborators` access without recursion
- `notifications` isolation
- `content_reports` reporter/admin segregation and admin-only UPDATE

## Spec divergences

Three spec gaps and one real spec bug are documented in the migration header and tracked in #73. No silent workarounds — each divergence is flagged with a `-- flagged in #73` comment.

## Validation

- [x] `pnpm run check-types` — passes
- [x] `pnpm run lint` — passes (zero warnings)
- [x] `pnpm run build` — passes
- [x] `pnpm run db:test` — blocked: local Supabase fails to start (`EAI_AGAIN supabase_db_time-traveler` DNS error in this environment)