### PR TITLE
fix: enforce single-primary on character_media

### DIFF
--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -514,6 +514,19 @@ CREATE UNIQUE INDEX char_rels_unique ON character_relationships
 
 All junction tables use composite primary keys, no surrogate `id`, no `user_id`. RLS is enforced via parent entity ownership checks.
 
+> **Single-primary junction flag pattern:** When a junction table exposes an `is_primary BOOLEAN` flag
+> that must be unique per group (e.g., "one primary media per character"), enforce it with a partial
+> unique index rather than a trigger or application-layer check:
+>
+> ```sql
+> CREATE UNIQUE INDEX <table>_one_primary
+>   ON <table> (<group_column>)
+>   WHERE is_primary = true;
+> ```
+>
+> Applied to `character_media` via migration `00012` (issue #125). If `event_media` or `timeline_media`
+> later grow a primary flag, apply the same pattern.
+
 > **Self-referential FK cycles:** `parent_event_id`, `parent_period_id`, and `parent_category_id` are unconstrained at the database level — cycles (A → B → A) are accepted by PostgreSQL. Cycle prevention is enforced in the service layer during create/update operations (#29, #31, #59, #60); the database intentionally does not attempt to detect cycles via constraints.
 
 ```sql
@@ -593,6 +606,12 @@ CREATE TABLE character_media (
   PRIMARY KEY (character_id, media_id)
 );
 
+-- Single-primary enforcement: at most one row per character_id may have is_primary = true.
+-- Applied via migration 00012 (issue #125).
+CREATE UNIQUE INDEX IF NOT EXISTS character_media_one_primary
+  ON public.character_media (character_id)
+  WHERE is_primary = true;
+
 -- Timelines ↔ Collaborators
 CREATE TABLE timeline_collaborators (
   timeline_id UUID REFERENCES timelines(id) ON DELETE CASCADE,
@@ -611,7 +630,7 @@ CREATE TABLE timeline_collaborators (
 > - `ON DELETE CASCADE` on all FKs.
 > - Added `event_media.sort_order` for controlling display order.
 > - Added `story_events` (stories linked directly to events, not just via periods).
-> - Added `character_media` for character profile images.
+> - Added `character_media` for character profile images; `is_primary` is enforced single-per-character via a partial unique index (`character_media_one_primary`, migration `00012`).
 > - Added `timeline_collaborators` for shared timeline access.
 > - Added `timeline_media` for timeline cover images and header media (per PRD Section 4.8.5).
 

--- a/supabase/migrations/00013_character_media_single_primary.sql
+++ b/supabase/migrations/00013_character_media_single_primary.sql
@@ -1,0 +1,33 @@
+-- Migration: 00012_character_media_single_primary.sql
+-- Issue: #125 — enforce single-primary on character_media via partial unique index
+--
+-- The character_media junction table has no created_at column. Cleanup tiebreaker
+-- is media_id ASC (UUID lexicographic order) — the lowest media_id survives as
+-- the primary for each character_id group with duplicate is_primary = true rows.
+
+-- Step 1: Clean up any existing rows where multiple is_primary = true per character_id.
+--         Retain the row with the lowest media_id per character_id group;
+--         set all others to false.
+WITH ranked AS (
+  SELECT
+    character_id,
+    media_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY character_id
+      ORDER BY media_id ASC
+    ) AS rn
+  FROM public.character_media
+  WHERE is_primary = true
+)
+UPDATE public.character_media cm
+SET is_primary = false
+FROM ranked r
+WHERE cm.character_id = r.character_id
+  AND cm.media_id     = r.media_id
+  AND r.rn > 1;
+
+-- Step 2: Enforce the invariant going forward.
+--         At most one row per character_id may have is_primary = true.
+CREATE UNIQUE INDEX IF NOT EXISTS character_media_one_primary
+  ON public.character_media (character_id)
+  WHERE is_primary = true;

--- a/supabase/tests/database/00013_character_media_single_primary_test.sql
+++ b/supabase/tests/database/00013_character_media_single_primary_test.sql
@@ -1,0 +1,76 @@
+-- pgTAP tests for 00012_character_media_single_primary.sql (issue #125)
+-- Verifies that at most one is_primary = true row per character_id is enforced.
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(4);
+
+-- ============================================================================
+-- Index exists
+-- ============================================================================
+select has_index(
+  'public', 'character_media', 'character_media_one_primary',
+  'character_media_one_primary partial unique index exists'
+);
+
+-- ============================================================================
+-- Test fixtures
+-- ============================================================================
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('aa000000-0000-0000-0000-000000000001'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'primary@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+insert into characters (user_id, slug, name, character_type) values
+  ('aa000000-0000-0000-0000-000000000001', 'cm-char-a', 'CM Char A', 'human');
+
+insert into media (user_id, slug, storage_path, url, media_type) values
+  ('aa000000-0000-0000-0000-000000000001', 'cm-media-1', '/path/1', 'http://x/1', 'image'),
+  ('aa000000-0000-0000-0000-000000000001', 'cm-media-2', '/path/2', 'http://x/2', 'image');
+
+-- Insert first primary row — must succeed.
+insert into character_media (character_id, media_id, is_primary)
+  select
+    (select id from characters where slug = 'cm-char-a'),
+    (select id from media where slug = 'cm-media-1'),
+    true;
+
+-- ============================================================================
+-- Uniqueness enforcement: second is_primary = true for same character_id fails
+-- ============================================================================
+select throws_ok(
+  $$insert into character_media (character_id, media_id, is_primary)
+    select
+      (select id from characters where slug = 'cm-char-a'),
+      (select id from media       where slug = 'cm-media-2'),
+      true$$,
+  '23505', null,
+  'character_media_one_primary rejects second is_primary = true for same character_id'
+);
+
+-- ============================================================================
+-- Negative path: is_primary = false alongside an existing primary is allowed
+-- ============================================================================
+select lives_ok(
+  $$insert into character_media (character_id, media_id, is_primary)
+    select
+      (select id from characters where slug = 'cm-char-a'),
+      (select id from media       where slug = 'cm-media-2'),
+      false$$,
+  'second row with is_primary = false for same character_id is allowed'
+);
+
+-- ============================================================================
+-- Negative path: two non-primary rows for the same character_id are allowed
+-- ============================================================================
+select lives_ok(
+  $$update character_media
+    set is_primary = false
+    where character_id = (select id from characters where slug = 'cm-char-a')
+      and media_id     = (select id from media       where slug = 'cm-media-1')$$,
+  'unsetting primary flag succeeds without error'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
This change enforces the single-primary invariant for character_media so each character can have at most one media row marked as primary.

Closes #125

## What changed
- Added a database migration to clean up any existing duplicate primary media rows per character before enforcing the constraint.
- Created a partial unique index on character_media(character_id) where is_primary is true.
- Added pgTAP database tests covering:
  - the index exists
  - a second primary row for the same character is rejected
  - non-primary rows remain allowed
- Updated the system design documentation to describe the single-primary junction pattern and record the new constraint.

## Why
The character media model needs a stable, enforceable rule for profile images so application logic and database state cannot drift apart.

## Notes
- Existing duplicate primary rows are normalized during migration using media_id as the deterministic tie-breaker.
- This follows the same pattern that can be reused later for other junction tables with a primary flag.