### PR TITLE
Supabase Storage buckets and RLS policies

### DIFF
--- a/supabase/migrations/00009_storage_buckets_and_policies.sql
+++ b/supabase/migrations/00009_storage_buckets_and_policies.sql
@@ -1,0 +1,95 @@
+-- ============================================================================
+-- 00009_storage_buckets_and_policies.sql
+--
+-- Supabase Storage buckets + RLS policies on storage.objects (issue #22).
+-- See docs/system-design.md §5.7 (buckets) and §9.3 (policy pattern).
+--
+-- Three buckets:
+--   media    — public read, authenticated upload, owner-only update/delete
+--   avatars  — public read, authenticated upload, owner-only update/delete
+--   exports  — owner-only read/write (private — never publicly readable)
+--
+-- 5MB per-upload size limit is enforced in TWO places (belt-and-suspenders):
+--   (a) bucket-level file_size_limit (cheap default; storage API rejects early)
+--   (b) policy WITH CHECK on (metadata->>'size')::bigint <= 5242880
+--       (matches AC literal "enforced in policy")
+-- ============================================================================
+
+-- Buckets (5MB = 5 * 1024 * 1024 = 5242880 bytes)
+INSERT INTO storage.buckets (id, name, public, file_size_limit) VALUES
+  ('media',   'media',   true,  5242880),
+  ('avatars', 'avatars', true,  5242880),
+  ('exports', 'exports', false, 5242880)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================================================
+-- media bucket: public read, authenticated upload, owner-only update/delete
+-- ============================================================================
+
+CREATE POLICY "media_select"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'media');
+
+CREATE POLICY "media_insert"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'media'
+    AND (metadata->>'size')::bigint <= 5242880
+  );
+
+CREATE POLICY "media_update"
+  ON storage.objects FOR UPDATE TO authenticated
+  USING (bucket_id = 'media' AND owner = auth.uid())
+  WITH CHECK (bucket_id = 'media' AND owner = auth.uid());
+
+CREATE POLICY "media_delete"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (bucket_id = 'media' AND owner = auth.uid());
+
+-- ============================================================================
+-- avatars bucket: same pattern as media
+-- ============================================================================
+
+CREATE POLICY "avatars_select"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'avatars');
+
+CREATE POLICY "avatars_insert"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (metadata->>'size')::bigint <= 5242880
+  );
+
+CREATE POLICY "avatars_update"
+  ON storage.objects FOR UPDATE TO authenticated
+  USING (bucket_id = 'avatars' AND owner = auth.uid())
+  WITH CHECK (bucket_id = 'avatars' AND owner = auth.uid());
+
+CREATE POLICY "avatars_delete"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (bucket_id = 'avatars' AND owner = auth.uid());
+
+-- ============================================================================
+-- exports bucket: owner-only read/write (private)
+-- ============================================================================
+
+CREATE POLICY "exports_select"
+  ON storage.objects FOR SELECT TO authenticated
+  USING (bucket_id = 'exports' AND owner = auth.uid());
+
+CREATE POLICY "exports_insert"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'exports'
+    AND (metadata->>'size')::bigint <= 5242880
+  );
+
+CREATE POLICY "exports_update"
+  ON storage.objects FOR UPDATE TO authenticated
+  USING (bucket_id = 'exports' AND owner = auth.uid())
+  WITH CHECK (bucket_id = 'exports' AND owner = auth.uid());
+
+CREATE POLICY "exports_delete"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (bucket_id = 'exports' AND owner = auth.uid());

