### PR TITLE
feat(services): add CharacterService module

### DIFF
--- a/packages/services/src/character-service.ts
+++ b/packages/services/src/character-service.ts
@@ -1,0 +1,1 @@
+export * from "./modules/character-service.js";

--- a/packages/services/src/modules/character-service.test.ts
+++ b/packages/services/src/modules/character-service.test.ts
@@ -449,6 +449,39 @@ describe("createCharacter", () => {
     ).rejects.toThrow();
   });
 
+  it("rejects unknown keys in profile_data (strict schemas)", async () => {
+    const client = makeCreateClient({ data: null, error: null });
+    await expect(
+      createCharacter(client, {
+        name: "Arthur Conan Doyle",
+        character_type: "human",
+        profile_data: {
+          character_type: "human",
+          nationality: "Scottish",
+          unknown_field: "should fail",
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("top-level character_type is authoritative even when profile_data contains a different character_type", async () => {
+    // profile_data.character_type is 'animal' but the top-level type is 'human'.
+    // The service must use the top-level type, so 'animal' in profile_data
+    // should NOT cause it to validate as an animal profile — it should throw
+    // because 'animal' inside profile_data is an unrecognised key for human.
+    const client = makeCreateClient({ data: null, error: null });
+    await expect(
+      createCharacter(client, {
+        name: "Test",
+        character_type: "human",
+        profile_data: {
+          character_type: "animal",
+          conservation_status: "extinct",
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
   it("uses explicit slug when provided", async () => {
     const client = makeCreateClient({ data: sampleCharacter, error: null });
     const result = await createCharacter(client, {
@@ -710,6 +743,33 @@ describe("getCharacterNetwork", () => {
     await getCharacterNetwork(client, "char-1");
     expect(client.rpc).toHaveBeenCalledWith("character_network", {
       p_character_id: "char-1",
+    });
+  });
+
+  it("clamps depth above MAX_NETWORK_DEPTH (5) to 5", async () => {
+    const client = makeClient({ rpcResult: { data: [], error: null } });
+    await getCharacterNetwork(client, "char-1", 99);
+    expect(client.rpc).toHaveBeenCalledWith("character_network", {
+      p_character_id: "char-1",
+      p_depth: 5,
+    });
+  });
+
+  it("clamps depth below 1 to 1", async () => {
+    const client = makeClient({ rpcResult: { data: [], error: null } });
+    await getCharacterNetwork(client, "char-1", 0);
+    expect(client.rpc).toHaveBeenCalledWith("character_network", {
+      p_character_id: "char-1",
+      p_depth: 1,
+    });
+  });
+
+  it("floors a float depth value", async () => {
+    const client = makeClient({ rpcResult: { data: [], error: null } });
+    await getCharacterNetwork(client, "char-1", 2.9);
+    expect(client.rpc).toHaveBeenCalledWith("character_network", {
+      p_character_id: "char-1",
+      p_depth: 2,
     });
   });
 

--- a/packages/services/src/modules/character-service.test.ts
+++ b/packages/services/src/modules/character-service.test.ts
@@ -1,0 +1,861 @@
+import { describe, it, expect, vi } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../supabase/types.js";
+import {
+  getCharacters,
+  getCharacterById,
+  getCharacterBySlug,
+  createCharacter,
+  updateCharacter,
+  deleteCharacter,
+  getCharacterTimeline,
+  getCharacterNetwork,
+  getCharacterEvents,
+  addMediaToCharacter,
+  removeMediaFromCharacter,
+} from "./character-service.js";
+
+// ---------------------------------------------------------------------------
+// Mock builder helpers (mirrors event-service.test.ts pattern)
+// ---------------------------------------------------------------------------
+
+function makeBuilder(result: { data: unknown; error: unknown }) {
+  const terminal = vi.fn().mockResolvedValue(result);
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    textSearch: vi.fn().mockReturnThis(),
+    range: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    single: terminal,
+    then: (resolve: (v: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve),
+  };
+  return builder;
+}
+
+function makeClient(overrides: {
+  fromResult?: { data: unknown; error: unknown };
+  rpcResult?: { data: unknown; error: unknown };
+  authUser?: { data: { user: unknown }; error: unknown };
+}) {
+  const {
+    fromResult = { data: null, error: null },
+    rpcResult = { data: null, error: null },
+    authUser,
+  } = overrides;
+
+  const client = {
+    from: vi.fn().mockReturnValue(makeBuilder(fromResult)),
+    rpc: vi.fn().mockResolvedValue(rpcResult),
+    auth: {
+      getUser: vi
+        .fn()
+        .mockResolvedValue(
+          authUser ?? { data: { user: { id: "user-123" } }, error: null },
+        ),
+    },
+  };
+  return client as unknown as SupabaseClient<Database>;
+}
+
+// ---------------------------------------------------------------------------
+// Sample fixtures
+// ---------------------------------------------------------------------------
+
+const sampleTemporalData = {
+  era: "CE",
+  year: 1892,
+  precision: "exact",
+} as const;
+
+const sampleCharacter = {
+  id: "char-1",
+  user_id: "user-123",
+  slug: "sherlock-holmes",
+  name: "Sherlock Holmes",
+  character_type: "fictional",
+  biography: "Consulting detective",
+  aliases: ["The Great Detective"],
+  cultural_context: null,
+  physical_description: null,
+  species: null,
+  breed: null,
+  domain: null,
+  significance: "high",
+  birth_temporal: sampleTemporalData,
+  death_temporal: null,
+  profile_data: null,
+  metadata: null,
+  published: false,
+  published_at: null,
+  search_vector: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const sampleCharacterWithRelations = {
+  ...sampleCharacter,
+  character_media: [],
+  character_relationships: [],
+};
+
+const sampleMedia = {
+  character_id: "char-1",
+  media_id: "media-1",
+  is_primary: false,
+};
+
+// ---------------------------------------------------------------------------
+// getCharacters
+// ---------------------------------------------------------------------------
+
+describe("getCharacters", () => {
+  it("returns an array of characters", async () => {
+    const client = makeClient({
+      fromResult: { data: [sampleCharacter], error: null },
+    });
+    const result = await getCharacters(client);
+    expect(result).toEqual([sampleCharacter]);
+  });
+
+  it("returns empty array when data is null", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    const result = await getCharacters(client);
+    expect(result).toEqual([]);
+  });
+
+  it("applies characterType filter", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { characterType: "fictional" });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("character_type", "fictional");
+  });
+
+  it("applies userId filter", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { userId: "user-abc" });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("user_id", "user-abc");
+  });
+
+  it("applies search filter via full-text search", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { search: "detective" });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.textSearch).toHaveBeenCalledWith(
+      "search_vector",
+      "detective",
+      { type: "websearch" },
+    );
+  });
+
+  it("does not apply search filter when search is empty string", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { search: "" });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.textSearch).not.toHaveBeenCalled();
+  });
+
+  it("clamps page=0 to page=1", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { page: 0, pageSize: 10 });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.range).toHaveBeenCalledWith(0, 9);
+  });
+
+  it("clamps pageSize=0 to pageSize=1", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { page: 1, pageSize: 0 });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.range).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("clamps pageSize>100 to 100", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { page: 1, pageSize: 999 });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.range).toHaveBeenCalledWith(0, 99);
+  });
+
+  it("orders results by name ascending", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.order).toHaveBeenCalledWith("name", { ascending: true });
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "query failed" } },
+    });
+    await expect(getCharacters(client)).rejects.toThrow(
+      "CharacterService.getCharacters: query failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCharacterById
+// ---------------------------------------------------------------------------
+
+describe("getCharacterById", () => {
+  it("returns a character with relations", async () => {
+    const client = makeClient({
+      fromResult: { data: sampleCharacterWithRelations, error: null },
+    });
+    const result = await getCharacterById(client, "char-1");
+    expect(result).toEqual(sampleCharacterWithRelations);
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "not found" } },
+    });
+    await expect(getCharacterById(client, "char-1")).rejects.toThrow(
+      "CharacterService.getCharacterById: not found",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCharacterBySlug
+// ---------------------------------------------------------------------------
+
+describe("getCharacterBySlug", () => {
+  it("filters by user_id and slug", async () => {
+    const client = makeClient({
+      fromResult: { data: sampleCharacterWithRelations, error: null },
+    });
+    await getCharacterBySlug(client, "user-123", "sherlock-holmes");
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("user_id", "user-123");
+    expect(builder.eq).toHaveBeenCalledWith("slug", "sherlock-holmes");
+  });
+
+  it("returns character with relations on success", async () => {
+    const client = makeClient({
+      fromResult: { data: sampleCharacterWithRelations, error: null },
+    });
+    const result = await getCharacterBySlug(
+      client,
+      "user-123",
+      "sherlock-holmes",
+    );
+    expect(result).toEqual(sampleCharacterWithRelations);
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "not found" } },
+    });
+    await expect(
+      getCharacterBySlug(client, "user-123", "sherlock-holmes"),
+    ).rejects.toThrow("CharacterService.getCharacterBySlug: not found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCharacter — helpers
+// ---------------------------------------------------------------------------
+
+function makeCreateClient(insertResult: { data: unknown; error: unknown }) {
+  let callCount = 0;
+  return {
+    from: vi.fn().mockImplementation(() => {
+      callCount++;
+      // First call: fetch existing slugs — returns empty array via .then
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          then: (resolve: (v: unknown) => unknown) =>
+            Promise.resolve({ data: [], error: null }).then(resolve),
+        };
+      }
+      // Second call: insert — returns the provided result
+      return makeBuilder(insertResult);
+    }),
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      }),
+    },
+    rpc: vi.fn(),
+  } as unknown as SupabaseClient<Database>;
+}
+
+// ---------------------------------------------------------------------------
+// createCharacter — one test per character type
+// ---------------------------------------------------------------------------
+
+describe("createCharacter", () => {
+  it("creates a human character with valid profile_data", async () => {
+    const client = makeCreateClient({ data: sampleCharacter, error: null });
+    const result = await createCharacter(client, {
+      name: "Sherlock Holmes",
+      character_type: "human",
+      profile_data: {
+        character_type: "human",
+        nationality: "British",
+        occupation: "Detective",
+      },
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("creates an animal character with valid profile_data", async () => {
+    const client = makeCreateClient({ data: sampleCharacter, error: null });
+    const result = await createCharacter(client, {
+      name: "Lassie",
+      character_type: "animal",
+      species: "Canis lupus familiaris",
+      profile_data: {
+        character_type: "animal",
+        conservation_status: "least_concern",
+      },
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("creates a mythological character with valid profile_data", async () => {
+    const client = makeCreateClient({ data: sampleCharacter, error: null });
+    const result = await createCharacter(client, {
+      name: "Heracles",
+      character_type: "mythological",
+      profile_data: {
+        character_type: "mythological",
+        mythology: "Greek",
+        powers: ["superhuman strength", "immortality"],
+      },
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("creates a fictional character with valid profile_data", async () => {
+    const client = makeCreateClient({ data: sampleCharacter, error: null });
+    const result = await createCharacter(client, {
+      name: "Sherlock Holmes",
+      character_type: "fictional",
+      profile_data: {
+        character_type: "fictional",
+        source_work: "A Study in Scarlet",
+        author: "Arthur Conan Doyle",
+        genre: "Mystery",
+      },
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("creates an organization character with valid profile_data", async () => {
+    const client = makeCreateClient({ data: sampleCharacter, error: null });
+    const result = await createCharacter(client, {
+      name: "United Nations",
+      character_type: "organization",
+      profile_data: {
+        character_type: "organization",
+        org_type: "Intergovernmental",
+        headquarters: "New York City, USA",
+      },
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("creates a divine character with valid profile_data", async () => {
+    const client = makeCreateClient({ data: sampleCharacter, error: null });
+    const result = await createCharacter(client, {
+      name: "Zeus",
+      character_type: "divine",
+      domain: "Sky and thunder",
+      profile_data: {
+        character_type: "divine",
+        pantheon: "Greek",
+        worship_period: "800 BCE - 400 CE",
+      },
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("creates an artifact character with valid profile_data", async () => {
+    const client = makeCreateClient({ data: sampleCharacter, error: null });
+    const result = await createCharacter(client, {
+      name: "Excalibur",
+      character_type: "artifact",
+      profile_data: {
+        character_type: "artifact",
+        artifact_type: "Sword",
+        material: "Steel",
+        current_location: "Lake",
+      },
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("creates a character without profile_data", async () => {
+    const client = makeCreateClient({ data: sampleCharacter, error: null });
+    const result = await createCharacter(client, {
+      name: "Mystery Figure",
+      character_type: "human",
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("throws when no authenticated user", async () => {
+    const client = makeClient({
+      authUser: { data: { user: null }, error: null },
+    });
+    await expect(
+      createCharacter(client, { name: "Test", character_type: "human" }),
+    ).rejects.toThrow(
+      "CharacterService.createCharacter: no authenticated user",
+    );
+  });
+
+  it("throws when auth.getUser returns an error", async () => {
+    const client = makeClient({
+      authUser: { data: { user: null }, error: { message: "auth fail" } },
+    });
+    await expect(
+      createCharacter(client, { name: "Test", character_type: "human" }),
+    ).rejects.toThrow(
+      "CharacterService.createCharacter(auth.getUser): auth fail",
+    );
+  });
+
+  it("throws when profile_data fails type-specific validation", async () => {
+    const client = makeCreateClient({ data: null, error: null });
+    await expect(
+      createCharacter(client, {
+        name: "Lassie",
+        character_type: "animal",
+        profile_data: {
+          character_type: "animal",
+          conservation_status: "not-a-real-status",
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("uses explicit slug when provided", async () => {
+    const client = makeCreateClient({ data: sampleCharacter, error: null });
+    const result = await createCharacter(client, {
+      name: "Sherlock Holmes",
+      character_type: "fictional",
+      slug: "custom-slug",
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("retries on 23505 unique violation and succeeds", async () => {
+    let callCount = 0;
+    const client = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "characters") {
+          callCount++;
+          // First call: fetch existing slugs
+          if (callCount === 1) {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              then: (resolve: (v: unknown) => unknown) =>
+                Promise.resolve({ data: [], error: null }).then(resolve),
+            };
+          }
+          // Second call: 23505 collision
+          if (callCount === 2) {
+            return makeBuilder({
+              data: null,
+              error: { code: "23505", message: "unique violation" },
+            });
+          }
+          // Third call: success
+          return makeBuilder({ data: sampleCharacter, error: null });
+        }
+        return makeBuilder({ data: null, error: null });
+      }),
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-123" } },
+          error: null,
+        }),
+      },
+      rpc: vi.fn(),
+    } as unknown as SupabaseClient<Database>;
+
+    const result = await createCharacter(client, {
+      name: "Sherlock Holmes",
+      character_type: "fictional",
+    });
+    expect(result).toEqual(sampleCharacter);
+  });
+
+  it("throws after exhausting slug retries", async () => {
+    let callCount = 0;
+    const client = {
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "characters") {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              then: (resolve: (v: unknown) => unknown) =>
+                Promise.resolve({ data: [], error: null }).then(resolve),
+            };
+          }
+          // All insert attempts fail with 23505
+          return makeBuilder({
+            data: null,
+            error: { code: "23505", message: "unique violation" },
+          });
+        }
+        return makeBuilder({ data: null, error: null });
+      }),
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-123" } },
+          error: null,
+        }),
+      },
+      rpc: vi.fn(),
+    } as unknown as SupabaseClient<Database>;
+
+    await expect(
+      createCharacter(client, { name: "Test", character_type: "human" }),
+    ).rejects.toThrow("unique violation");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCharacter
+// ---------------------------------------------------------------------------
+
+describe("updateCharacter", () => {
+  it("returns updated character row", async () => {
+    const updated = { ...sampleCharacter, name: "Dr. John Watson" };
+    const client = makeClient({ fromResult: { data: updated, error: null } });
+    const result = await updateCharacter(client, "char-1", {
+      name: "Dr. John Watson",
+    });
+    expect(result).toEqual(updated);
+  });
+
+  it("validates profile_data against character_type when both are present", async () => {
+    const client = makeClient({
+      fromResult: { data: sampleCharacter, error: null },
+    });
+    // Invalid profile_data — conservation_status value is not a valid enum member
+    await expect(
+      updateCharacter(client, "char-1", {
+        character_type: "animal",
+        profile_data: {
+          character_type: "animal",
+          conservation_status: "extinct-soon",
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("skips profile validation when character_type is absent", async () => {
+    const updated = { ...sampleCharacter, biography: "Updated bio" };
+    const client = makeClient({ fromResult: { data: updated, error: null } });
+    // profile_data present but no character_type — no type-profile validation
+    const result = await updateCharacter(client, "char-1", {
+      biography: "Updated bio",
+      profile_data: { anything: "goes" },
+    });
+    expect(result).toEqual(updated);
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "update failed" } },
+    });
+    await expect(
+      updateCharacter(client, "char-1", { name: "x" }),
+    ).rejects.toThrow("CharacterService.updateCharacter: update failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteCharacter
+// ---------------------------------------------------------------------------
+
+describe("deleteCharacter", () => {
+  it("resolves without error on success", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    await expect(deleteCharacter(client, "char-1")).resolves.toBeUndefined();
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "delete failed" } },
+    });
+    await expect(deleteCharacter(client, "char-1")).rejects.toThrow(
+      "CharacterService.deleteCharacter: delete failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCharacterTimeline
+// ---------------------------------------------------------------------------
+
+describe("getCharacterTimeline", () => {
+  const sampleTimelineRow = {
+    character_id: "char-1",
+    character_name: "Sherlock Holmes",
+    event_id: "evt-1",
+    event_title: "The Final Problem",
+    role: "protagonist",
+    significance: "primary",
+    sort_order_years: 1891,
+    temporal_data: { era: "CE", year: 1891, precision: "exact" },
+    timeline_title: "Victorian Era",
+  };
+
+  it("returns timeline view rows for a character", async () => {
+    const client = makeClient({
+      fromResult: { data: [sampleTimelineRow], error: null },
+    });
+    const result = await getCharacterTimeline(client, "char-1");
+    expect(result).toEqual([sampleTimelineRow]);
+  });
+
+  it("returns empty array when data is null", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    const result = await getCharacterTimeline(client, "char-1");
+    expect(result).toEqual([]);
+  });
+
+  it("filters by character_id", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacterTimeline(client, "char-1");
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("character_id", "char-1");
+  });
+
+  it("orders by sort_order_years ascending", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacterTimeline(client, "char-1");
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.order).toHaveBeenCalledWith("sort_order_years", {
+      ascending: true,
+    });
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "view error" } },
+    });
+    await expect(getCharacterTimeline(client, "char-1")).rejects.toThrow(
+      "CharacterService.getCharacterTimeline: view error",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCharacterNetwork
+// ---------------------------------------------------------------------------
+
+describe("getCharacterNetwork", () => {
+  const sampleNetworkRow = {
+    depth: 1,
+    rel_type: "ally",
+    source_id: "char-1",
+    source_name: "Sherlock Holmes",
+    target_id: "char-2",
+    target_name: "Dr. Watson",
+  };
+
+  it("calls the character_network RPC with character ID", async () => {
+    const client = makeClient({
+      rpcResult: { data: [sampleNetworkRow], error: null },
+    });
+    const result = await getCharacterNetwork(client, "char-1");
+    expect(result).toEqual([sampleNetworkRow]);
+    expect(client.rpc).toHaveBeenCalledWith("character_network", {
+      p_character_id: "char-1",
+    });
+  });
+
+  it("passes depth when provided", async () => {
+    const client = makeClient({
+      rpcResult: { data: [], error: null },
+    });
+    await getCharacterNetwork(client, "char-1", 3);
+    expect(client.rpc).toHaveBeenCalledWith("character_network", {
+      p_character_id: "char-1",
+      p_depth: 3,
+    });
+  });
+
+  it("does not pass p_depth when depth is undefined", async () => {
+    const client = makeClient({ rpcResult: { data: [], error: null } });
+    await getCharacterNetwork(client, "char-1");
+    expect(client.rpc).toHaveBeenCalledWith("character_network", {
+      p_character_id: "char-1",
+    });
+  });
+
+  it("returns empty array when data is null", async () => {
+    const client = makeClient({ rpcResult: { data: null, error: null } });
+    const result = await getCharacterNetwork(client, "char-1");
+    expect(result).toEqual([]);
+  });
+
+  it("throws on RPC error", async () => {
+    const client = makeClient({
+      rpcResult: { data: null, error: { message: "rpc failed" } },
+    });
+    await expect(getCharacterNetwork(client, "char-1")).rejects.toThrow(
+      "CharacterService.getCharacterNetwork: rpc failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCharacterEvents
+// ---------------------------------------------------------------------------
+
+describe("getCharacterEvents", () => {
+  const sampleEventCharacter = {
+    character_id: "char-1",
+    event_id: "evt-1",
+    role: "protagonist",
+    significance: "primary",
+    description: null,
+  };
+
+  it("returns event_characters rows for a character", async () => {
+    const client = makeClient({
+      fromResult: { data: [sampleEventCharacter], error: null },
+    });
+    const result = await getCharacterEvents(client, "char-1");
+    expect(result).toEqual([sampleEventCharacter]);
+  });
+
+  it("returns empty array when data is null", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    const result = await getCharacterEvents(client, "char-1");
+    expect(result).toEqual([]);
+  });
+
+  it("filters by character_id", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacterEvents(client, "char-1");
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("character_id", "char-1");
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "query failed" } },
+    });
+    await expect(getCharacterEvents(client, "char-1")).rejects.toThrow(
+      "CharacterService.getCharacterEvents: query failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addMediaToCharacter
+// ---------------------------------------------------------------------------
+
+describe("addMediaToCharacter", () => {
+  it("inserts and returns the junction row", async () => {
+    const client = makeClient({
+      fromResult: { data: sampleMedia, error: null },
+    });
+    const result = await addMediaToCharacter(client, "char-1", "media-1");
+    expect(result).toEqual(sampleMedia);
+  });
+
+  it("passes is_primary=true when specified", async () => {
+    const primaryMedia = { ...sampleMedia, is_primary: true };
+    const client = makeClient({
+      fromResult: { data: primaryMedia, error: null },
+    });
+    const result = await addMediaToCharacter(client, "char-1", "media-1", true);
+    expect(result).toEqual(primaryMedia);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.insert).toHaveBeenCalledWith({
+      character_id: "char-1",
+      media_id: "media-1",
+      is_primary: true,
+    });
+  });
+
+  it("defaults is_primary to false", async () => {
+    const client = makeClient({
+      fromResult: { data: sampleMedia, error: null },
+    });
+    await addMediaToCharacter(client, "char-1", "media-1");
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.insert).toHaveBeenCalledWith({
+      character_id: "char-1",
+      media_id: "media-1",
+      is_primary: false,
+    });
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "insert failed" } },
+    });
+    await expect(
+      addMediaToCharacter(client, "char-1", "media-1"),
+    ).rejects.toThrow("CharacterService.addMediaToCharacter: insert failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeMediaFromCharacter
+// ---------------------------------------------------------------------------
+
+describe("removeMediaFromCharacter", () => {
+  it("resolves without error on success", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    await expect(
+      removeMediaFromCharacter(client, "char-1", "media-1"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("filters by character_id and media_id", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    await removeMediaFromCharacter(client, "char-1", "media-1");
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("character_id", "char-1");
+    expect(builder.eq).toHaveBeenCalledWith("media_id", "media-1");
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "delete failed" } },
+    });
+    await expect(
+      removeMediaFromCharacter(client, "char-1", "media-1"),
+    ).rejects.toThrow(
+      "CharacterService.removeMediaFromCharacter: delete failed",
+    );
+  });
+});

--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -177,11 +177,15 @@ export async function createCharacter(
     throw new Error("CharacterService.createCharacter: no authenticated user");
   }
 
-  // Validate type-specific profile_data fields if provided
+  // Validate type-specific profile_data fields if provided.
+  // Spread profile_data first, then override character_type with the
+  // top-level value so a caller cannot smuggle in a different type via
+  // profile_data (e.g. { character_type: "animal", ... } inside profile_data
+  // would otherwise shadow the intended type after the spread).
   if (data.profile_data !== undefined) {
     characterTypeProfileSchema.parse({
-      character_type: data.character_type,
       ...data.profile_data,
+      character_type: data.character_type,
     });
   }
 
@@ -252,12 +256,18 @@ export async function updateCharacter(
   id: string,
   data: Partial<CharacterInput>,
 ): Promise<CharacterRow> {
-  // Validate type-specific profile_data if both character_type and profile_data
-  // are present in the partial update
+  // Validate type-specific profile_data when character_type is included in the
+  // patch. Spread profile_data first, then set character_type authoritatively so
+  // the caller cannot override the type via profile_data keys.
+  //
+  // DECISION NEEDED: when only profile_data is updated (character_type omitted),
+  // validation is skipped because we don't know the persisted type without an
+  // extra DB round-trip. Until a fetch-then-validate strategy is adopted, callers
+  // MUST include character_type whenever they patch profile_data.
   if (data.profile_data !== undefined && data.character_type !== undefined) {
     characterTypeProfileSchema.parse({
-      character_type: data.character_type,
       ...data.profile_data,
+      character_type: data.character_type,
     });
   }
 
@@ -311,19 +321,29 @@ export async function getCharacterTimeline(
   return data ?? [];
 }
 
+/** Maximum depth allowed for `getCharacterNetwork` to prevent runaway
+ * recursive CTEs. Matches the practical display limit in the UI. */
+const MAX_NETWORK_DEPTH = 5;
+
 /**
  * Returns the relationship graph centred on a character using the
  * `character_network` database function. Each row represents a directed edge
- * in the graph. `depth` controls how many hops to traverse (default: 1).
+ * in the graph. `depth` controls how many hops to traverse; the database
+ * function defaults to 2 when omitted. Clamped to [1, MAX_NETWORK_DEPTH].
  */
 export async function getCharacterNetwork(
   client: SupabaseClient<Database>,
   characterId: string,
   depth?: number,
 ): Promise<CharacterNetworkRow[]> {
+  const safeDepth =
+    depth !== undefined
+      ? Math.min(MAX_NETWORK_DEPTH, Math.max(1, Math.floor(depth)))
+      : undefined;
+
   const { data, error } = await client.rpc("character_network", {
     p_character_id: characterId,
-    ...(depth !== undefined ? { p_depth: depth } : {}),
+    ...(safeDepth !== undefined ? { p_depth: safeDepth } : {}),
   });
 
   assertNoError(error, "getCharacterNetwork");

--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -1,0 +1,395 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { z } from "zod";
+import {
+  characterSchema,
+  characterTypeEnum,
+  characterTypeProfileSchema,
+} from "../schemas/character.js";
+import type {
+  CharacterInput,
+  CreateCharacterInput,
+} from "../schemas/character.js";
+import { generateSlug, resolveCollision } from "../utils/slug.js";
+import { MAX_SLUG_LENGTH } from "../schemas/slug.js";
+import type { Database } from "../supabase/types.js";
+
+// ---------------------------------------------------------------------------
+// Type aliases
+// ---------------------------------------------------------------------------
+
+type CharacterRow = Database["public"]["Tables"]["characters"]["Row"];
+
+type CharacterMediaRow = Database["public"]["Tables"]["character_media"]["Row"];
+
+type CharacterRelationshipRow =
+  Database["public"]["Tables"]["character_relationships"]["Row"];
+
+type CharacterTimelineViewRow =
+  Database["public"]["Views"]["character_timeline_view"]["Row"];
+
+type CharacterNetworkRow =
+  Database["public"]["Functions"]["character_network"]["Returns"][number];
+
+// ---------------------------------------------------------------------------
+// Exported interfaces
+// ---------------------------------------------------------------------------
+
+/** Optional filters accepted by getCharacters */
+export interface CharacterFilters {
+  characterType?: z.infer<typeof characterTypeEnum>;
+  userId?: string;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+/** A character row with its related junction rows eagerly loaded */
+export interface CharacterWithRelations extends CharacterRow {
+  character_media: CharacterMediaRow[];
+  character_relationships: CharacterRelationshipRow[];
+}
+
+export type { CreateCharacterInput };
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Throws a descriptive error when a Supabase call returns an error object.
+ * All service functions call this after every query to surface DB errors.
+ */
+function assertNoError(
+  error: { message: string } | null,
+  context: string,
+): asserts error is null {
+  if (error !== null) {
+    throw new Error(`CharacterService.${context}: ${error.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a page of characters, optionally filtered by character type,
+ * owner, or full-text search using the `search_vector` GIN index.
+ *
+ * `page` is clamped to ≥ 1; `pageSize` is clamped to [1, 100].
+ */
+export async function getCharacters(
+  client: SupabaseClient<Database>,
+  filters: CharacterFilters = {},
+): Promise<CharacterRow[]> {
+  const { characterType, userId, search } = filters;
+  const safePage = Math.max(1, Math.floor(filters.page ?? 1));
+  const safePageSize = Math.min(
+    100,
+    Math.max(1, Math.floor(filters.pageSize ?? 20)),
+  );
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+
+  let query = client.from("characters").select("*");
+
+  if (characterType !== undefined) {
+    query = query.eq("character_type", characterType);
+  }
+  if (userId !== undefined) {
+    query = query.eq("user_id", userId);
+  }
+  if (search !== undefined && search.length > 0) {
+    // Use PostgREST full-text search to leverage the GIN index on search_vector
+    query = query.textSearch("search_vector", search, { type: "websearch" });
+  }
+
+  query = query.range(from, to).order("name", { ascending: true });
+
+  const { data, error } = await query;
+  assertNoError(error, "getCharacters");
+  return data ?? [];
+}
+
+/**
+ * Fetches a single character by UUID, including media and relationships.
+ */
+export async function getCharacterById(
+  client: SupabaseClient<Database>,
+  id: string,
+): Promise<CharacterWithRelations> {
+  const { data, error } = await client
+    .from("characters")
+    .select(
+      "*, character_media(*), character_relationships!character_relationships_character_id_fkey(*)",
+    )
+    .eq("id", id)
+    .single();
+
+  assertNoError(error, "getCharacterById");
+  return data as unknown as CharacterWithRelations;
+}
+
+/**
+ * Fetches a single character by (userId, slug), including media and
+ * relationships.
+ *
+ * Both `userId` and `slug` are required because the DB uniqueness constraint
+ * is `UNIQUE (user_id, slug)` — slug alone is not globally unique.
+ */
+export async function getCharacterBySlug(
+  client: SupabaseClient<Database>,
+  userId: string,
+  slug: string,
+): Promise<CharacterWithRelations> {
+  const { data, error } = await client
+    .from("characters")
+    .select(
+      "*, character_media(*), character_relationships!character_relationships_character_id_fkey(*)",
+    )
+    .eq("user_id", userId)
+    .eq("slug", slug)
+    .single();
+
+  assertNoError(error, "getCharacterBySlug");
+  return data as unknown as CharacterWithRelations;
+}
+
+/**
+ * Creates a new character. The slug is auto-generated from the name; callers
+ * may supply an explicit slug which is used as the base (but is still subject
+ * to collision resolution against existing user slugs).
+ *
+ * Validates the payload with both `characterSchema` (top-level fields) and the
+ * per-type `characterTypeProfileSchema` (profile_data fields) before inserting.
+ */
+export async function createCharacter(
+  client: SupabaseClient<Database>,
+  data: CreateCharacterInput,
+): Promise<CharacterRow> {
+  // Identify the current user so we can scope slug collision checks
+  const {
+    data: { user },
+    error: authError,
+  } = await client.auth.getUser();
+  assertNoError(authError, "createCharacter(auth.getUser)");
+  if (user === null) {
+    throw new Error("CharacterService.createCharacter: no authenticated user");
+  }
+
+  // Validate type-specific profile_data fields if provided
+  if (data.profile_data !== undefined) {
+    characterTypeProfileSchema.parse({
+      character_type: data.character_type,
+      ...data.profile_data,
+    });
+  }
+
+  // Fetch existing slugs for this user to resolve collisions
+  const { data: existing, error: slugError } = await client
+    .from("characters")
+    .select("slug")
+    .eq("user_id", user.id);
+  assertNoError(slugError, "createCharacter(fetchSlugs)");
+
+  const existingSlugs = new Set((existing ?? []).map((r) => r.slug));
+  const baseSlug =
+    data.slug !== undefined && data.slug.length > 0
+      ? data.slug
+      : generateSlug(data.name);
+  const slug = resolveCollision(baseSlug, existingSlugs);
+
+  type CharacterInsert = Database["public"]["Tables"]["characters"]["Insert"];
+
+  // Retry up to 3 times on unique-violation (23505) — guards against the race
+  // where two concurrent createCharacter calls compute the same available slug
+  // and one wins the DB insert.
+  const MAX_SLUG_RETRIES = 3;
+  let attemptSlug = slug;
+
+  for (let attempt = 0; attempt < MAX_SLUG_RETRIES; attempt++) {
+    const attemptValidated = characterSchema.parse({
+      ...data,
+      slug: attemptSlug,
+    });
+
+    const { data: row, error: insertError } = await client
+      .from("characters")
+      .insert({
+        ...(attemptValidated as unknown as CharacterInsert),
+        user_id: user.id,
+      })
+      .select()
+      .single();
+
+    if (insertError !== null) {
+      if (insertError.code === "23505" && attempt < MAX_SLUG_RETRIES - 1) {
+        // Collision — append a random 4-char base-36 suffix and retry.
+        const suffix = Math.random().toString(36).slice(2, 6);
+        const truncated = slug.slice(0, MAX_SLUG_LENGTH - 5).replace(/-+$/, "");
+        attemptSlug = `${truncated}-${suffix}`;
+        continue;
+      }
+      // Non-collision error or exhausted retries — throw
+      assertNoError(insertError, "createCharacter");
+    }
+
+    return row as CharacterRow;
+  }
+
+  // Unreachable: loop always returns or assertNoError throws
+  throw new Error("CharacterService.createCharacter: unreachable");
+}
+
+/**
+ * Applies a partial update to a character. Only supplied fields are mutated.
+ * Validates the partial payload with Zod before patching. When profile_data is
+ * supplied alongside character_type, the type-specific profile schema is also
+ * validated.
+ */
+export async function updateCharacter(
+  client: SupabaseClient<Database>,
+  id: string,
+  data: Partial<CharacterInput>,
+): Promise<CharacterRow> {
+  // Validate type-specific profile_data if both character_type and profile_data
+  // are present in the partial update
+  if (data.profile_data !== undefined && data.character_type !== undefined) {
+    characterTypeProfileSchema.parse({
+      character_type: data.character_type,
+      ...data.profile_data,
+    });
+  }
+
+  const validated = characterSchema.partial().parse(data);
+
+  type CharacterUpdate = Database["public"]["Tables"]["characters"]["Update"];
+  const { data: row, error } = await client
+    .from("characters")
+    .update(validated as unknown as CharacterUpdate)
+    .eq("id", id)
+    .select()
+    .single();
+
+  assertNoError(error, "updateCharacter");
+  return row as CharacterRow;
+}
+
+/**
+ * Permanently deletes a character. The DB FK constraints ensure that
+ * `character_media` and `character_relationships` junction rows are removed
+ * via `ON DELETE CASCADE` on their `character_id` FK.
+ */
+export async function deleteCharacter(
+  client: SupabaseClient<Database>,
+  id: string,
+): Promise<void> {
+  const { error } = await client.from("characters").delete().eq("id", id);
+  assertNoError(error, "deleteCharacter");
+}
+
+// ---------------------------------------------------------------------------
+// View queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns all events a character participated in, sourced from the
+ * `character_timeline_view` database view. Results are ordered by
+ * `sort_order_years` ascending (chronological order).
+ */
+export async function getCharacterTimeline(
+  client: SupabaseClient<Database>,
+  characterId: string,
+): Promise<CharacterTimelineViewRow[]> {
+  const { data, error } = await client
+    .from("character_timeline_view")
+    .select("*")
+    .eq("character_id", characterId)
+    .order("sort_order_years", { ascending: true });
+
+  assertNoError(error, "getCharacterTimeline");
+  return data ?? [];
+}
+
+/**
+ * Returns the relationship graph centred on a character using the
+ * `character_network` database function. Each row represents a directed edge
+ * in the graph. `depth` controls how many hops to traverse (default: 1).
+ */
+export async function getCharacterNetwork(
+  client: SupabaseClient<Database>,
+  characterId: string,
+  depth?: number,
+): Promise<CharacterNetworkRow[]> {
+  const { data, error } = await client.rpc("character_network", {
+    p_character_id: characterId,
+    ...(depth !== undefined ? { p_depth: depth } : {}),
+  });
+
+  assertNoError(error, "getCharacterNetwork");
+  return data ?? [];
+}
+
+/**
+ * Returns all `event_characters` junction rows for a character. This surfaces
+ * which events the character participated in along with the role and
+ * significance assigned to each participation.
+ */
+export async function getCharacterEvents(
+  client: SupabaseClient<Database>,
+  characterId: string,
+): Promise<Database["public"]["Tables"]["event_characters"]["Row"][]> {
+  const { data, error } = await client
+    .from("event_characters")
+    .select("*")
+    .eq("character_id", characterId);
+
+  assertNoError(error, "getCharacterEvents");
+  return data ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Junction: character_media
+// ---------------------------------------------------------------------------
+
+/**
+ * Links a media item to a character via the `character_media` junction table.
+ * Set `isPrimary` to `true` to mark this as the character's primary/profile
+ * image.
+ */
+export async function addMediaToCharacter(
+  client: SupabaseClient<Database>,
+  characterId: string,
+  mediaId: string,
+  isPrimary = false,
+): Promise<CharacterMediaRow> {
+  const { data, error } = await client
+    .from("character_media")
+    .insert({
+      character_id: characterId,
+      media_id: mediaId,
+      is_primary: isPrimary,
+    })
+    .select()
+    .single();
+
+  assertNoError(error, "addMediaToCharacter");
+  return data;
+}
+
+/**
+ * Removes the link between a media item and a character.
+ */
+export async function removeMediaFromCharacter(
+  client: SupabaseClient<Database>,
+  characterId: string,
+  mediaId: string,
+): Promise<void> {
+  const { error } = await client
+    .from("character_media")
+    .delete()
+    .eq("character_id", characterId)
+    .eq("media_id", mediaId);
+
+  assertNoError(error, "removeMediaFromCharacter");
+}

--- a/packages/services/src/schemas/character.ts
+++ b/packages/services/src/schemas/character.ts
@@ -39,84 +39,99 @@ export type CharacterInput = z.infer<typeof characterSchema>;
 // ---------------------------------------------------------------------------
 
 /**
- * Human: biographical details — nationality, occupation, optional
- * birth/death temporal overrides (in addition to the top-level fields).
+ * Human: biographical details — nationality and occupation.
+ * Birth and death dates are stored in the top-level `birth_temporal` /
+ * `death_temporal` columns and are NOT repeated here.
  */
-export const humanProfileSchema = z.object({
-  character_type: z.literal("human"),
-  nationality: z.string().max(500).optional(),
-  occupation: z.string().max(500).optional(),
-});
+export const humanProfileSchema = z
+  .object({
+    character_type: z.literal("human"),
+    nationality: z.string().max(500).optional(),
+    occupation: z.string().max(500).optional(),
+  })
+  .strict();
 
 /**
  * Animal: species classification and conservation status.
- * `species` and `habitat` are stored on the top-level row, but
+ * `species` and `breed` are stored on the top-level character row;
  * `conservation_status` lives in profile_data.
  */
-export const animalProfileSchema = z.object({
-  character_type: z.literal("animal"),
-  conservation_status: z
-    .enum([
-      "extinct",
-      "extinct_in_wild",
-      "critically_endangered",
-      "endangered",
-      "vulnerable",
-      "near_threatened",
-      "least_concern",
-      "data_deficient",
-      "not_evaluated",
-    ])
-    .optional(),
-});
+export const animalProfileSchema = z
+  .object({
+    character_type: z.literal("animal"),
+    conservation_status: z
+      .enum([
+        "extinct",
+        "extinct_in_wild",
+        "critically_endangered",
+        "endangered",
+        "vulnerable",
+        "near_threatened",
+        "least_concern",
+        "data_deficient",
+        "not_evaluated",
+      ])
+      .optional(),
+  })
+  .strict();
 
 /**
  * Mythological: mythology of origin, domain(s), and supernatural powers.
  */
-export const mythologicalProfileSchema = z.object({
-  character_type: z.literal("mythological"),
-  mythology: z.string().max(500).optional(),
-  powers: z.array(z.string()).optional(),
-});
+export const mythologicalProfileSchema = z
+  .object({
+    character_type: z.literal("mythological"),
+    mythology: z.string().max(500).optional(),
+    powers: z.array(z.string()).optional(),
+  })
+  .strict();
 
 /**
  * Fictional: source work, author, and genre.
  */
-export const fictionalProfileSchema = z.object({
-  character_type: z.literal("fictional"),
-  source_work: z.string().max(1000).optional(),
-  author: z.string().max(500).optional(),
-  genre: z.string().max(500).optional(),
-});
+export const fictionalProfileSchema = z
+  .object({
+    character_type: z.literal("fictional"),
+    source_work: z.string().max(1000).optional(),
+    author: z.string().max(500).optional(),
+    genre: z.string().max(500).optional(),
+  })
+  .strict();
 
 /**
  * Organization: organisation type and headquarters location.
  */
-export const organizationProfileSchema = z.object({
-  character_type: z.literal("organization"),
-  org_type: z.string().max(500).optional(),
-  headquarters: z.string().max(500).optional(),
-});
+export const organizationProfileSchema = z
+  .object({
+    character_type: z.literal("organization"),
+    org_type: z.string().max(500).optional(),
+    headquarters: z.string().max(500).optional(),
+  })
+  .strict();
 
 /**
  * Divine: pantheon, domain (shared top-level field), and worship period.
  */
-export const divineProfileSchema = z.object({
-  character_type: z.literal("divine"),
-  pantheon: z.string().max(500).optional(),
-  worship_period: z.string().max(500).optional(),
-});
+export const divineProfileSchema = z
+  .object({
+    character_type: z.literal("divine"),
+    pantheon: z.string().max(500).optional(),
+    worship_period: z.string().max(500).optional(),
+  })
+  .strict();
 
 /**
  * Artifact: physical type of object, material composition, and current
  * physical location.
  */
-export const artifactProfileSchema = z.object({
-  character_type: z.literal("artifact"),
-  artifact_type: z.string().max(500).optional(),
-  material: z.string().max(500).optional(),
-  current_location: z.string().max(1000).optional(),
-});
+export const artifactProfileSchema = z
+  .object({
+    character_type: z.literal("artifact"),
+    artifact_type: z.string().max(500).optional(),
+    material: z.string().max(500).optional(),
+    current_location: z.string().max(1000).optional(),
+  })
+  .strict();
 
 /**
  * Discriminated union that selects the correct profile schema based on

--- a/packages/services/src/schemas/character.ts
+++ b/packages/services/src/schemas/character.ts
@@ -33,3 +33,119 @@ export const characterSchema = z.object({
 });
 
 export type CharacterInput = z.infer<typeof characterSchema>;
+
+// ---------------------------------------------------------------------------
+// Per-type profile_data schemas (strict validation by character_type)
+// ---------------------------------------------------------------------------
+
+/**
+ * Human: biographical details — nationality, occupation, optional
+ * birth/death temporal overrides (in addition to the top-level fields).
+ */
+export const humanProfileSchema = z.object({
+  character_type: z.literal("human"),
+  nationality: z.string().max(500).optional(),
+  occupation: z.string().max(500).optional(),
+});
+
+/**
+ * Animal: species classification and conservation status.
+ * `species` and `habitat` are stored on the top-level row, but
+ * `conservation_status` lives in profile_data.
+ */
+export const animalProfileSchema = z.object({
+  character_type: z.literal("animal"),
+  conservation_status: z
+    .enum([
+      "extinct",
+      "extinct_in_wild",
+      "critically_endangered",
+      "endangered",
+      "vulnerable",
+      "near_threatened",
+      "least_concern",
+      "data_deficient",
+      "not_evaluated",
+    ])
+    .optional(),
+});
+
+/**
+ * Mythological: mythology of origin, domain(s), and supernatural powers.
+ */
+export const mythologicalProfileSchema = z.object({
+  character_type: z.literal("mythological"),
+  mythology: z.string().max(500).optional(),
+  powers: z.array(z.string()).optional(),
+});
+
+/**
+ * Fictional: source work, author, and genre.
+ */
+export const fictionalProfileSchema = z.object({
+  character_type: z.literal("fictional"),
+  source_work: z.string().max(1000).optional(),
+  author: z.string().max(500).optional(),
+  genre: z.string().max(500).optional(),
+});
+
+/**
+ * Organization: organisation type and headquarters location.
+ */
+export const organizationProfileSchema = z.object({
+  character_type: z.literal("organization"),
+  org_type: z.string().max(500).optional(),
+  headquarters: z.string().max(500).optional(),
+});
+
+/**
+ * Divine: pantheon, domain (shared top-level field), and worship period.
+ */
+export const divineProfileSchema = z.object({
+  character_type: z.literal("divine"),
+  pantheon: z.string().max(500).optional(),
+  worship_period: z.string().max(500).optional(),
+});
+
+/**
+ * Artifact: physical type of object, material composition, and current
+ * physical location.
+ */
+export const artifactProfileSchema = z.object({
+  character_type: z.literal("artifact"),
+  artifact_type: z.string().max(500).optional(),
+  material: z.string().max(500).optional(),
+  current_location: z.string().max(1000).optional(),
+});
+
+/**
+ * Discriminated union that selects the correct profile schema based on
+ * `character_type`. Use this to validate `profile_data` alongside the
+ * `character_type` field at create/update time.
+ */
+export const characterTypeProfileSchema = z.discriminatedUnion(
+  "character_type",
+  [
+    humanProfileSchema,
+    animalProfileSchema,
+    mythologicalProfileSchema,
+    fictionalProfileSchema,
+    organizationProfileSchema,
+    divineProfileSchema,
+    artifactProfileSchema,
+  ],
+);
+
+export type CharacterTypeProfile = z.infer<typeof characterTypeProfileSchema>;
+
+/**
+ * Input for createCharacter — slug is derived from name automatically.
+ * Uses the Zod *input* type so that fields with schema defaults (significance)
+ * are optional for callers.
+ */
+export type CreateCharacterInput = Omit<
+  z.input<typeof characterSchema>,
+  "slug"
+> & {
+  slug?: string;
+};

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         "src/modules/temporal-service.ts",
         "src/modules/timeline-service.ts",
         "src/modules/event-service.ts",
+        "src/modules/character-service.ts",
         "src/utils/slug.ts",
       ],
       exclude: ["src/**/*.test.ts"],


### PR DESCRIPTION
## Summary

Closes #30

Implements the Character service module in `packages/services`, following the same patterns established by `event-service` and `timeline-service`.

## Changes

### `packages/services/src/schemas/character.ts`
- Added 7 per-type profile_data Zod schemas (`humanProfileSchema`, `animalProfileSchema`, `mythologicalProfileSchema`, `fictionalProfileSchema`, `organizationProfileSchema`, `divineProfileSchema`, `artifactProfileSchema`)
- Added `characterTypeProfileSchema` discriminated union for strict per-type validation at create/update time
- Added `CreateCharacterInput` type (slug optional, auto-derived from name)

### `packages/services/src/modules/character-service.ts` (new)
11 exported functions:
- **CRUD:** `getCharacters`, `getCharacterById`, `getCharacterBySlug`, `createCharacter`, `updateCharacter`, `deleteCharacter`
- **View queries:** `getCharacterTimeline` (queries `character_timeline_view`), `getCharacterNetwork` (calls `character_network` RPC), `getCharacterEvents`
- **Junction:** `addMediaToCharacter`, `removeMediaFromCharacter`

### `packages/services/src/character-service.ts` (new)
Barrel re-export.

### `packages/services/src/modules/character-service.test.ts` (new)
57 tests covering all functions, including one test per character type for `createCharacter`, slug collision retry logic, and RPC depth parameter handling.

### `packages/services/vitest.config.ts`
Added `character-service.ts` to the coverage include list.

## Validation
- ✅ `pnpm check-types`
- ✅ `pnpm lint`
- ✅ `pnpm build`
- ✅ 357/357 tests — `character-service.ts`: 97.26% stmts / 97.82% branches