### PR TITLE
Harden function search_path (00010)

### DIFF
--- a/supabase/migrations/00010_function_search_path_hardening.sql
+++ b/supabase/migrations/00010_function_search_path_hardening.sql
@@ -1,4 +1,22 @@
--- Hardens function-level search_path for Security Advisor findings.
+-- ============================================================================
+-- 00010_function_search_path_hardening.sql
+--
+-- Hardens function-level search_path for Supabase Security Advisor findings
+-- (issue #112). Sets search_path = '' on all affected public functions so
+-- Postgres cannot resolve object references through an attacker-controlled
+-- search path.
+--
+-- Affected functions:
+--   public.events_in_temporal_range(bigint, bigint, uuid)
+--   public.immutable_array_to_string(text[], text)
+--   public.handle_updated_at()
+--   public.sync_notification_read_at()
+--   public.character_network(uuid, integer)
+--   public.events_shared_by_characters(uuid[])
+--
+-- No function bodies are modified; this is a configuration-only change.
+-- See docs/system-design.md §8 (security hardening) for background.
+-- ============================================================================
 
 ALTER FUNCTION public.events_in_temporal_range(BIGINT, BIGINT, UUID)
   SET search_path = '';

--- a/supabase/migrations/00010_function_search_path_hardening.sql
+++ b/supabase/migrations/00010_function_search_path_hardening.sql
@@ -1,0 +1,19 @@
+-- Hardens function-level search_path for Security Advisor findings.
+
+ALTER FUNCTION public.events_in_temporal_range(BIGINT, BIGINT, UUID)
+  SET search_path = '';
+
+ALTER FUNCTION public.immutable_array_to_string(TEXT[], TEXT)
+  SET search_path = '';
+
+ALTER FUNCTION public.handle_updated_at()
+  SET search_path = '';
+
+ALTER FUNCTION public.sync_notification_read_at()
+  SET search_path = '';
+
+ALTER FUNCTION public.character_network(UUID, INTEGER)
+  SET search_path = '';
+
+ALTER FUNCTION public.events_shared_by_characters(UUID[])
+  SET search_path = '';

--- a/supabase/tests/database/00010_function_search_path_hardening_test.sql
+++ b/supabase/tests/database/00010_function_search_path_hardening_test.sql
@@ -1,0 +1,67 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(6);
+
+select is(
+  (select array_to_string(proconfig, ',')
+   from pg_proc
+   where pronamespace='public'::regnamespace
+     and proname='events_in_temporal_range'
+     and oidvectortypes(proargtypes)='bigint, bigint, uuid'),
+  'search_path=""',
+  'events_in_temporal_range has search_path hardening'
+);
+
+select is(
+  (select array_to_string(proconfig, ',')
+   from pg_proc
+   where pronamespace='public'::regnamespace
+     and proname='immutable_array_to_string'
+     and oidvectortypes(proargtypes)='text[], text'),
+  'search_path=""',
+  'immutable_array_to_string has search_path hardening'
+);
+
+select is(
+  (select array_to_string(proconfig, ',')
+   from pg_proc
+   where pronamespace='public'::regnamespace
+     and proname='handle_updated_at'
+     and oidvectortypes(proargtypes)=''),
+  'search_path=""',
+  'handle_updated_at has search_path hardening'
+);
+
+select is(
+  (select array_to_string(proconfig, ',')
+   from pg_proc
+   where pronamespace='public'::regnamespace
+     and proname='sync_notification_read_at'
+     and oidvectortypes(proargtypes)=''),
+  'search_path=""',
+  'sync_notification_read_at has search_path hardening'
+);
+
+select is(
+  (select array_to_string(proconfig, ',')
+   from pg_proc
+   where pronamespace='public'::regnamespace
+     and proname='character_network'
+     and oidvectortypes(proargtypes)='uuid, integer'),
+  'search_path=""',
+  'character_network has search_path hardening'
+);
+
+select is(
+  (select array_to_string(proconfig, ',')
+   from pg_proc
+   where pronamespace='public'::regnamespace
+     and proname='events_shared_by_characters'
+     and oidvectortypes(proargtypes)='uuid[]'),
+  'search_path=""',
+  'events_shared_by_characters has search_path hardening'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/00010_function_search_path_hardening_test.sql
+++ b/supabase/tests/database/00010_function_search_path_hardening_test.sql
@@ -1,3 +1,4 @@
+-- pgTAP tests for 00010_function_search_path_hardening.sql (issue #112 — security hardening)
 begin;
 create extension if not exists pgtap with schema extensions;
 


### PR DESCRIPTION
Adds migration 00010 to set function-level search_path='' for six functions to address Supabase Security Advisor findings, and includes a pgTAP regression test.