### PR TITLE
feat(admin,ui): Batch B — app shell + route groups + placeholder pages

### DIFF
--- a/apps/admin/app/(admin)/layout.tsx
+++ b/apps/admin/app/(admin)/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+/**
+ * Admin route group. Real gate lives in `proxy.ts` (Batch C / #36),
+ * which checks `profiles.is_admin = true` server-side. This layout is a
+ * structural placeholder so the route group resolves and Batch C has
+ * something to wire — `(admin)/*` pages reuse `(protected)/*`'s Shell
+ * by living inside it via parallel route mounting in a later batch.
+ */
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/admin/app/(protected)/categories/page.tsx
+++ b/apps/admin/app/(protected)/categories/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "../../../components/placeholder-page";
+
+export default function CategoriesPage() {
+  return (
+    <PlaceholderPage
+      title="Categories"
+      description="Hierarchical tags applied to events, characters, and media."
+      trackedIn="Batch F (list primitives)"
+    />
+  );
+}

--- a/apps/admin/app/(protected)/characters/page.tsx
+++ b/apps/admin/app/(protected)/characters/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "../../../components/placeholder-page";
+
+export default function CharactersPage() {
+  return (
+    <PlaceholderPage
+      title="Characters"
+      description="Human, Animal, Mythological, Fictional, Organization, Divine, Artifact."
+      trackedIn="Batch F (list primitives)"
+    />
+  );
+}

--- a/apps/admin/app/(protected)/dashboard/page.tsx
+++ b/apps/admin/app/(protected)/dashboard/page.tsx
@@ -1,0 +1,12 @@
+import { PlaceholderPage } from "../../../components/placeholder-page";
+
+export default function DashboardPage() {
+  return (
+    <PlaceholderPage
+      title="Dashboard"
+      description="Recent activity, draft work, and quick links."
+      trackedIn="a later batch (TBD)"
+      rows={3}
+    />
+  );
+}

--- a/apps/admin/app/(protected)/events/page.tsx
+++ b/apps/admin/app/(protected)/events/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "../../../components/placeholder-page";
+
+export default function EventsPage() {
+  return (
+    <PlaceholderPage
+      title="Events"
+      description="Discrete moments across the full span of time, with participants and uncertainty."
+      trackedIn="Batch F (list primitives)"
+    />
+  );
+}

--- a/apps/admin/app/(protected)/layout.tsx
+++ b/apps/admin/app/(protected)/layout.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import { Shell } from "@repo/ui/components/shell";
+import { ShellLink } from "../../components/shell-link";
+import { NAV_ITEMS, QUICK_CREATE_ITEMS } from "../../lib/nav";
+
+/**
+ * Protected-route layout. Mounts the Shell chrome around every page in
+ * the `(protected)` route group.
+ *
+ * Batch B ships chrome only — placeholder user, inert sign-out, no real
+ * session check. The session gate + real user lands in Batch C (Supabase
+ * Auth + `proxy.ts`) and Batch D (auth UI). The placeholder is the
+ * "visible affordance" the wireframes call for, not a security boundary.
+ */
+const PLACEHOLDER_USER = {
+  name: "Marie Curie",
+  email: "marie@example.com",
+};
+
+export default function ProtectedLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname() ?? "/dashboard";
+  return (
+    <Shell
+      nav={NAV_ITEMS}
+      currentPath={pathname}
+      user={PLACEHOLDER_USER}
+      quickCreateItems={QUICK_CREATE_ITEMS}
+      LinkComponent={ShellLink}
+    >
+      {children}
+    </Shell>
+  );
+}

--- a/apps/admin/app/(protected)/media/page.tsx
+++ b/apps/admin/app/(protected)/media/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "../../../components/placeholder-page";
+
+export default function MediaPage() {
+  return (
+    <PlaceholderPage
+      title="Media"
+      description="Images, audio, and documents attached to events and characters."
+      trackedIn="Batch F (list primitives)"
+    />
+  );
+}

--- a/apps/admin/app/(protected)/periods/page.tsx
+++ b/apps/admin/app/(protected)/periods/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "../../../components/placeholder-page";
+
+export default function PeriodsPage() {
+  return (
+    <PlaceholderPage
+      title="Periods"
+      description="Named temporal spans — eras, ages, dynasties, geological epochs."
+      trackedIn="Batch F (list primitives)"
+    />
+  );
+}

--- a/apps/admin/app/(protected)/stories/page.tsx
+++ b/apps/admin/app/(protected)/stories/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "../../../components/placeholder-page";
+
+export default function StoriesPage() {
+  return (
+    <PlaceholderPage
+      title="Stories"
+      description="Curated narratives weaving events into a single arc."
+      trackedIn="Batch F (list primitives)"
+    />
+  );
+}

--- a/apps/admin/app/(protected)/timelines/page.tsx
+++ b/apps/admin/app/(protected)/timelines/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "../../../components/placeholder-page";
+
+export default function TimelinesPage() {
+  return (
+    <PlaceholderPage
+      title="Timelines"
+      description="Fractal temporal hierarchies — author, scope, publish."
+      trackedIn="Batch F (list primitives)"
+    />
+  );
+}

--- a/apps/admin/app/(public)/timelines/[slug]/page.tsx
+++ b/apps/admin/app/(public)/timelines/[slug]/page.tsx
@@ -1,0 +1,21 @@
+interface PublicTimelinePageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function PublicTimelinePage({
+  params,
+}: PublicTimelinePageProps) {
+  const { slug } = await params;
+  return (
+    <main className="mx-auto max-w-3xl space-y-4 p-6">
+      <h1 className="font-display text-4xl text-foreground">{slug}</h1>
+      <p className="font-body text-sm text-foreground-muted">
+        Public timeline rendering — placeholder until the dedicated reader
+        surface lands.
+      </p>
+      <p className="font-mono text-xs text-foreground-subtle">
+        Placeholder · public route group, no auth gate
+      </p>
+    </main>
+  );
+}

