### PR TITLE
feat(slug): implement generateSlug, validateSlug, resolveCollision

### DIFF
--- a/packages/services/src/schemas/slug.ts
+++ b/packages/services/src/schemas/slug.ts
@@ -1,10 +1,17 @@
 import { z } from "zod";
 
 /**
+ * Upper bound on slug length, matching the migrations' `VARCHAR(100)`.
+ * Exported so generators/collision-resolvers can truncate against the same
+ * limit the validator enforces — single source of truth.
+ */
+export const MAX_SLUG_LENGTH = 100;
+
+/**
  * Shared slug validator — URL-safe identifier used as the per-user unique
  * key on every content entity (events, timelines, characters, etc.).
  *
- * Constraints align with the migrations' VARCHAR(100) + per-user unique
+ * Constraints align with the migrations' `VARCHAR(100)` + per-user unique
  * index on `(user_id, slug)`. The regex is the application-layer addition
  * (DB only enforces length). It rejects leading/trailing hyphens and
  * consecutive hyphens — matches the shape produced by `generateSlug` so the
@@ -13,7 +20,7 @@ import { z } from "zod";
 export const slugSchema = z
   .string()
   .min(1)
-  .max(100)
+  .max(MAX_SLUG_LENGTH)
   .regex(
     /^[a-z0-9]+(-[a-z0-9]+)*$/,
     "slug must be lowercase alphanumeric segments separated by single hyphens",

--- a/packages/services/src/schemas/slug.ts
+++ b/packages/services/src/schemas/slug.ts
@@ -6,10 +6,15 @@ import { z } from "zod";
  *
  * Constraints align with the migrations' VARCHAR(100) + per-user unique
  * index on `(user_id, slug)`. The regex is the application-layer addition
- * (DB only enforces length).
+ * (DB only enforces length). It rejects leading/trailing hyphens and
+ * consecutive hyphens — matches the shape produced by `generateSlug` so the
+ * utility and validator agree on a single definition of "valid slug".
  */
 export const slugSchema = z
   .string()
   .min(1)
   .max(100)
-  .regex(/^[a-z0-9-]+$/, "slug must be lowercase alphanumeric with hyphens");
+  .regex(
+    /^[a-z0-9]+(-[a-z0-9]+)*$/,
+    "slug must be lowercase alphanumeric segments separated by single hyphens",
+  );

