### PR TITLE
chore: restrict Dependabot groups to minor/patch only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,14 +17,23 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+        update-types:
+          - minor
+          - patch
       next-ecosystem:
         patterns:
           - "next"
           - "@next/*"
+        update-types:
+          - minor
+          - patch
       supabase-ecosystem:
         patterns:
           - "@supabase/*"
           - "supabase"
+        update-types:
+          - minor
+          - patch
       typescript-toolchain:
         patterns:
           - "typescript"
@@ -33,6 +42,9 @@ updates:
           - "@typescript-eslint/*"
           - "prettier"
           - "turbo"
+        update-types:
+          - minor
+          - patch
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
Major version bumps (e.g. TypeScript 5→6, ESLint 9→10) require migration work and should not be auto-grouped. Each major upgrade will now get its own individual PR, keeping grouped PRs safe to merge without CI investigation.

Closes the root cause of #103.