--- a/apps/admin/app/not-found.tsx
+++ b/apps/admin/app/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-8">
+      <div className="max-w-md space-y-4 text-center">
+        <p className="font-mono text-xs uppercase tracking-wider text-foreground-subtle">
+          404
+        </p>
+        <h1 className="font-display text-4xl text-foreground">
+          Not found in this era
+        </h1>
+        <p className="font-body text-sm text-foreground-muted">
+          This route hasn&apos;t been authored yet, or the resource has been
+          archived. Head back to the dashboard to continue.
+        </p>
+        <Link
+          href="/dashboard"
+          className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Back to dashboard
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/admin/app/page.tsx
+++ b/apps/admin/app/page.tsx
@@ -1,19 +1,10 @@
+import { redirect } from "next/navigation";
+
 /**
- * Placeholder home page — proves the Tailwind 4 + token + Google Fonts
- * pipeline. Real routes ship in later fidelity-2 batches.
+ * Root route — sends every visitor to the dashboard. Real auth gating
+ * lands in Batch C (`proxy.ts` + #36); until then anyone reaching `/`
+ * is routed into the protected shell unconditionally.
  */
 export default function Home() {
-  return (
-    <main className="flex min-h-screen items-center justify-center p-8">
-      <div className="max-w-md space-y-4 text-center">
-        <h1 className="font-display text-5xl">Time Traveler</h1>
-        <p className="font-body text-foreground-muted">
-          Temporal content management — admin
-        </p>
-        <p className="font-mono text-foreground-subtle text-sm">
-          Tailwind 4 + design tokens loaded.
-        </p>
-      </div>
-    </main>
-  );
+  redirect("/dashboard");
 }