--- a/packages/services/src/utils/slug.ts
+++ b/packages/services/src/utils/slug.ts
@@ -1,6 +1,4 @@
-import { slugSchema } from "../schemas/slug.js";
-
-const MAX_SLUG_LENGTH = 100;
+import { MAX_SLUG_LENGTH, slugSchema } from "../schemas/slug.js";
 
 /**
  * Converts an arbitrary title to a URL-safe slug:
@@ -23,7 +21,7 @@ export function generateSlug(title: string): string {
 
   const normalized = title
     .normalize("NFKD")
-    .replace(/[̀-ͯ]/g, "")
+    .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
@@ -40,7 +38,7 @@ export function generateSlug(title: string): string {
 /**
  * Returns true when `slug` matches the canonical form enforced by
  * `slugSchema`: lowercase alphanumeric segments separated by single hyphens,
- * 1–100 chars, no leading/trailing/consecutive hyphens.
+ * 1–MAX_SLUG_LENGTH chars, no leading/trailing/consecutive hyphens.
  */
 export function validateSlug(slug: string): boolean {
   return slugSchema.safeParse(slug).success;
@@ -51,11 +49,21 @@ export function validateSlug(slug: string): boolean {
  * appends the smallest numeric suffix ≥ 2 (`my-title-2`, `my-title-3`, ...)
  * that's free. Truncates the base when necessary so the suffixed result
  * stays within MAX_SLUG_LENGTH.
+ *
+ * `baseSlug` must already satisfy `slugSchema` (typically produced by
+ * `generateSlug`) — throws otherwise so callers fail fast rather than
+ * producing a colliding-but-still-invalid slug downstream.
  */
 export function resolveCollision(
   baseSlug: string,
   existingSlugs: Iterable<string>,
 ): string {
+  if (!validateSlug(baseSlug)) {
+    throw new Error(
+      `resolveCollision requires baseSlug to satisfy slugSchema — got "${baseSlug}"`,
+    );
+  }
+
   const taken = existingSlugs instanceof Set ? existingSlugs : new Set(existingSlugs);
   if (!taken.has(baseSlug)) return baseSlug;
 

--- a/packages/services/src/utils/slug.ts
+++ b/packages/services/src/utils/slug.ts
@@ -1,0 +1,76 @@
+import { slugSchema } from "../schemas/slug.js";
+
+const MAX_SLUG_LENGTH = 100;
+
+/**
+ * Converts an arbitrary title to a URL-safe slug:
+ * - Unicode NFKD normalization + combining-mark strip folds most Latin
+ *   diacritics to ASCII (café → cafe, résumé → resume, naïve → naive).
+ *   Non-Latin scripts (中文, العربية, emoji) drop out and will throw if
+ *   nothing usable remains.
+ * - Anything not in [a-z0-9] becomes a single hyphen, runs collapse, and
+ *   leading/trailing hyphens are trimmed.
+ * - Result is truncated to MAX_SLUG_LENGTH at a word (hyphen) boundary when
+ *   possible — falls back to a hard cut if no boundary exists in range.
+ *
+ * Throws when the input is empty/whitespace-only or yields nothing usable
+ * after normalization (e.g., a pure-emoji title).
+ */
+export function generateSlug(title: string): string {
+  if (title.trim().length === 0) {
+    throw new Error("slug cannot be generated from empty or whitespace-only input");
+  }
+
+  const normalized = title
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (normalized.length === 0) {
+    throw new Error(
+      `slug cannot be generated from "${title}" — no ASCII alphanumeric characters survived normalization`,
+    );
+  }
+
+  return truncateAtBoundary(normalized, MAX_SLUG_LENGTH);
+}
+
+/**
+ * Returns true when `slug` matches the canonical form enforced by
+ * `slugSchema`: lowercase alphanumeric segments separated by single hyphens,
+ * 1–100 chars, no leading/trailing/consecutive hyphens.
+ */
+export function validateSlug(slug: string): boolean {
+  return slugSchema.safeParse(slug).success;
+}
+
+/**
+ * Returns `baseSlug` if it doesn't collide with `existingSlugs`; otherwise
+ * appends the smallest numeric suffix ≥ 2 (`my-title-2`, `my-title-3`, ...)
+ * that's free. Truncates the base when necessary so the suffixed result
+ * stays within MAX_SLUG_LENGTH.
+ */
+export function resolveCollision(
+  baseSlug: string,
+  existingSlugs: Iterable<string>,
+): string {
+  const taken = existingSlugs instanceof Set ? existingSlugs : new Set(existingSlugs);
+  if (!taken.has(baseSlug)) return baseSlug;
+
+  for (let n = 2; ; n++) {
+    const suffix = `-${n}`;
+    const room = MAX_SLUG_LENGTH - suffix.length;
+    const truncated = baseSlug.length > room ? truncateAtBoundary(baseSlug, room) : baseSlug;
+    const candidate = `${truncated}${suffix}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+function truncateAtBoundary(slug: string, maxLength: number): string {
+  if (slug.length <= maxLength) return slug;
+  const window = slug.slice(0, maxLength);
+  const lastHyphen = window.lastIndexOf("-");
+  return lastHyphen > 0 ? window.slice(0, lastHyphen) : window;
+}


### PR DESCRIPTION
Closes #25.

## Summary

- Adds `packages/services/src/utils/slug.ts` — first file under a new `utils/` sibling to `modules/` and `schemas/` — exporting three pure helpers used by entity services for URL-safe identifiers (timelines, events, periods, characters, stories, categories).
- Tightens `slugSchema` regex so it agrees with what `generateSlug` actually produces (single source of truth for "valid slug").

## What's in `utils/slug.ts`

- **`generateSlug(title)`** — Unicode NFKD normalize → strip combining marks → lowercase → collapse non-`[a-z0-9]` runs into single hyphens → trim → truncate to 100 at word (`-`) boundary. Throws on empty/whitespace input and on inputs that yield nothing usable (pure emoji, non-Latin scripts NFKD can't fold).
- **`validateSlug(slug)`** — delegates to `slugSchema.safeParse(slug).success` so the regex lives in exactly one place.
- **`resolveCollision(baseSlug, existingSlugs)`** — returns `baseSlug` if free, else smallest `${baseSlug}-N` for N ≥ 2 that's unused. Accepts `Iterable<string>` (Array, Set, generator). Truncates the base when needed so the suffixed slug still fits in 100 chars.

## Tradeoffs and known gaps

- **NFKD doesn't transliterate non-Latin scripts** — `"中文"`, `"العربية"`, `"🎉"` throw rather than producing an empty slug silently. German `ß` likewise stays as `ß` (NFKD doesn't decompose it to `ss`) and becomes a hyphen, so `"müßer"` → `"mu-er"`. Avoiding a dependency was the explicit design choice; if a real use case for non-Latin titles surfaces, swapping in a library (`@sindresorhus/slugify`) is a one-call change inside `generateSlug`.
- **Per-user uniqueness is the caller's job** — DB constraints are `UNIQUE (user_id, slug)`, so `resolveCollision` takes the existing list as an input rather than querying. Entity services (#28, #29 …) will fetch the relevant per-user slugs and pass them in.

## Test plan

- [x] `pnpm run check-types` passes
- [x] `pnpm run lint --max-warnings 0` passes
- [x] `pnpm run build` passes
- [x] Runtime sanity script covered: ASCII titles, diacritics, punctuation runs, leading/trailing junk, mixed case, very long titles (boundary-cut to ≤100), empty / whitespace / pure-emoji / pure-Chinese inputs (all throw), all validator cases (uppercase, leading/trailing/consecutive hyphens, 100-char boundary), collision chains with gaps, long-base collisions staying ≤100, and `generateSlug → validateSlug` roundtrip for the sample set
- [ ] Formal unit tests land in #27