### PR TITLE
feat(schema): add sort_order to timeline_events junction

### DIFF
--- a/packages/services/src/modules/timeline-service.test.ts
+++ b/packages/services/src/modules/timeline-service.test.ts
@@ -616,11 +616,26 @@ describe("updateCollaboratorRole", () => {
 // ---------------------------------------------------------------------------
 
 describe("addEventToTimeline", () => {
-  it("returns the new junction row", async () => {
-    const row = { timeline_id: "timeline-1", event_id: "event-1" };
+  it("returns the new junction row with default sort_order=0", async () => {
+    const row = {
+      timeline_id: "timeline-1",
+      event_id: "event-1",
+      sort_order: 0,
+    };
     const client = makeClient({ fromResult: { data: row, error: null } });
     const result = await addEventToTimeline(client, "timeline-1", "event-1");
     expect(result).toEqual(row);
+  });
+
+  it("accepts an explicit sort_order", async () => {
+    const row = {
+      timeline_id: "timeline-1",
+      event_id: "event-1",
+      sort_order: 5,
+    };
+    const client = makeClient({ fromResult: { data: row, error: null } });
+    const result = await addEventToTimeline(client, "timeline-1", "event-1", 5);
+    expect(result.sort_order).toBe(5);
   });
 
   it("throws on Supabase error", async () => {

--- a/packages/services/src/modules/timeline-service.ts
+++ b/packages/services/src/modules/timeline-service.ts
@@ -390,20 +390,24 @@ export async function updateCollaboratorRole(
 
 /**
  * Links an event to a timeline via the `timeline_events` junction table.
- *
- * // DECISION NEEDED: The issue spec mentions a `sortOrder` parameter but the
- * //  `timeline_events` junction table has no `sort_order` column (unlike
- * //  `timeline_media`). This function omits sortOrder until the schema is
- * //  updated or a decision is made to add the column. Tracked in #122.
+ * `sortOrder` defaults to 0; when all rows for a timeline share the default,
+ * consumers should fall back to ordering by the joined `events.sort_order_start`
+ * (chronological order). Set a non-zero value to enforce an editorial ordering
+ * (e.g., for comparative or thematic timelines).
  */
 export async function addEventToTimeline(
   client: SupabaseClient<Database>,
   timelineId: string,
   eventId: string,
+  sortOrder = 0,
 ): Promise<TimelineEventRow> {
   const { data, error } = await client
     .from("timeline_events")
-    .insert({ timeline_id: timelineId, event_id: eventId })
+    .insert({
+      timeline_id: timelineId,
+      event_id: eventId,
+      sort_order: sortOrder,
+    })
     .select()
     .single();
 

--- a/packages/services/src/supabase/types.ts
+++ b/packages/services/src/supabase/types.ts
@@ -1099,14 +1099,17 @@ export type Database = {
       timeline_events: {
         Row: {
           event_id: string;
+          sort_order: number | null;
           timeline_id: string;
         };
         Insert: {
           event_id: string;
+          sort_order?: number | null;
           timeline_id: string;
         };
         Update: {
           event_id?: string;
+          sort_order?: number | null;
           timeline_id?: string;
         };
         Relationships: [

--- a/supabase/migrations/00012_timeline_events_sort_order.sql
+++ b/supabase/migrations/00012_timeline_events_sort_order.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- 00012_timeline_events_sort_order.sql
+--
+-- Adds sort_order INTEGER column to the timeline_events junction table
+-- (issue #122).
+--
+-- The original spec (#28) for the addEventToTimeline service function
+-- defined a sortOrder parameter, but the timeline_events junction table
+-- created in 00002_relationships_junctions.sql omitted the corresponding
+-- column. timeline_media has the equivalent sort_order column already; this
+-- migration brings timeline_events into alignment so editors can give events
+-- a deterministic, override-able display order within a timeline (e.g., for
+-- comparative or thematic timelines that group events non-chronologically).
+--
+-- The default value of 0 is backward-compatible: existing rows receive
+-- sort_order = 0 automatically and callers that omit the sortOrder argument
+-- continue to work. When all sort_order values are equal (i.e., still unset),
+-- the application layer is expected to fall back to ordering by the joined
+-- events.sort_order_start (chronological order).
+-- ============================================================================
+
+ALTER TABLE timeline_events ADD COLUMN sort_order INTEGER DEFAULT 0;

--- a/supabase/tests/database/00012_timeline_events_sort_order_test.sql
+++ b/supabase/tests/database/00012_timeline_events_sort_order_test.sql
@@ -1,0 +1,76 @@
+-- pgTAP tests for 00012_timeline_events_sort_order.sql (issue #122 — add
+-- sort_order to timeline_events junction).
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(5);
+
+-- ============================================================================
+-- Column presence + type
+-- ============================================================================
+
+select has_column(
+  'public', 'timeline_events', 'sort_order',
+  'timeline_events.sort_order column exists'
+);
+
+select col_type_is(
+  'public', 'timeline_events', 'sort_order', 'integer',
+  'timeline_events.sort_order is integer'
+);
+
+-- ============================================================================
+-- Default = 0; nullable (matches the timeline_media.sort_order pattern)
+-- ============================================================================
+
+select col_default_is(
+  'public', 'timeline_events', 'sort_order', '0',
+  'timeline_events.sort_order defaults to 0'
+);
+
+select col_is_null(
+  'public', 'timeline_events', 'sort_order',
+  'timeline_events.sort_order is nullable (mirrors timeline_media)'
+);
+
+-- ============================================================================
+-- Insert without sort_order receives the 0 default (round-trip behaviour)
+-- ============================================================================
+
+select lives_ok(
+  $$
+    do $body$
+    declare
+      v_user_id uuid := '00000000-0000-0000-0000-000000000000';
+      v_timeline_id uuid;
+      v_event_id uuid;
+      v_sort_order integer;
+    begin
+      -- Minimal setup: insert a timeline and an event owned by a synthetic user.
+      insert into public.timelines (user_id, slug, title)
+        values (v_user_id, 'tl-test-122', 'Timeline 00012 test')
+        returning id into v_timeline_id;
+      insert into public.events (user_id, slug, title)
+        values (v_user_id, 'ev-test-122', 'Event 00012 test')
+        returning id into v_event_id;
+
+      insert into public.timeline_events (timeline_id, event_id)
+        values (v_timeline_id, v_event_id);
+
+      select sort_order into v_sort_order
+        from public.timeline_events
+        where timeline_id = v_timeline_id and event_id = v_event_id;
+
+      if v_sort_order is distinct from 0 then
+        raise exception 'expected default sort_order = 0, got %', v_sort_order;
+      end if;
+
+      -- Cleanup is handled by the outer rollback.
+    end
+    $body$;
+  $$,
+  'insert without sort_order receives the 0 default'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/00012_timeline_events_sort_order_test.sql
+++ b/supabase/tests/database/00012_timeline_events_sort_order_test.sql
@@ -46,7 +46,15 @@ select lives_ok(
       v_event_id uuid;
       v_sort_order integer;
     begin
-      -- Minimal setup: insert a timeline and an event owned by a synthetic user.
+      -- Seed a corresponding auth.users row for FK integrity.
+      insert into auth.users (id, instance_id, email, encrypted_password,
+                              email_confirmed_at, created_at, updated_at, aud, role)
+        values (v_user_id,
+                '00000000-0000-0000-0000-000000000000'::uuid,
+                'timeline-events-122@local', '', now(), now(), now(),
+                'authenticated', 'authenticated');
+
+      -- Minimal setup: insert a timeline and an event owned by the synthetic user.
       insert into public.timelines (user_id, slug, title)
         values (v_user_id, 'tl-test-122', 'Timeline 00012 test')
         returning id into v_timeline_id;


### PR DESCRIPTION
Closes #122. Resolves the `// DECISION NEEDED` comment that's been shipping in `timeline-service.ts` since the Timeline service module landed in #121.

## Background

The original spec for `addEventToTimeline` (#28) defined a `sortOrder` parameter, but migration 00002 omitted the corresponding column on the `timeline_events` junction. `timeline_media` already has an equivalent `sort_order` column; this PR brings `timeline_events` into alignment.

## Changes

- **`supabase/migrations/00012_timeline_events_sort_order.sql`** — `ALTER TABLE timeline_events ADD COLUMN sort_order INTEGER DEFAULT 0`. Default is backward-compatible: existing rows get `sort_order = 0` automatically; callers omitting the argument continue to work.
- **`supabase/tests/database/00012_timeline_events_sort_order_test.sql`** — pgTAP test covers column presence, type (`integer`), default value (`0`), nullability (mirrors `timeline_media`), and an insert-without-sortOrder round-trip.
- **`packages/services/src/modules/timeline-service.ts`** — `addEventToTimeline` now accepts an optional `sortOrder` argument (default 0), mirroring `addMediaToTimeline`. The `// DECISION NEEDED` comment is replaced with usage guidance: when all rows for a timeline share the default value, consumers fall back to ordering by the joined `events.sort_order_start` (chronological); non-zero values enforce editorial ordering (comparative / thematic timelines).
- **`packages/services/src/modules/timeline-service.test.ts`** — existing test updated to expect `sort_order: 0`; new test added for explicit `sort_order` argument.
- **`packages/services/src/supabase/types.ts`** — `timeline_events` Row / Insert / Update entries gain `sort_order: number | null` mirroring `timeline_media`.

## Note on types regeneration

Docker wasn't available locally to run `pnpm run db:start` + `pnpm run db:gen:types`, so the `types.ts` change is a manual edit mirroring the `timeline_media` pattern exactly. After the migration lands and someone regenerates types against the new schema, the diff should be empty (or trivial whitespace).

## Validation

- [x] `pnpm run check-types` ✓
- [x] `pnpm run lint` ✓ (zero warnings)
- [x] `pnpm run build` ✓
- [x] `pnpm run test:coverage` ✓ (478 tests pass, 91% coverage; `timeline-service.ts` at 93.58% / 80% / 100% / 93.42%)
- [ ] `pnpm run db:test` — deferred to CI (Docker not available locally)

## Suggested merge gate

Wait for CI to run `db:test` against the new migration; that's the validation this PR depends on most.

Refs: #28, #121, #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)