--- a/apps/admin/components/placeholder-page.tsx
+++ b/apps/admin/components/placeholder-page.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from "@repo/ui/components/skeleton";
+
+interface PlaceholderPageProps {
+  title: string;
+  description: string;
+  /** Issue or batch that will fill this surface in. */
+  trackedIn: string;
+  /** Number of skeleton list rows to render. */
+  rows?: number;
+}
+
+export function PlaceholderPage({
+  title,
+  description,
+  trackedIn,
+  rows = 5,
+}: PlaceholderPageProps) {
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      <header className="space-y-1">
+        <h1 className="font-display text-3xl text-foreground">{title}</h1>
+        <p className="font-body text-sm text-foreground-muted">{description}</p>
+        <p className="font-mono text-xs text-foreground-subtle">
+          Placeholder · real content lands in {trackedIn}
+        </p>
+      </header>
+      <div className="space-y-2 rounded-md border border-border bg-surface p-4">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <Skeleton className="h-9 w-9 rounded-full" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3 w-1/3" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+            <Skeleton className="h-3 w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/components/shell-link.tsx
+++ b/apps/admin/components/shell-link.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import Link from "next/link";
+import type { ShellLinkProps } from "@repo/ui/components/shell";
+
+/**
+ * Next-specific adapter for the Shell's framework-agnostic
+ * `LinkComponent` slot. Confines `next/link` to the app layer per
+ * Batch C's design-for-extraction note in
+ * docs/design/admin/fidelity-2-plan.md.
+ */
+export const ShellLink = ({
+  href,
+  className,
+  children,
+  ...rest
+}: ShellLinkProps) => (
+  <Link href={href} className={className} {...rest}>
+    {children}
+  </Link>
+);

--- a/apps/admin/lib/nav.ts
+++ b/apps/admin/lib/nav.ts
@@ -1,0 +1,45 @@
+import {
+  BookOpen,
+  Calendar,
+  Clock,
+  FolderTree,
+  GitBranch,
+  Image as ImageIcon,
+  LayoutDashboard,
+  Users,
+} from "lucide-react";
+import type {
+  ShellNavItem,
+  ShellQuickCreateItem,
+} from "@repo/ui/components/shell";
+
+/**
+ * Sidebar navigation. Routes match the route-group scaffolding in
+ * `app/(protected)/*`. Order mirrors the wireframe inventory.
+ */
+export const NAV_ITEMS: ShellNavItem[] = [
+  { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Timelines", href: "/timelines", icon: GitBranch },
+  { label: "Events", href: "/events", icon: Calendar },
+  { label: "Characters", href: "/characters", icon: Users },
+  { label: "Periods", href: "/periods", icon: Clock },
+  { label: "Stories", href: "/stories", icon: BookOpen },
+  { label: "Categories", href: "/categories", icon: FolderTree },
+  { label: "Media", href: "/media", icon: ImageIcon },
+];
+
+/**
+ * Topbar quick-create dropdown. Eight entity types — the seven sidebar
+ * routes that take CRUD plus Relationship (which is junction-only).
+ * Routes 404-stub until Batch G ships the editor primitives.
+ */
+export const QUICK_CREATE_ITEMS: ShellQuickCreateItem[] = [
+  { label: "Character", href: "/characters/new" },
+  { label: "Event", href: "/events/new" },
+  { label: "Period", href: "/periods/new" },
+  { label: "Story", href: "/stories/new" },
+  { label: "Timeline", href: "/timelines/new" },
+  { label: "Category", href: "/categories/new" },
+  { label: "Media", href: "/media/new" },
+  { label: "Relationship", href: "/relationships/new" },
+];

--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  transpilePackages: ["@repo/ui"],
+};
 
 export default nextConfig;

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -15,6 +15,7 @@
     "@repo/ui": "workspace:*",
     "@tanstack/react-query": "^5.80.5",
     "@tanstack/react-query-devtools": "^5.80.5",
+    "lucide-react": "^0.469.0",
     "next": "16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"

--- a/docs/design/admin/fidelity-2-plan.md
+++ b/docs/design/admin/fidelity-2-plan.md
@@ -30,16 +30,16 @@ The fidelity-1 design review filed three follow-up issues; all are resolved or o
 
 The original fidelity-2 outline didn't reference the foundational GitHub issues that gate the admin app's bootstrap. This revision aligns each batch with the open issues it closes, so the work shows up against the project plan and doesn't grow a parallel paper trail.
 
-| Batch                                  | Closes / advances                                                                                                                                                        | Status                  |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- |
-| **[A](#batch-a--foundations)**         | [#37](https://github.com/shaes-farm/time-traveler/issues/37) (shadcn + Tailwind theme)                                                                                   | A.1, A.2 done; A.3 next |
-| **[B](#batch-b--app-shell)**           | [#38](https://github.com/shaes-farm/time-traveler/issues/38) (app shell + route groups + sidebar/header)                                                                 | not started             |
-| **[C](#batch-c--auth-infrastructure)** | [#35](https://github.com/shaes-farm/time-traveler/issues/35) (Supabase Auth), [#36](https://github.com/shaes-farm/time-traveler/issues/36) (`proxy.ts` route protection) | not started             |
-| **[D](#batch-d--auth-ui)**             | [#39](https://github.com/shaes-farm/time-traveler/issues/39) (login, register, magic link, password reset)                                                               | not started             |
-| **[E](#batch-e--temporal-primitive)**  | originally Batch B; reads against PRD §4 / system-design §4                                                                                                              | not started             |
-| **[F](#batch-f--list-primitives)**     | originally Batch D                                                                                                                                                       | not started             |
-| **[G](#batch-g--editor-primitives)**   | originally Batch E                                                                                                                                                       | not started             |
-| **[H](#batch-h--relationship-editor)** | originally Batch F; finishes the [#119](https://github.com/shaes-farm/time-traveler/issues/119) UX                                                                       | not started             |
+| Batch                                  | Closes / advances                                                                                                                                                        | Status      |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| **[A](#batch-a--foundations)**         | [#37](https://github.com/shaes-farm/time-traveler/issues/37) (shadcn + Tailwind theme)                                                                                   | done        |
+| **[B](#batch-b--app-shell)**           | [#38](https://github.com/shaes-farm/time-traveler/issues/38) (app shell + route groups + sidebar/header)                                                                 | next        |
+| **[C](#batch-c--auth-infrastructure)** | [#35](https://github.com/shaes-farm/time-traveler/issues/35) (Supabase Auth), [#36](https://github.com/shaes-farm/time-traveler/issues/36) (`proxy.ts` route protection) | not started |
+| **[D](#batch-d--auth-ui)**             | [#39](https://github.com/shaes-farm/time-traveler/issues/39) (login, register, magic link, password reset)                                                               | not started |
+| **[E](#batch-e--temporal-primitive)**  | originally Batch B; reads against PRD §4 / system-design §4                                                                                                              | not started |
+| **[F](#batch-f--list-primitives)**     | originally Batch D                                                                                                                                                       | not started |
+| **[G](#batch-g--editor-primitives)**   | originally Batch E                                                                                                                                                       | not started |
+| **[H](#batch-h--relationship-editor)** | originally Batch F; finishes the [#119](https://github.com/shaes-farm/time-traveler/issues/119) UX                                                                       | not started |
 
 Why app shell + auth before the temporal primitive: the TemporalDisplay primitive is the highest-leverage component visually, but every later batch (lists, editors, relationships) renders inside the protected shell. Building the chrome first means later composite stories can mount their primitives in a real shell context instead of a Storybook-only frame, and the auth + proxy work unblocks any future "go look at the running admin app" verification step. The TemporalDisplay still lands before list/editor work, which is where it actually gets consumed.
 
@@ -116,7 +116,7 @@ Closes [#37](https://github.com/shaes-farm/time-traveler/issues/37). Three PRs l
 - Vitest tests for the Button (variants, sizes, ref, disabled, onClick)
 - `storybook-static/` added to `.gitignore` and to ESLint ignores
 
-**PR A.3 — shadcn primitives + Foundations stories** ⏭ next
+**PR A.3 — shadcn primitives + Foundations stories** ✅ landed in [#151](https://github.com/shaes-farm/time-traveler/pull/151)
 
 - Install the shadcn primitives the next four batches consume, into `packages/ui/src/components/`:
   - **App shell (Batch B):** `separator`, `scroll-area`, `sheet`, `tabs`, `avatar`, `tooltip`, `dropdown-menu`, `breadcrumb`, `command`
@@ -158,8 +158,12 @@ Closes [#38](https://github.com/shaes-farm/time-traveler/issues/38).
   ```
 
 - `Shell` layout (sidebar + topbar + breadcrumb + content slot) — lives in `packages/ui/src/components/shell/` so the composite stories in Batch E–H can mount the same chrome
-- Sidebar: 240/64 collapsed per [#127](https://github.com/shaes-farm/time-traveler/issues/127); active-route highlighting; user avatar + sign-out at the bottom; collapsed state wired to `useUiStore` from [#138](https://github.com/shaes-farm/time-traveler/pull/138)
-- Topbar: global search trigger (`⌘K`, opens shadcn `command`), quick-create button, user menu (lucide icons + dropdown-menu)
+- Scope: **chrome only**. Every protected route ships a minimal placeholder page (heading + sub copy + a few Skeleton stand-ins). #38's acceptance criteria tick via navigation + collapse + responsive behavior; real content lands in later batches.
+- Sidebar: 240/64 collapsed per [#127](https://github.com/shaes-farm/time-traveler/issues/127); active-route highlighting; user avatar + sign-out at the bottom; collapsed state wired to `useUiStore` from [#138](https://github.com/shaes-farm/time-traveler/pull/138), **persisted to `localStorage` cross-tab** so the preference survives reload
+- Topbar:
+  - Global search trigger (`⌘K`, opens shadcn `command`)
+  - Quick-create button: dropdown listing all 8 entity types (Character / Event / Period / Story / Timeline / Category / Media / Relationship); each item links to `/<entity>/new` (which 404-stubs until Batch G's editor primitives land)
+  - User menu: **placeholder user** (hardcoded avatar fallback + name + email), inert menu items (Profile / Settings / Sign out) — visible but non-functional in Batch B. Wired to real auth in Batch C/D
 - Breadcrumb derives from route segments
 - Mobile: sidebar collapses into a `sheet`
 - Providers component (`components/providers.tsx`): TanStack Query, future ThemeProvider hook (dark-only for now), Zustand bridging if needed

--- a/packages/ui/src/components/alert.stories.tsx
+++ b/packages/ui/src/components/alert.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { CircleAlert } from "lucide-react";
-import { Alert, AlertDescription, AlertTitle } from "./alert.js";
+import { Alert, AlertDescription, AlertTitle } from "./alert";
 
 const meta = {
   title: "Components/Alert",

--- a/packages/ui/src/components/avatar.stories.tsx
+++ b/packages/ui/src/components/avatar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Avatar, AvatarFallback, AvatarImage } from "./avatar.js";
+import { Avatar, AvatarFallback, AvatarImage } from "./avatar";
 
 const meta = {
   title: "Components/Avatar",

--- a/packages/ui/src/components/badge.stories.tsx
+++ b/packages/ui/src/components/badge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Badge } from "./badge.js";
+import { Badge } from "./badge";
 
 const meta = {
   title: "Components/Badge",

--- a/packages/ui/src/components/breadcrumb.stories.tsx
+++ b/packages/ui/src/components/breadcrumb.stories.tsx
@@ -6,7 +6,7 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
-} from "./breadcrumb.js";
+} from "./breadcrumb";
 
 const meta = {
   title: "Components/Breadcrumb",

--- a/packages/ui/src/components/button.stories.tsx
+++ b/packages/ui/src/components/button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Button } from "./button.js";
+import { Button } from "./button";
 
 const meta = {
   title: "Components/Button",

--- a/packages/ui/src/components/button.test.tsx
+++ b/packages/ui/src/components/button.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { createRef } from "react";
-import { Button } from "./button.js";
+import { Button } from "./button";
 
 describe("Button", () => {
   it("renders its children", () => {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "../lib/utils.js";
+import { cn } from "../lib/utils";
 
 /**
  * Button — the first design-system primitive (smoke test for the

--- a/packages/ui/src/components/card.stories.tsx
+++ b/packages/ui/src/components/card.stories.tsx
@@ -6,8 +6,8 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from "./card.js";
-import { Button } from "./button.js";
+} from "./card";
+import { Button } from "./button";
 
 const meta = {
   title: "Components/Card",

--- a/packages/ui/src/components/command.stories.tsx
+++ b/packages/ui/src/components/command.stories.tsx
@@ -7,7 +7,7 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
-} from "./command.js";
+} from "./command";
 
 const meta = {
   title: "Components/Command",

--- a/packages/ui/src/components/dialog.stories.tsx
+++ b/packages/ui/src/components/dialog.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Button } from "./button.js";
+import { Button } from "./button";
 import {
   Dialog,
   DialogContent,
@@ -8,7 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "./dialog.js";
+} from "./dialog";
 
 const meta = {
   title: "Components/Dialog",

--- a/packages/ui/src/components/dropdown-menu.stories.tsx
+++ b/packages/ui/src/components/dropdown-menu.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Button } from "./button.js";
+import { Button } from "./button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -7,7 +7,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "./dropdown-menu.js";
+} from "./dropdown-menu";
 
 const meta = {
   title: "Components/DropdownMenu",

--- a/packages/ui/src/components/form.stories.tsx
+++ b/packages/ui/src/components/form.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useForm } from "react-hook-form";
-import { Button } from "./button.js";
+import { Button } from "./button";
 import {
   Form,
   FormControl,
@@ -9,8 +9,8 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from "./form.js";
-import { Input } from "./input.js";
+} from "./form";
+import { Input } from "./input";
 
 const meta: Meta = {
   title: "Components/Form",

--- a/packages/ui/src/components/input.stories.tsx
+++ b/packages/ui/src/components/input.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Input } from "./input.js";
+import { Input } from "./input";
 
 const meta = {
   title: "Components/Input",

--- a/packages/ui/src/components/label.stories.tsx
+++ b/packages/ui/src/components/label.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Label } from "./label.js";
-import { Input } from "./input.js";
+import { Label } from "./label";
+import { Input } from "./input";
 
 const meta = {
   title: "Components/Label",

--- a/packages/ui/src/components/popover.stories.tsx
+++ b/packages/ui/src/components/popover.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Button } from "./button.js";
-import { Popover, PopoverContent, PopoverTrigger } from "./popover.js";
+import { Button } from "./button";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
 const meta = {
   title: "Components/Popover",

--- a/packages/ui/src/components/scroll-area.stories.tsx
+++ b/packages/ui/src/components/scroll-area.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { ScrollArea } from "./scroll-area.js";
+import { ScrollArea } from "./scroll-area";
 
 const meta = {
   title: "Components/ScrollArea",

--- a/packages/ui/src/components/separator.stories.tsx
+++ b/packages/ui/src/components/separator.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Separator } from "./separator.js";
+import { Separator } from "./separator";
 
 const meta = {
   title: "Components/Separator",

--- a/packages/ui/src/components/sheet.stories.tsx
+++ b/packages/ui/src/components/sheet.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Button } from "./button.js";
+import { Button } from "./button";
 import {
   Sheet,
   SheetContent,
@@ -7,7 +7,7 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
-} from "./sheet.js";
+} from "./sheet";
 
 const meta = {
   title: "Components/Sheet",

--- a/packages/ui/src/components/shell.stories.tsx
+++ b/packages/ui/src/components/shell.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  BookOpen,
+  Calendar,
+  Clock,
+  FolderTree,
+  GitBranch,
+  Image as ImageIcon,
+  LayoutDashboard,
+  Users,
+} from "lucide-react";
+import { Skeleton } from "./skeleton";
+import { Shell, type ShellNavItem, type ShellQuickCreateItem } from "./shell";
+
+const meta = {
+  title: "Pages/Shell",
+  component: Shell,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof Shell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const NAV: ShellNavItem[] = [
+  { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Timelines", href: "/timelines", icon: GitBranch },
+  { label: "Events", href: "/events", icon: Calendar },
+  { label: "Characters", href: "/characters", icon: Users },
+  { label: "Periods", href: "/periods", icon: Clock },
+  { label: "Stories", href: "/stories", icon: BookOpen },
+  { label: "Categories", href: "/categories", icon: FolderTree },
+  { label: "Media", href: "/media", icon: ImageIcon },
+];
+
+const QUICK_CREATE: ShellQuickCreateItem[] = [
+  { label: "Character", href: "/characters/new" },
+  { label: "Event", href: "/events/new" },
+  { label: "Period", href: "/periods/new" },
+  { label: "Story", href: "/stories/new" },
+  { label: "Timeline", href: "/timelines/new" },
+  { label: "Category", href: "/categories/new" },
+  { label: "Media", href: "/media/new" },
+  { label: "Relationship", href: "/relationships/new" },
+];
+
+const USER = {
+  name: "Marie Curie",
+  email: "marie@example.com",
+};
+
+const PlaceholderContent = ({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) => (
+  <div className="mx-auto max-w-5xl space-y-6 p-6">
+    <header className="space-y-1">
+      <h1 className="font-display text-3xl text-foreground">{title}</h1>
+      <p className="font-body text-sm text-foreground-muted">{description}</p>
+    </header>
+    <div className="space-y-2 rounded-md border border-border bg-surface p-4">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <Skeleton className="h-9 w-9 rounded-full" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3 w-1/3" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <Skeleton className="h-3 w-16" />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const Dashboard: Story = {
+  args: {
+    nav: NAV,
+    currentPath: "/dashboard",
+    user: USER,
+    quickCreateItems: QUICK_CREATE,
+    children: (
+      <PlaceholderContent
+        title="Dashboard"
+        description="Recent activity, draft work, and quick links."
+      />
+    ),
+  },
+};
+
+export const Characters: Story = {
+  args: {
+    ...Dashboard.args,
+    currentPath: "/characters",
+    children: (
+      <PlaceholderContent
+        title="Characters"
+        description="Human, Animal, Mythological, Fictional, Organization, Divine, Artifact."
+      />
+    ),
+  },
+};
+
+export const DeepBreadcrumb: Story = {
+  args: {
+    ...Dashboard.args,
+    currentPath: "/characters/curie-marie",
+    breadcrumbs: [
+      { label: "Characters", href: "/characters" },
+      { label: "Marie Curie" },
+    ],
+    children: (
+      <PlaceholderContent
+        title="Marie Curie"
+        description="Character detail — explicit breadcrumb override."
+      />
+    ),
+  },
+};

--- a/packages/ui/src/components/shell.tsx
+++ b/packages/ui/src/components/shell.tsx
@@ -1,0 +1,466 @@
+"use client";
+
+import { type ComponentType, type ReactNode } from "react";
+import {
+  ChevronsLeft,
+  ChevronsRight,
+  Clock,
+  LogOut,
+  Plus,
+  Search,
+  Settings,
+  User as UserIcon,
+} from "lucide-react";
+import { cn } from "@repo/ui/lib/utils";
+import { useUiStore } from "@repo/ui/stores";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@repo/ui/components/avatar";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@repo/ui/components/breadcrumb";
+import { Button } from "@repo/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@repo/ui/components/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@repo/ui/components/tooltip";
+
+/**
+ * Framework-agnostic link contract. The admin app supplies `next/link`;
+ * Storybook stories supply a plain `<a>`. Keeping the Shell unaware of
+ * Next means the future reader app (D3-based, deferred) can mount the
+ * same primitive without a rewrite.
+ */
+export interface ShellLinkProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+  "aria-label"?: string;
+}
+
+export type ShellLinkComponent = ComponentType<ShellLinkProps>;
+
+export interface ShellNavItem {
+  label: string;
+  href: string;
+  icon: ComponentType<{ className?: string }>;
+}
+
+export interface ShellQuickCreateItem {
+  label: string;
+  href: string;
+}
+
+export interface ShellBreadcrumbItem {
+  label: string;
+  /** Omit for the trailing/current crumb. */
+  href?: string;
+}
+
+export interface ShellUser {
+  name: string;
+  email: string;
+  avatarUrl?: string;
+}
+
+const DefaultShellLink = ({
+  href,
+  className,
+  children,
+  ...rest
+}: ShellLinkProps) => (
+  <a href={href} className={className} {...rest}>
+    {children}
+  </a>
+);
+
+// ---------------------------------------------------------------------
+// Sidebar
+// ---------------------------------------------------------------------
+
+export interface ShellSidebarProps {
+  nav: ShellNavItem[];
+  currentPath: string;
+  LinkComponent?: ShellLinkComponent;
+}
+
+export const ShellSidebar = ({
+  nav,
+  currentPath,
+  LinkComponent = DefaultShellLink,
+}: ShellSidebarProps) => {
+  const sidebarOpen = useUiStore((s) => s.sidebarOpen);
+  const toggleSidebar = useUiStore((s) => s.toggleSidebar);
+
+  return (
+    <aside
+      className={cn(
+        "flex h-screen shrink-0 flex-col border-r border-border bg-surface transition-[width] duration-150",
+        sidebarOpen ? "w-60" : "w-16",
+      )}
+      aria-label="Primary navigation"
+    >
+      <div
+        className={cn(
+          "flex h-14 items-center border-b border-border px-3",
+          sidebarOpen ? "justify-start gap-2" : "justify-center",
+        )}
+      >
+        <Clock className="h-5 w-5 shrink-0 text-foreground" aria-hidden />
+        {sidebarOpen && (
+          <span className="font-display text-base leading-none text-foreground">
+            Time Traveler
+          </span>
+        )}
+      </div>
+      <nav className="flex-1 overflow-y-auto p-2">
+        <ul className="flex flex-col gap-1">
+          {nav.map((item) => {
+            const active =
+              currentPath === item.href ||
+              (item.href !== "/" && currentPath.startsWith(`${item.href}/`));
+            const Icon = item.icon;
+            const link = (
+              <LinkComponent
+                href={item.href}
+                aria-label={item.label}
+                className={cn(
+                  "flex h-9 items-center rounded-md text-sm transition-colors",
+                  sidebarOpen ? "gap-3 px-3" : "justify-center",
+                  active
+                    ? "bg-surface-2 text-foreground"
+                    : "text-foreground-muted hover:bg-surface-2 hover:text-foreground",
+                )}
+              >
+                <Icon className="h-4 w-4 shrink-0" aria-hidden />
+                {sidebarOpen && <span>{item.label}</span>}
+              </LinkComponent>
+            );
+            return (
+              <li key={item.href}>
+                {sidebarOpen ? (
+                  link
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger asChild>{link}</TooltipTrigger>
+                    <TooltipContent side="right">{item.label}</TooltipContent>
+                  </Tooltip>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+      <div className="border-t border-border p-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={toggleSidebar}
+          className={cn(
+            "w-full text-foreground-muted",
+            sidebarOpen ? "justify-start" : "justify-center px-0",
+          )}
+          aria-label={sidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+        >
+          {sidebarOpen ? (
+            <>
+              <ChevronsLeft className="h-4 w-4" aria-hidden />
+              <span className="ml-2 text-xs">Collapse</span>
+            </>
+          ) : (
+            <ChevronsRight className="h-4 w-4" aria-hidden />
+          )}
+        </Button>
+      </div>
+    </aside>
+  );
+};
+
+// ---------------------------------------------------------------------
+// Breadcrumb
+// ---------------------------------------------------------------------
+
+export interface ShellBreadcrumbProps {
+  items: ShellBreadcrumbItem[];
+  LinkComponent?: ShellLinkComponent;
+}
+
+export const ShellBreadcrumb = ({
+  items,
+  LinkComponent = DefaultShellLink,
+}: ShellBreadcrumbProps) => {
+  if (items.length === 0) return null;
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        {items.map((item, index) => {
+          const last = index === items.length - 1;
+          return (
+            <BreadcrumbItem key={`${item.label}-${index}`}>
+              {last || !item.href ? (
+                <BreadcrumbPage>{item.label}</BreadcrumbPage>
+              ) : (
+                <>
+                  <BreadcrumbLink asChild>
+                    <LinkComponent href={item.href}>{item.label}</LinkComponent>
+                  </BreadcrumbLink>
+                  <BreadcrumbSeparator />
+                </>
+              )}
+            </BreadcrumbItem>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+};
+
+// ---------------------------------------------------------------------
+// User menu
+// ---------------------------------------------------------------------
+
+export interface ShellUserMenuProps {
+  user: ShellUser;
+  onSignOut?: () => void;
+}
+
+const initialsFor = (name: string) =>
+  name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+
+export const ShellUserMenu = ({ user, onSignOut }: ShellUserMenuProps) => (
+  <DropdownMenu>
+    <DropdownMenuTrigger asChild>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-9 gap-2 px-2"
+        aria-label="Open user menu"
+      >
+        <Avatar className="h-7 w-7">
+          {user.avatarUrl && (
+            <AvatarImage src={user.avatarUrl} alt={user.name} />
+          )}
+          <AvatarFallback className="text-xs">
+            {initialsFor(user.name) || "?"}
+          </AvatarFallback>
+        </Avatar>
+      </Button>
+    </DropdownMenuTrigger>
+    <DropdownMenuContent align="end" className="w-56">
+      <DropdownMenuLabel className="flex flex-col gap-0.5">
+        <span className="text-sm text-foreground">{user.name}</span>
+        <span className="text-xs font-normal text-foreground-muted">
+          {user.email}
+        </span>
+      </DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem disabled>
+        <UserIcon className="mr-2 h-4 w-4" aria-hidden />
+        Profile
+      </DropdownMenuItem>
+      <DropdownMenuItem disabled>
+        <Settings className="mr-2 h-4 w-4" aria-hidden />
+        Settings
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem disabled={!onSignOut} onSelect={onSignOut}>
+        <LogOut className="mr-2 h-4 w-4" aria-hidden />
+        Sign out
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  </DropdownMenu>
+);
+
+// ---------------------------------------------------------------------
+// Quick-create menu
+// ---------------------------------------------------------------------
+
+export interface ShellQuickCreateMenuProps {
+  items: ShellQuickCreateItem[];
+  LinkComponent?: ShellLinkComponent;
+}
+
+export const ShellQuickCreateMenu = ({
+  items,
+  LinkComponent = DefaultShellLink,
+}: ShellQuickCreateMenuProps) => (
+  <DropdownMenu>
+    <DropdownMenuTrigger asChild>
+      <Button variant="secondary" size="sm" aria-label="Quick create">
+        <Plus className="h-4 w-4" aria-hidden />
+        <span className="ml-1.5 hidden sm:inline">New</span>
+      </Button>
+    </DropdownMenuTrigger>
+    <DropdownMenuContent align="end" className="w-48">
+      <DropdownMenuLabel>Create</DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      {items.map((item) => (
+        <DropdownMenuItem key={item.href} asChild>
+          <LinkComponent href={item.href}>{item.label}</LinkComponent>
+        </DropdownMenuItem>
+      ))}
+    </DropdownMenuContent>
+  </DropdownMenu>
+);
+
+// ---------------------------------------------------------------------
+// Search trigger
+// ---------------------------------------------------------------------
+
+export interface ShellSearchTriggerProps {
+  onOpen?: () => void;
+}
+
+export const ShellSearchTrigger = ({ onOpen }: ShellSearchTriggerProps) => (
+  <Button
+    variant="secondary"
+    size="sm"
+    onClick={onOpen}
+    className="h-9 w-full max-w-xs justify-start gap-2 text-foreground-muted"
+    aria-label="Open search"
+  >
+    <Search className="h-4 w-4 shrink-0" aria-hidden />
+    <span className="flex-1 text-left text-sm">Search…</span>
+    <kbd className="hidden rounded border border-border bg-surface px-1.5 py-0.5 font-mono text-[10px] text-foreground-subtle sm:inline">
+      ⌘K
+    </kbd>
+  </Button>
+);
+
+// ---------------------------------------------------------------------
+// Topbar
+// ---------------------------------------------------------------------
+
+export interface ShellTopbarProps {
+  breadcrumbs: ShellBreadcrumbItem[];
+  user: ShellUser;
+  onSignOut?: () => void;
+  quickCreateItems: ShellQuickCreateItem[];
+  onSearchOpen?: () => void;
+  LinkComponent?: ShellLinkComponent;
+}
+
+export const ShellTopbar = ({
+  breadcrumbs,
+  user,
+  onSignOut,
+  quickCreateItems,
+  onSearchOpen,
+  LinkComponent,
+}: ShellTopbarProps) => (
+  <header className="flex h-14 shrink-0 items-center gap-3 border-b border-border bg-background px-4">
+    <div className="flex flex-1 items-center gap-4 overflow-hidden">
+      <div className="hidden flex-1 sm:block">
+        <ShellSearchTrigger onOpen={onSearchOpen} />
+      </div>
+      <div className="hidden min-w-0 flex-1 truncate md:block">
+        <ShellBreadcrumb items={breadcrumbs} LinkComponent={LinkComponent} />
+      </div>
+    </div>
+    <div className="flex items-center gap-2">
+      <ShellQuickCreateMenu
+        items={quickCreateItems}
+        LinkComponent={LinkComponent}
+      />
+      <ShellUserMenu user={user} onSignOut={onSignOut} />
+    </div>
+  </header>
+);
+
+// ---------------------------------------------------------------------
+// Shell composer
+// ---------------------------------------------------------------------
+
+export interface ShellProps {
+  /** Sidebar navigation entries. */
+  nav: ShellNavItem[];
+  /** Current route — drives sidebar active state and auto-breadcrumb fallback. */
+  currentPath: string;
+  /** Authenticated user. Placeholder during Batch B; wired to real auth in Batch C/D. */
+  user: ShellUser;
+  /** Entity types surfaced by the topbar quick-create dropdown. */
+  quickCreateItems: ShellQuickCreateItem[];
+  /** Explicit breadcrumb trail. Omit to auto-derive a single crumb from `currentPath` + `nav`. */
+  breadcrumbs?: ShellBreadcrumbItem[];
+  /** Sign-out handler for the user menu. Inert when omitted. */
+  onSignOut?: () => void;
+  /** Handler for the ⌘K search trigger. */
+  onSearchOpen?: () => void;
+  /** Framework-specific link primitive (e.g. `next/link`). Falls back to a plain `<a>`. */
+  LinkComponent?: ShellLinkComponent;
+  children: ReactNode;
+}
+
+const deriveBreadcrumbs = (
+  currentPath: string,
+  nav: ShellNavItem[],
+): ShellBreadcrumbItem[] => {
+  const match = nav.find(
+    (item) =>
+      currentPath === item.href ||
+      (item.href !== "/" && currentPath.startsWith(`${item.href}/`)),
+  );
+  if (match) return [{ label: match.label }];
+  return [];
+};
+
+export const Shell = ({
+  nav,
+  currentPath,
+  user,
+  quickCreateItems,
+  breadcrumbs,
+  onSignOut,
+  onSearchOpen,
+  LinkComponent,
+  children,
+}: ShellProps) => {
+  const resolvedBreadcrumbs =
+    breadcrumbs ?? deriveBreadcrumbs(currentPath, nav);
+  const sidebarProps: ShellSidebarProps = {
+    nav,
+    currentPath,
+    ...(LinkComponent ? { LinkComponent } : {}),
+  };
+  const topbarProps: ShellTopbarProps = {
+    breadcrumbs: resolvedBreadcrumbs,
+    user,
+    quickCreateItems,
+    ...(onSignOut ? { onSignOut } : {}),
+    ...(onSearchOpen ? { onSearchOpen } : {}),
+    ...(LinkComponent ? { LinkComponent } : {}),
+  };
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">
+        <ShellSidebar {...sidebarProps} />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <ShellTopbar {...topbarProps} />
+          <main className="flex-1 overflow-y-auto">{children}</main>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+};

--- a/packages/ui/src/components/skeleton.stories.tsx
+++ b/packages/ui/src/components/skeleton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Skeleton } from "./skeleton.js";
+import { Skeleton } from "./skeleton";
 
 const meta = {
   title: "Components/Skeleton",

--- a/packages/ui/src/components/sonner.stories.tsx
+++ b/packages/ui/src/components/sonner.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { toast } from "sonner";
-import { Button } from "./button.js";
-import { Toaster } from "./sonner.js";
+import { Button } from "./button";
+import { Toaster } from "./sonner";
 
 const meta = {
   title: "Components/Toaster",

--- a/packages/ui/src/components/status-badge.stories.tsx
+++ b/packages/ui/src/components/status-badge.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StatusBadge } from "./status-badge";
+
+const meta = {
+  title: "Components/StatusBadge",
+  component: StatusBadge,
+  parameters: { layout: "centered" },
+  argTypes: {
+    status: {
+      control: "select",
+      options: ["published", "draft", "shared"],
+    },
+  },
+} satisfies Meta<typeof StatusBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Published: Story = { args: { status: "published" } };
+export const Draft: Story = { args: { status: "draft" } };
+export const Shared: Story = { args: { status: "shared" } };
+
+export const AllStatuses: Story = {
+  render: () => (
+    <div className="flex gap-3">
+      <StatusBadge status="published" />
+      <StatusBadge status="draft" />
+      <StatusBadge status="shared" />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/status-badge.tsx
+++ b/packages/ui/src/components/status-badge.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { ArrowLeftRight, Check, Minus } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@repo/ui/lib/utils";
+
+const statusBadgeVariants = cva(
+  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+  {
+    variants: {
+      status: {
+        published:
+          "bg-emerald-500/10 text-emerald-400 ring-1 ring-inset ring-emerald-500/20",
+        draft:
+          "bg-surface-2 text-foreground-muted ring-1 ring-inset ring-border",
+        shared: "bg-sky-500/10 text-sky-400 ring-1 ring-inset ring-sky-500/20",
+      },
+    },
+    defaultVariants: {
+      status: "draft",
+    },
+  },
+);
+
+const STATUS_ICON: Record<
+  NonNullable<VariantProps<typeof statusBadgeVariants>["status"]>,
+  React.ComponentType<{ className?: string }>
+> = {
+  published: Check,
+  draft: Minus,
+  shared: ArrowLeftRight,
+};
+
+const STATUS_LABEL: Record<
+  NonNullable<VariantProps<typeof statusBadgeVariants>["status"]>,
+  string
+> = {
+  published: "Published",
+  draft: "Draft",
+  shared: "Shared",
+};
+
+export interface StatusBadgeProps
+  extends
+    Omit<React.HTMLAttributes<HTMLSpanElement>, "children">,
+    VariantProps<typeof statusBadgeVariants> {
+  /** Optional label override; defaults to the canonical name for the status. */
+  label?: string;
+}
+
+export const StatusBadge = React.forwardRef<HTMLSpanElement, StatusBadgeProps>(
+  ({ className, status, label, ...props }, ref) => {
+    const resolvedStatus = status ?? "draft";
+    const Icon = STATUS_ICON[resolvedStatus];
+    return (
+      <span
+        ref={ref}
+        className={cn(statusBadgeVariants({ status, className }))}
+        {...props}
+      >
+        <Icon className="h-3 w-3" aria-hidden />
+        {label ?? STATUS_LABEL[resolvedStatus]}
+      </span>
+    );
+  },
+);
+StatusBadge.displayName = "StatusBadge";
+
+export { statusBadgeVariants };

--- a/packages/ui/src/components/tabs.stories.tsx
+++ b/packages/ui/src/components/tabs.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs.js";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
 
 const meta = {
   title: "Components/Tabs",

--- a/packages/ui/src/components/tooltip.stories.tsx
+++ b/packages/ui/src/components/tooltip.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Button } from "./button.js";
+import { Button } from "./button";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "./tooltip.js";
+} from "./tooltip";
 
 const meta = {
   title: "Components/Tooltip",

--- a/packages/ui/src/hooks/index.tsx
+++ b/packages/ui/src/hooks/index.tsx
@@ -4,11 +4,11 @@
  * Import individual hook files for tree-shaking, or use this barrel
  * for convenience: `import { useCharacters } from "@repo/ui/hooks"`
  */
-export * from "./use-categories.js";
-export * from "./use-character-relationships.js";
-export * from "./use-characters.js";
-export * from "./use-events.js";
-export * from "./use-media.js";
-export * from "./use-periods.js";
-export * from "./use-stories.js";
-export * from "./use-timelines.js";
+export * from "./use-categories";
+export * from "./use-character-relationships";
+export * from "./use-characters";
+export * from "./use-events";
+export * from "./use-media";
+export * from "./use-periods";
+export * from "./use-stories";
+export * from "./use-timelines";

--- a/packages/ui/src/hooks/use-categories.test.tsx
+++ b/packages/ui/src/hooks/use-categories.test.tsx
@@ -10,7 +10,7 @@ import {
   useUpdateCategory,
   useDeleteCategory,
   categoryKeys,
-} from "./use-categories.js";
+} from "./use-categories";
 
 vi.mock("@repo/services/category-service.js", () => ({
   getCategories: vi.fn(),

--- a/packages/ui/src/hooks/use-character-relationships.test.tsx
+++ b/packages/ui/src/hooks/use-character-relationships.test.tsx
@@ -12,7 +12,7 @@ import {
   useUpdateRelationship,
   useDeleteRelationship,
   relationshipKeys,
-} from "./use-character-relationships.js";
+} from "./use-character-relationships";
 
 vi.mock("@repo/services/character-relationship-service.js", () => ({
   getRelationships: vi.fn(),

--- a/packages/ui/src/hooks/use-characters.test.tsx
+++ b/packages/ui/src/hooks/use-characters.test.tsx
@@ -11,7 +11,7 @@ import {
   useCharacterTimeline,
   useCharacterNetwork,
   characterKeys,
-} from "./use-characters.js";
+} from "./use-characters";
 
 // ---------------------------------------------------------------------------
 // Mock the character service

--- a/packages/ui/src/hooks/use-events.test.tsx
+++ b/packages/ui/src/hooks/use-events.test.tsx
@@ -17,7 +17,7 @@ import {
   useAddMediaToEvent,
   useRemoveMediaFromEvent,
   eventKeys,
-} from "./use-events.js";
+} from "./use-events";
 
 vi.mock("@repo/services/event-service.js", () => ({
   getEvents: vi.fn(),

--- a/packages/ui/src/hooks/use-media.test.tsx
+++ b/packages/ui/src/hooks/use-media.test.tsx
@@ -11,7 +11,7 @@ import {
   useUpdateMedia,
   useDeleteMedia,
   mediaKeys,
-} from "./use-media.js";
+} from "./use-media";
 
 vi.mock("@repo/services/media-service.js", () => ({
   getMedia: vi.fn(),

--- a/packages/ui/src/hooks/use-periods.test.tsx
+++ b/packages/ui/src/hooks/use-periods.test.tsx
@@ -12,7 +12,7 @@ import {
   useAddPeriodToTimeline,
   useRemovePeriodFromTimeline,
   periodKeys,
-} from "./use-periods.js";
+} from "./use-periods";
 
 vi.mock("@repo/services/period-service.js", () => ({
   getPeriods: vi.fn(),

--- a/packages/ui/src/hooks/use-stories.test.tsx
+++ b/packages/ui/src/hooks/use-stories.test.tsx
@@ -15,7 +15,7 @@ import {
   useAddPeriodToStory,
   useRemovePeriodFromStory,
   storyKeys,
-} from "./use-stories.js";
+} from "./use-stories";
 
 vi.mock("@repo/services/story-service.js", () => ({
   getStories: vi.fn(),

--- a/packages/ui/src/hooks/use-timelines.test.tsx
+++ b/packages/ui/src/hooks/use-timelines.test.tsx
@@ -12,7 +12,7 @@ import {
   useUnpublishTimeline,
   useTimelineCollaborators,
   timelineKeys,
-} from "./use-timelines.js";
+} from "./use-timelines";
 
 vi.mock("@repo/services/timeline-service.js", () => ({
   getTimelines: vi.fn(),

--- a/packages/ui/src/stores/index.ts
+++ b/packages/ui/src/stores/index.ts
@@ -7,7 +7,7 @@ export {
   type NavigationActions,
   type ViewMode,
   type VisibleRange,
-} from "./navigation-store.js";
+} from "./navigation-store";
 
 export {
   useUiStore,
@@ -16,4 +16,4 @@ export {
   type UiActions,
   type Toast,
   type ToastVariant,
-} from "./ui-store.js";
+} from "./ui-store";

--- a/packages/ui/src/stores/navigation-store.test.ts
+++ b/packages/ui/src/stores/navigation-store.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import {
-  useNavigationStore,
-  type NavigationState,
-} from "./navigation-store.js";
+import { useNavigationStore, type NavigationState } from "./navigation-store";
 
 // Reset store to initial state before each test to ensure isolation.
 beforeEach(() => {

--- a/packages/ui/src/stores/ui-store.test.ts
+++ b/packages/ui/src/stores/ui-store.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { useUiStore, type UiState, type Toast } from "./ui-store.js";
+import { useUiStore, type UiState, type Toast } from "./ui-store";
 
 // Reset store to initial state before each test to ensure isolation.
 beforeEach(() => {

--- a/packages/ui/src/styles/colors.stories.tsx
+++ b/packages/ui/src/styles/colors.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { colors } from "./tokens.js";
+import { colors } from "./tokens";
 
 type Swatch = {
   cssVar: string;

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "dist",
     "strictNullChecks": true,
-    "types": ["node", "react", "react-dom"]
+    "types": ["node", "react", "react-dom"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
   },
   "include": ["src", "vitest.setup.ts"],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.80.5
         version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
+      lucide-react:
+        specifier: ^0.469.0
+        version: 0.469.0(react@19.2.6)
       next:
         specifier: 16.2.6
         version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
## Summary

Closes #38.

**Shell primitive** (`packages/ui/src/components/shell.tsx`) — composite layout with sidebar, topbar, breadcrumb, and content slot. Framework-agnostic via a `LinkComponent` slot (admin passes `next/link`; the future reader app can mount the same primitive without rework).

- Sidebar: 240px expanded / 64px collapsed per [#127](https://github.com/shaes-farm/time-traveler/issues/127), active-route highlighting, tooltips when collapsed. Collapse state persists cross-tab via `useUiStore` (already wired in [#138](https://github.com/shaes-farm/time-traveler/pull/138)).
- Topbar: ⌘K search trigger, quick-create dropdown to all 8 entity types, user menu with avatar dropdown.
- Mobile: search/breadcrumb hide below `sm`/`md`; sidebar still collapsible.

**StatusBadge primitive** — Published (✓ + emerald) / Draft (─ + zinc) / Shared (⇄ + sky) per PRD §7.11.5.

**Route groups in `apps/admin/app/`:**
- `(protected)/` mounts the Shell — dashboard, timelines, events, characters, periods, stories, categories, media
- `(public)/timelines/[slug]` — public timeline placeholder
- `(admin)/` — structural placeholder; real gate lands in Batch C `proxy.ts`
- `not-found.tsx` — themed 404
- root `/` → redirects to `/dashboard`

**Batch B scope per the [updated plan](docs/design/admin/fidelity-2-plan.md):** chrome only. Each protected page renders heading + sub-copy + Skeleton stand-ins. User menu shows a hardcoded placeholder user with inert items (Profile/Settings/Sign out) until Batch C/D wires real auth. Quick-create links to `/<entity>/new` routes that 404-stub until Batch G.

## Repo plumbing

| Change | Why |
| --- | --- |
| `packages/ui/tsconfig.json` overrides `module`/`moduleResolution` to ESNext/Bundler | Turbopack reads workspace files directly and couldn't resolve `.js` → `.tsx` via NodeNext semantics. Bundler resolution lets both `tsc` and Turbopack agree. Internal `.js` imports under `packages/ui/src` were stripped to extensionless form. No public API change. |
| `apps/admin/next.config.js` adds `transpilePackages: ["@repo/ui"]` | Documents the workspace-transpilation expectation; future-proofs against Turbopack default changes. |
| `apps/admin` adds `lucide-react` as direct dep | Sidebar nav icons; previously only transitively available via `@repo/ui`. |
| `docs/design/admin/fidelity-2-plan.md` Batch B section | Folds the four scope decisions from this session (user menu, chrome-only scope, localStorage cross-tab persistence, quick-create dropdown). |

## Test plan

- [x] `pnpm run check-types` — green
- [x] `pnpm run lint` — green
- [x] `pnpm run build` — admin renders 12 static routes + 1 dynamic
- [x] `pnpm --filter @repo/ui run test` — 147 / 147 passing
- [x] `pnpm --filter @repo/ui run build-storybook` — green, with three new `Pages > Shell` stories (Dashboard, Characters, DeepBreadcrumb)
- [x] `pnpm --filter admin run dev` and manually click each sidebar item to confirm active-route highlighting, collapse persistence across reload, breadcrumb auto-derivation, quick-create dropdown to a 404 stub, user-menu render

🤖 Generated with [Claude Code](https://claude.com/claude-code)