### PR TITLE
Add read-only database functions

### DIFF
--- a/supabase/migrations/00008_database_functions.sql
+++ b/supabase/migrations/00008_database_functions.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- 00008_database_functions.sql
+--
+-- Read-only database functions exposed via supabase.rpc() (issue #20).
+-- See docs/system-design.md §5.4.
+--
+-- All four functions are LANGUAGE sql STABLE — inlineable by the optimizer.
+-- Three run with the caller's privileges (RLS on base tables applies);
+-- get_user_metrics is SECURITY DEFINER for arbitrary-user lookup, with
+-- search_path='' hardening (matches the is_admin pattern from #16).
+-- ============================================================================
+
+-- Temporal range query (uses computed sort column)
+CREATE OR REPLACE FUNCTION public.events_in_temporal_range(
+  p_start_years BIGINT,
+  p_end_years BIGINT,
+  p_timeline_id UUID DEFAULT NULL
+) RETURNS SETOF public.events
+LANGUAGE sql STABLE
+AS $$
+  SELECT * FROM public.events
+  WHERE sort_order_years >= p_start_years
+    AND sort_order_years <= p_end_years
+    AND (p_timeline_id IS NULL OR timeline_id = p_timeline_id)
+  ORDER BY sort_order_years;
+$$;
+
+-- Recursive character relationship network (depth-bounded)
+CREATE OR REPLACE FUNCTION public.character_network(
+  p_character_id UUID,
+  p_depth INT DEFAULT 2
+) RETURNS TABLE(
+  source_id UUID,
+  target_id UUID,
+  rel_type TEXT,
+  source_name TEXT,
+  target_name TEXT,
+  depth INT
+)
+LANGUAGE sql STABLE
+AS $$
+  WITH RECURSIVE network AS (
+    SELECT cr.character_id,
+           cr.related_character_id,
+           cr.relationship_type,
+           1 AS depth
+    FROM public.character_relationships cr
+    WHERE cr.character_id = p_character_id
+    UNION ALL
+    SELECT cr.character_id,
+           cr.related_character_id,
+           cr.relationship_type,
+           n.depth + 1
+    FROM public.character_relationships cr
+    JOIN network n ON cr.character_id = n.related_character_id
+    WHERE n.depth < p_depth
+  )
+  SELECT n.character_id,
+         n.related_character_id,
+         n.relationship_type::text,
+         c1.name::text,
+         c2.name::text,
+         n.depth
+  FROM network n
+  JOIN public.characters c1 ON n.character_id = c1.id
+  JOIN public.characters c2 ON n.related_character_id = c2.id;
+$$;
+
+-- Events where ALL specified characters participated
+CREATE OR REPLACE FUNCTION public.events_shared_by_characters(
+  p_character_ids UUID[]
+) RETURNS SETOF public.events
+LANGUAGE sql STABLE
+AS $$
+  SELECT e.* FROM public.events e
+  WHERE (
+    SELECT COUNT(DISTINCT ec.character_id)
+    FROM public.event_characters ec
+    WHERE ec.event_id = e.id
+      AND ec.character_id = ANY(p_character_ids)
+  ) = array_length(p_character_ids, 1)
+  ORDER BY e.sort_order_years;
+$$;
+
+-- User metrics dashboard. SECURITY DEFINER so any caller (e.g. a public
+-- profile page) can request counts for any user; bypasses RLS to keep counts
+-- accurate. search_path='' + fully-qualified refs prevent search-path attacks.
+CREATE OR REPLACE FUNCTION public.get_user_metrics(p_user_id UUID)
+RETURNS TABLE(entity_type TEXT, count BIGINT)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT 'events'::text,     COUNT(*) FROM public.events     WHERE user_id = p_user_id
+  UNION ALL
+  SELECT 'timelines'::text,  COUNT(*) FROM public.timelines  WHERE user_id = p_user_id
+  UNION ALL
+  SELECT 'periods'::text,    COUNT(*) FROM public.periods    WHERE user_id = p_user_id
+  UNION ALL
+  SELECT 'stories'::text,    COUNT(*) FROM public.stories    WHERE user_id = p_user_id
+  UNION ALL
+  SELECT 'characters'::text, COUNT(*) FROM public.characters WHERE user_id = p_user_id
+  UNION ALL
+  SELECT 'categories'::text, COUNT(*) FROM public.categories WHERE user_id = p_user_id
+  UNION ALL
+  SELECT 'media'::text,      COUNT(*) FROM public.media      WHERE user_id = p_user_id;
+$$;

--- a/supabase/tests/database/00008_database_functions_test.sql
+++ b/supabase/tests/database/00008_database_functions_test.sql
@@ -1,0 +1,274 @@
+-- pgTAP tests for 00008_database_functions.sql (issue #20 — read-only RPC functions)
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(27);
+
+-- ============================================================================
+-- Function signatures + volatility + security mode
+-- ============================================================================
+
+select has_function('public', 'events_in_temporal_range',
+  array['bigint', 'bigint', 'uuid'],
+  'events_in_temporal_range function exists');
+select volatility_is('public', 'events_in_temporal_range',
+  array['bigint', 'bigint', 'uuid'], 'stable',
+  'events_in_temporal_range is STABLE');
+
+select has_function('public', 'character_network',
+  array['uuid', 'integer'],
+  'character_network function exists');
+select volatility_is('public', 'character_network',
+  array['uuid', 'integer'], 'stable',
+  'character_network is STABLE');
+
+select has_function('public', 'events_shared_by_characters',
+  array['uuid[]'],
+  'events_shared_by_characters function exists');
+select volatility_is('public', 'events_shared_by_characters',
+  array['uuid[]'], 'stable',
+  'events_shared_by_characters is STABLE');
+
+select has_function('public', 'get_user_metrics',
+  array['uuid'],
+  'get_user_metrics function exists');
+select volatility_is('public', 'get_user_metrics',
+  array['uuid'], 'stable',
+  'get_user_metrics is STABLE');
+select is(
+  (select prosecdef from pg_proc
+    where proname='get_user_metrics' and pronamespace='public'::regnamespace),
+  true,
+  'get_user_metrics is SECURITY DEFINER'
+);
+
+-- ============================================================================
+-- Fixture data
+-- ============================================================================
+
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('cccccccc-0000-0000-0000-cccccccccccc'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'rpc@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+insert into timelines (id, user_id, slug, title, temporal_data) values
+  ('cccccccc-0001-0000-0000-cccccccccccc'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc',
+   'tl-main', 'Main TL', '{"year":1000,"era":"CE"}'::jsonb),
+  ('cccccccc-0001-0000-0000-dddddddddddd'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc',
+   'tl-side', 'Side TL', '{"year":1000,"era":"CE"}'::jsonb);
+
+-- 5 events at years 100, 500, 1000, 1500, 2000 on the main timeline,
+-- plus one event at year 1200 on the side timeline (to test timeline filter)
+insert into events (id, user_id, slug, title, temporal_data, timeline_id) values
+  ('cccccccc-0002-0000-0000-000000000100'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc',
+   'ev-100', 'Year 100', '{"year":100,"era":"CE"}'::jsonb,
+   'cccccccc-0001-0000-0000-cccccccccccc'),
+  ('cccccccc-0002-0000-0000-000000000500'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc',
+   'ev-500', 'Year 500', '{"year":500,"era":"CE"}'::jsonb,
+   'cccccccc-0001-0000-0000-cccccccccccc'),
+  ('cccccccc-0002-0000-0000-000000001000'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc',
+   'ev-1000', 'Year 1000', '{"year":1000,"era":"CE"}'::jsonb,
+   'cccccccc-0001-0000-0000-cccccccccccc'),
+  ('cccccccc-0002-0000-0000-000000001500'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc',
+   'ev-1500', 'Year 1500', '{"year":1500,"era":"CE"}'::jsonb,
+   'cccccccc-0001-0000-0000-cccccccccccc'),
+  ('cccccccc-0002-0000-0000-000000002000'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc',
+   'ev-2000', 'Year 2000', '{"year":2000,"era":"CE"}'::jsonb,
+   'cccccccc-0001-0000-0000-cccccccccccc'),
+  ('cccccccc-0002-0000-0000-000000001200'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc',
+   'ev-side-1200', 'Side Year 1200', '{"year":1200,"era":"CE"}'::jsonb,
+   'cccccccc-0001-0000-0000-dddddddddddd');
+
+-- Characters: Hero, Rival, Ally
+insert into characters (id, user_id, slug, name, character_type) values
+  ('cccccccc-0004-0000-0000-000000000001'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc', 'hero', 'Hero', 'human'),
+  ('cccccccc-0004-0000-0000-000000000002'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc', 'rival', 'Rival', 'human'),
+  ('cccccccc-0004-0000-0000-000000000003'::uuid,
+   'cccccccc-0000-0000-0000-cccccccccccc', 'ally', 'Ally', 'human');
+
+-- Chain: Hero -> Rival, Rival -> Ally (for character_network depth tests)
+insert into character_relationships (user_id, character_id, related_character_id, relationship_type)
+values
+  ('cccccccc-0000-0000-0000-cccccccccccc',
+   'cccccccc-0004-0000-0000-000000000001',
+   'cccccccc-0004-0000-0000-000000000002', 'rivalry'),
+  ('cccccccc-0000-0000-0000-cccccccccccc',
+   'cccccccc-0004-0000-0000-000000000002',
+   'cccccccc-0004-0000-0000-000000000003', 'friendship');
+
+-- Event participation:
+--   ev-500 has Hero + Rival
+--   ev-1000 has Hero only
+--   ev-1500 has Hero + Rival + Ally
+insert into event_characters (event_id, character_id, role, significance) values
+  ('cccccccc-0002-0000-0000-000000000500',
+   'cccccccc-0004-0000-0000-000000000001', 'protagonist', 'primary'),
+  ('cccccccc-0002-0000-0000-000000000500',
+   'cccccccc-0004-0000-0000-000000000002', 'antagonist', 'primary'),
+  ('cccccccc-0002-0000-0000-000000001000',
+   'cccccccc-0004-0000-0000-000000000001', 'protagonist', 'primary'),
+  ('cccccccc-0002-0000-0000-000000001500',
+   'cccccccc-0004-0000-0000-000000000001', 'protagonist', 'primary'),
+  ('cccccccc-0002-0000-0000-000000001500',
+   'cccccccc-0004-0000-0000-000000000002', 'antagonist', 'secondary'),
+  ('cccccccc-0002-0000-0000-000000001500',
+   'cccccccc-0004-0000-0000-000000000003', 'witness', 'secondary');
+
+-- ============================================================================
+-- events_in_temporal_range
+-- ============================================================================
+
+select is(
+  (select count(*) from public.events_in_temporal_range(500::bigint, 1500::bigint)),
+  4::bigint, 'events_in_temporal_range with no timeline filter returns all 4 events in range (main + side)'
+);
+
+select is(
+  (select count(*) from public.events_in_temporal_range(0::bigint, 50::bigint)),
+  0::bigint, 'events_in_temporal_range returns 0 for an empty range'
+);
+
+select is(
+  (select count(*) from public.events_in_temporal_range(
+    500::bigint, 1500::bigint, 'cccccccc-0001-0000-0000-cccccccccccc'::uuid)),
+  3::bigint, 'events_in_temporal_range with timeline filter excludes side-timeline event'
+);
+
+select is(
+  (select array_agg(title order by sort_order_years)
+     from public.events_in_temporal_range(500::bigint, 1500::bigint,
+       'cccccccc-0001-0000-0000-cccccccccccc'::uuid)),
+  array['Year 500'::varchar, 'Year 1000'::varchar, 'Year 1500'::varchar],
+  'events_in_temporal_range returns results sorted ascending by year'
+);
+
+-- ============================================================================
+-- character_network
+-- ============================================================================
+
+select is(
+  (select count(*) from public.character_network(
+    'cccccccc-0004-0000-0000-000000000001'::uuid, 1)),
+  1::bigint, 'character_network with depth=1 returns 1 row (Hero -> Rival)'
+);
+
+select is(
+  (select count(*) from public.character_network(
+    'cccccccc-0004-0000-0000-000000000001'::uuid, 2)),
+  2::bigint, 'character_network with depth=2 returns 2 rows (adds Rival -> Ally)'
+);
+
+select is(
+  (select max(depth) from public.character_network(
+    'cccccccc-0004-0000-0000-000000000001'::uuid, 2)),
+  2, 'character_network respects depth bound'
+);
+
+select is(
+  (select target_name from public.character_network(
+    'cccccccc-0004-0000-0000-000000000001'::uuid, 2)
+    where depth = 2),
+  'Ally', 'character_network surfaces the depth-2 target name'
+);
+
+-- ============================================================================
+-- events_shared_by_characters
+-- ============================================================================
+
+-- Hero + Rival together: ev-500 and ev-1500
+select is(
+  (select count(*) from public.events_shared_by_characters(
+    array['cccccccc-0004-0000-0000-000000000001'::uuid,
+          'cccccccc-0004-0000-0000-000000000002'::uuid])),
+  2::bigint, 'events_shared_by_characters(Hero, Rival) returns 2 shared events'
+);
+
+-- Hero + Rival + Ally together: only ev-1500
+select is(
+  (select count(*) from public.events_shared_by_characters(
+    array['cccccccc-0004-0000-0000-000000000001'::uuid,
+          'cccccccc-0004-0000-0000-000000000002'::uuid,
+          'cccccccc-0004-0000-0000-000000000003'::uuid])),
+  1::bigint, 'events_shared_by_characters(Hero, Rival, Ally) returns 1 shared event'
+);
+
+select is(
+  (select title from public.events_shared_by_characters(
+    array['cccccccc-0004-0000-0000-000000000001'::uuid,
+          'cccccccc-0004-0000-0000-000000000002'::uuid,
+          'cccccccc-0004-0000-0000-000000000003'::uuid])),
+  'Year 1500'::varchar, 'events_shared_by_characters surfaces the right event title'
+);
+
+-- Single character: all events with that character
+select is(
+  (select count(*) from public.events_shared_by_characters(
+    array['cccccccc-0004-0000-0000-000000000001'::uuid])),
+  3::bigint, 'events_shared_by_characters(Hero) returns all 3 events with Hero'
+);
+
+-- ============================================================================
+-- get_user_metrics
+-- ============================================================================
+
+select is(
+  (select count(*) from public.get_user_metrics(
+    'cccccccc-0000-0000-0000-cccccccccccc'::uuid)),
+  7::bigint, 'get_user_metrics returns one row per entity type (7 total)'
+);
+
+select is(
+  (select count from public.get_user_metrics(
+    'cccccccc-0000-0000-0000-cccccccccccc'::uuid)
+    where entity_type = 'events'),
+  6::bigint, 'get_user_metrics counts owner''s 6 events correctly'
+);
+
+select is(
+  (select count from public.get_user_metrics(
+    'cccccccc-0000-0000-0000-cccccccccccc'::uuid)
+    where entity_type = 'timelines'),
+  2::bigint, 'get_user_metrics counts owner''s 2 timelines correctly'
+);
+
+select is(
+  (select count from public.get_user_metrics(
+    'cccccccc-0000-0000-0000-cccccccccccc'::uuid)
+    where entity_type = 'characters'),
+  3::bigint, 'get_user_metrics counts owner''s 3 characters correctly'
+);
+
+-- Nonexistent user → all zeros
+select is(
+  (select sum(count)::bigint from public.get_user_metrics(
+    '00000000-0000-0000-0000-000000000000'::uuid)),
+  0::bigint, 'get_user_metrics returns all zeros for an unknown user_id'
+);
+
+-- ============================================================================
+-- SECURITY DEFINER bypasses RLS — anon can call get_user_metrics
+-- and still see accurate counts even though anon would otherwise be filtered.
+-- ============================================================================
+
+set local role anon;
+select is(
+  (select count from public.get_user_metrics(
+    'cccccccc-0000-0000-0000-cccccccccccc'::uuid)
+    where entity_type = 'events'),
+  6::bigint, 'anon can call get_user_metrics and SECURITY DEFINER bypasses RLS for accurate counts'
+);
+
+reset role;
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

00008_database_functions.sql — four read-only PostgreSQL functions exposed via `supabase.rpc()`, implementing the query patterns specified in `docs/system-design.md §5.4`.

Closes #20

## Functions Added

| Function | Signature | Purpose |
|---|---|---|
| `events_in_temporal_range` | `(p_start_years BIGINT, p_end_years BIGINT, p_timeline_id UUID DEFAULT NULL)` | Returns `SETOF events` ordered by `sort_order_years`; optional timeline filter |
| `character_network` | `(p_character_id UUID, p_depth INT DEFAULT 2)` | Recursive CTE returning the relationship graph to a specified depth, with both character names resolved |
| `events_shared_by_characters` | `(p_character_ids UUID[])` | Returns events where **all** specified characters participated, using a count-equals-array-length predicate |
| `get_user_metrics` | `(p_user_id UUID)` | Returns `(entity_type TEXT, count BIGINT)` rows for all 7 owned entity types; `SECURITY DEFINER` so any caller gets accurate counts regardless of RLS |

All functions are `LANGUAGE sql STABLE` (not plpgsql) for query-optimizer inlining, per locked decision #2. The three caller-privilege functions respect RLS on base tables. `get_user_metrics` uses `SECURITY DEFINER` + `SET search_path = ''` + fully-qualified refs, matching the `is_admin` hardening pattern from migration 00004.

## Tests

00008_database_functions_test.sql — 27 pgTAP assertions covering:

- **Signatures + volatility + security mode** (9 assertions) — `has_function`, `volatility_is`, and `prosecdef` check for all 4 functions
- **`events_in_temporal_range`** (4) — range bounds, empty range, timeline filter, sort order
- **`character_network`** (4) — depth=1, depth=2, depth bound, target name resolution at depth 2
- **`events_shared_by_characters`** (4) — 2-character intersection, 3-character intersection, title check, single-character passthrough
- **`get_user_metrics`** (5) — row count, event count, timeline count, character count, all-zeros for unknown user
- **`SECURITY DEFINER` bypass** (1) — `anon` role can invoke and receives accurate counts

Full suite after `db:reset`: **247 tests across 8 files, all green.**

## Acceptance criteria (issue #20)

- [x] All 4 functions created per `system-design.md §5.4`
- [x] All use `LANGUAGE sql STABLE` (not plpgsql)
- [x] `get_user_metrics` uses `SECURITY DEFINER`
- [x] Functions callable via `supabase.rpc()`
- [x] No CRUD functions — reads only (locked decision #2)