--- a/supabase/tests/database/00009_storage_buckets_and_policies_test.sql
+++ b/supabase/tests/database/00009_storage_buckets_and_policies_test.sql
@@ -1,0 +1,162 @@
+-- pgTAP tests for 00009_storage_buckets_and_policies.sql (issue #22 — storage)
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(20);
+
+-- ============================================================================
+-- Buckets exist with correct public/private + 5MB size limit
+-- ============================================================================
+
+select is(
+  (select count(*)::bigint from storage.buckets
+    where id in ('media', 'avatars', 'exports')),
+  3::bigint,
+  'all 3 buckets created (media, avatars, exports)'
+);
+
+select is(
+  (select public from storage.buckets where id = 'media'),
+  true, 'media bucket is public'
+);
+select is(
+  (select public from storage.buckets where id = 'avatars'),
+  true, 'avatars bucket is public'
+);
+select is(
+  (select public from storage.buckets where id = 'exports'),
+  false, 'exports bucket is private'
+);
+
+select is(
+  (select file_size_limit from storage.buckets where id = 'media'),
+  5242880::bigint, 'media bucket has 5MB file_size_limit'
+);
+select is(
+  (select file_size_limit from storage.buckets where id = 'avatars'),
+  5242880::bigint, 'avatars bucket has 5MB file_size_limit'
+);
+select is(
+  (select file_size_limit from storage.buckets where id = 'exports'),
+  5242880::bigint, 'exports bucket has 5MB file_size_limit'
+);
+
+-- ============================================================================
+-- All 12 policies exist on storage.objects (4 per bucket × 3 buckets)
+-- ============================================================================
+
+select policies_are(
+  'storage', 'objects',
+  array[
+    'media_select',   'media_insert',   'media_update',   'media_delete',
+    'avatars_select', 'avatars_insert', 'avatars_update', 'avatars_delete',
+    'exports_select', 'exports_insert', 'exports_update', 'exports_delete'
+  ],
+  'all 12 storage policies present (4 ops × 3 buckets)'
+);
+
+-- ============================================================================
+-- Spot-check per-bucket policy commands match intent
+-- (storage.objects already has RLS enabled by default Supabase setup)
+-- ============================================================================
+
+select is(
+  (select rowsecurity from pg_tables
+    where schemaname='storage' and tablename='objects'),
+  true,
+  'storage.objects has RLS enabled (Supabase default)'
+);
+
+-- Verify INSERT policies contain the 5MB size check (literal pattern match)
+select ok(
+  (select qual is null and with_check like '%5242880%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='media_insert'),
+  'media_insert policy enforces 5MB limit in WITH CHECK'
+);
+select ok(
+  (select with_check like '%5242880%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='avatars_insert'),
+  'avatars_insert policy enforces 5MB limit in WITH CHECK'
+);
+select ok(
+  (select with_check like '%5242880%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='exports_insert'),
+  'exports_insert policy enforces 5MB limit in WITH CHECK'
+);
+
+-- Verify public-read policies have NULL `roles` filter or include public
+-- (i.e., not restricted to authenticated only)
+select ok(
+  (select 'public' = any(roles) or roles is null
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='media_select'),
+  'media_select is reachable by anon (public role)'
+);
+select ok(
+  (select 'public' = any(roles) or roles is null
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='avatars_select'),
+  'avatars_select is reachable by anon (public role)'
+);
+
+-- Verify exports SELECT is RESTRICTED to authenticated (not public)
+select ok(
+  (select 'authenticated' = any(roles) and not ('public' = any(roles))
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='exports_select'),
+  'exports_select restricted to authenticated role (no anon access)'
+);
+
+-- Verify owner-only DELETE policies reference auth.uid()
+select ok(
+  (select qual like '%auth.uid()%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='media_delete'),
+  'media_delete enforces owner = auth.uid()'
+);
+select ok(
+  (select qual like '%auth.uid()%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='exports_delete'),
+  'exports_delete enforces owner = auth.uid()'
+);
+
+-- Verify owner-only UPDATE policies reference auth.uid() in both USING and WITH CHECK
+select ok(
+  (select qual like '%auth.uid()%' and with_check like '%auth.uid()%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='media_update'),
+  'media_update enforces owner = auth.uid() in both USING and WITH CHECK'
+);
+select ok(
+  (select qual like '%auth.uid()%' and with_check like '%auth.uid()%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='exports_update'),
+  'exports_update enforces owner = auth.uid() in both USING and WITH CHECK'
+);
+
+-- INSERT policies have NULL `qual` (only WITH CHECK applies to INSERT)
+-- and the WITH CHECK references the bucket_id and metadata->>'size'
+select ok(
+  (select with_check like '%bucket_id%' and with_check like '%metadata%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='media_insert'),
+  'media_insert WITH CHECK references bucket_id + metadata'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Adds migration `00009_storage_buckets_and_policies.sql` to create the three Supabase Storage buckets defined in system-design.md §5.7, with full RLS policies on `storage.objects` covering all four operations (SELECT, INSERT, UPDATE, DELETE) for each bucket. A pgTAP test file with 20 assertions verifies every acceptance criterion.

Closes #22

## Buckets

| Bucket | Public | Purpose |
|--------|--------|---------|
| `media` | Yes | Event and character media (images, docs) |
| `avatars` | Yes | User profile avatars |
| `exports` | No | Private timeline exports (PDF, JSON) |

All three buckets are created with a `file_size_limit` of 5MB (5,242,880 bytes).

## Policies (12 total — 4 ops × 3 buckets)

| Bucket | SELECT | INSERT | UPDATE | DELETE |
|--------|--------|--------|--------|--------|
| `media` | Public (anon + authenticated) | Authenticated only | Owner only | Owner only |
| `avatars` | Public (anon + authenticated) | Authenticated only | Owner only | Owner only |
| `exports` | Owner only (authenticated) | Authenticated only | Owner only | Owner only |

The 5MB limit is enforced in two places:
- **Bucket-level** `file_size_limit` — Storage API rejects early before any policy check
- **Policy-level** `WITH CHECK (metadata->>'size')::bigint <= 5242880` on all INSERT policies — satisfies the acceptance criterion "enforced in policy"

All UPDATE policies include `auth.uid()` in both `USING` and `WITH CHECK` to prevent an owner from transferring an object to another user.

## Files Changed

- **New** 00009_storage_buckets_and_policies.sql — bucket creation + 12 RLS policies
- **New** 00009_storage_buckets_and_policies_test.sql — 20 pgTAP assertions covering: bucket count, public/private flags, per-bucket file size limits, all 12 policy names present, INSERT size-check content, public SELECT accessibility, exports SELECT authenticated-only restriction, owner-only DELETE/UPDATE enforcement

## Acceptance Criteria

- [x] All 3 buckets created (`media`, `avatars`, `exports`)
- [x] Public/private access configured correctly (`media` and `avatars` public; `exports` private)
- [x] Upload policies restrict to authenticated users (INSERT requires `authenticated` role)
- [x] Delete policies restrict to file owner (`owner = auth.uid()`)
- [x] 5MB file size limit enforced (bucket `file_size_limit` + INSERT `WITH CHECK`)