### PR TITLE
docs(temporal): align geological examples and spec text for #111

### DIFF
--- a/docs/prd/PRD-0001-time-traveler-system.md
+++ b/docs/prd/PRD-0001-time-traveler-system.md
@@ -5371,8 +5371,8 @@ The temporal input component is the most complex and critical UI element, enabli
 **Examples:**
 
 - "March 15, 44 BCE"
-- "66 ± 1 MYA (Cretaceous-Paleogene boundary)"
-- "13.8 BYA (Big Bang)"
+- "Cretaceous-Paleogene boundary (~66 MYA)"
+- "Big Bang (~14 BYA)"
 
 #### 7.3.11 Validation Feedback
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -1227,13 +1227,13 @@ export class TemporalService {
 
 ### 6.2 Display Formats
 
-| Input                                  | Format       | Output                 |
-| -------------------------------------- | ------------ | ---------------------- |
-| year: 2024, month: 8, day: 11, era: CE | standard     | August 11, 2024        |
-| year: 44, month: 3, day: 15, era: BCE  | standard     | March 15, 44 BCE       |
-| year: 66, era: MYA, geol: "K-Pg"       | geological   | 66 MYA (K-Pg boundary) |
-| year: 5, era: BYA, ±500M               | scientific   | ~4.5 ± 0.5 BYA         |
-| year: 14, era: BYA, epoch: "Big Bang"  | cosmological | Big Bang (~13.8 BYA)   |
+| Input                                                    | Format       | Output                    |
+| -------------------------------------------------------- | ------------ | ------------------------- |
+| year: 2024, month: 8, day: 11, era: CE                   | standard     | August 11, 2024           |
+| year: 44, month: 3, day: 15, era: BCE                    | standard     | March 15, 44 BCE          |
+| year: 66, era: MYA, geological_period: "Late Cretaceous" | geological   | Late Cretaceous (~66 MYA) |
+| year: 5, era: BYA, ±500M                                 | scientific   | 5 ± 0.5 BYA               |
+| year: 14, era: BYA, epoch: "Big Bang"                    | cosmological | Big Bang (~14 BYA)        |
 
 ### 6.3 Logarithmic Scale for Visualization
 

--- a/packages/services/src/modules/temporal-service.ts
+++ b/packages/services/src/modules/temporal-service.ts
@@ -181,10 +181,9 @@ export class TemporalService {
   }
 
   /**
-   * Form is "<label> (~<year> <era>)" per the issue #24 body, with the
-   * spec/issue ordering discrepancy tracked in #111. When both fields are
-   * present, prefers `geological_epoch` over `geological_period` since epochs
-   * are more granular in the geologic time hierarchy (era > period > epoch).
+   * Form is "<label> (~<year> <era>)". When both fields are present,
+   * prefers `geological_epoch` over `geological_period` since epochs are
+   * more granular in the geologic time hierarchy (era > period > epoch).
    */
   private static formatGeological(t: TemporalData): string {
     const label = t.geological_epoch ?? t.geological_period;


### PR DESCRIPTION
## Summary
- align geological display examples in system design with canonical formatter output
- update temporal preview examples in PRD for consistency with current service behavior
- remove obsolete discrepancy wording in TemporalService geological formatting comment

## Context
Issue: #111

## Validation
- pre-commit hooks passed (prettier, lint, type checks)
- no runtime behavior changes; documentation/comment alignment only
