### PR TITLE
Add GitHub Actions labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,54 @@
+# .github/labeler.yml
+# Path-based label rules for actions/labeler@v5.
+# Each key is a GitHub label name; values are glob patterns matched against
+# changed file paths in a pull request.
+
+"area: admin":
+  - changed-files:
+      - any-glob-to-any-file: "apps/admin/**"
+
+"area: docs-app":
+  - changed-files:
+      - any-glob-to-any-file: "apps/docs/**"
+
+"area: ui":
+  - changed-files:
+      - any-glob-to-any-file: "packages/ui/**"
+
+"area: services":
+  - changed-files:
+      - any-glob-to-any-file: "packages/services/**"
+
+"area: database":
+  - changed-files:
+      - any-glob-to-any-file: "supabase/**"
+
+"area: documentation":
+  - changed-files:
+      - any-glob-to-any-file: "docs/**"
+      - any-glob-to-any-file: "**/*.md"
+
+"area: ci":
+  - changed-files:
+      - any-glob-to-any-file: ".github/workflows/**"
+      - any-glob-to-any-file: ".github/actions/**"
+
+"area: config":
+  - changed-files:
+      - any-glob-to-any-file: ".github/dependabot.yml"
+      - any-glob-to-any-file: "turbo.json"
+      - any-glob-to-any-file: "pnpm-workspace.yaml"
+      - any-glob-to-any-file: "package.json"
+      - any-glob-to-any-file: "packages/eslint-config/**"
+      - any-glob-to-any-file: "packages/typescript-config/**"
+
+"area: security":
+  - changed-files:
+      - any-glob-to-any-file: "SECURITY.md"
+      - any-glob-to-any-file: ".github/codeql*.yml"
+      - any-glob-to-any-file: "supabase/migrations/*rls*"
+      - any-glob-to-any-file: "supabase/migrations/*security*"
+      - any-glob-to-any-file: "supabase/migrations/*hardening*"
+      - any-glob-to-any-file: "supabase/tests/database/*rls*"
+      - any-glob-to-any-file: "supabase/tests/database/*security*"
+      - any-glob-to-any-file: "supabase/tests/database/*hardening*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -45,7 +45,7 @@
 "area: security":
   - changed-files:
       - any-glob-to-any-file: "SECURITY.md"
-      - any-glob-to-any-file: ".github/codeql*.yml"
+      - any-glob-to-any-file: ".github/workflows/codeql*.yml"
       - any-glob-to-any-file: "supabase/migrations/*rls*"
       - any-glob-to-any-file: "supabase/migrations/*security*"
       - any-glob-to-any-file: "supabase/migrations/*hardening*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,28 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply Labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Apply path-based labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false


### PR DESCRIPTION
## Summary

Adds automated PR labeling via [actions/labeler@v5](https://github.com/actions/labeler).

### New files
- `.github/labeler.yml` — path-based label rules covering all workspace areas
- `.github/workflows/labeler.yml` — runs on `pull_request_target` (open/sync/reopen)

### Labels applied automatically

| Label | Trigger paths |
|---|---|
| `area: admin` | `apps/admin/**` |
| `area: docs-app` | `apps/docs/**` |
| `area: ui` | `packages/ui/**` |
| `area: services` | `packages/services/**` |
| `area: database` | `supabase/**` |
| `area: documentation` | `docs/**`, `**/*.md` |
| `area: ci` | `.github/workflows/**` |
| `area: config` | root config files, eslint-config, typescript-config |
| `area: security` | `SECURITY.md`, CodeQL config, RLS/security/hardening migrations |

`sync-labels: false` is set intentionally so manually applied labels are not removed.