### PR TITLE
Build TemporalInput component  & edit primitives

### DIFF
--- a/docs/design/admin/fidelity-2-plan.md
+++ b/docs/design/admin/fidelity-2-plan.md
@@ -37,8 +37,8 @@ The original fidelity-2 outline didn't reference the foundational GitHub issues 
 | **[C](#batch-c--auth-infrastructure)** | [#35](https://github.com/shaes-farm/time-traveler/issues/35) (Supabase Auth), [#36](https://github.com/shaes-farm/time-traveler/issues/36) (`proxy.ts` route protection) | done        |
 | **[D](#batch-d--auth-ui)**             | [#39](https://github.com/shaes-farm/time-traveler/issues/39) (login, register, magic link, password reset)                                                               | done        |
 | **[E](#batch-e--temporal-primitive)**  | originally Batch B; reads against PRD §4 / system-design §4                                                                                                              | done        |
-| **[F](#batch-f--list-primitives)**     | originally Batch D                                                                                                                                                       | next        |
-| **[G](#batch-g--editor-primitives)**   | originally Batch E                                                                                                                                                       | not started |
+| **[F](#batch-f--list-primitives)**     | originally Batch D                                                                                                                                                       | done        |
+| **[G](#batch-g--editor-primitives)**   | [#40](https://github.com/shaes-farm/time-traveler/issues/40) (TemporalInput/editor primitives + docs refresh)                                                            | in review   |
 | **[H](#batch-h--relationship-editor)** | originally Batch F; finishes the [#119](https://github.com/shaes-farm/time-traveler/issues/119) UX                                                                       | not started |
 
 Why app shell + auth before the temporal primitive: the TemporalDisplay primitive is the highest-leverage component visually, but every later batch (lists, editors, relationships) renders inside the protected shell. Building the chrome first means later composite stories can mount their primitives in a real shell context instead of a Storybook-only frame, and the auth + proxy work unblocks any future "go look at the running admin app" verification step. The TemporalDisplay still lands before list/editor work, which is where it actually gets consumed.
@@ -162,7 +162,7 @@ Closes [#38](https://github.com/shaes-farm/time-traveler/issues/38).
 - Sidebar: 240/64 collapsed per [#127](https://github.com/shaes-farm/time-traveler/issues/127); active-route highlighting; user avatar + sign-out at the bottom; collapsed state wired to `useUiStore` from [#138](https://github.com/shaes-farm/time-traveler/pull/138), **persisted to `localStorage` cross-tab** so the preference survives reload
 - Topbar:
   - Global search trigger (`⌘K`, opens shadcn `command`)
-  - Quick-create button: dropdown listing all 8 entity types (Character / Event / Period / Story / Timeline / Category / Media / Relationship); each item links to `/<entity>/new` (which 404-stubs until Batch G's editor primitives land)
+  - Quick-create button: dropdown listing all 8 entity types (Character / Event / Period / Story / Timeline / Category / Media / Relationship); each item links to `/<entity>/new` (currently 404-stubbed; route integration is tracked outside Batch G)
   - User menu: **placeholder user** (hardcoded avatar fallback + name + email), inert menu items (Profile / Settings / Sign out) — visible but non-functional in Batch B. Wired to real auth in Batch C/D
 - Breadcrumb derives from route segments
 - Mobile: sidebar collapses into a `sheet`
@@ -239,10 +239,10 @@ Originally Batch B. Two PRs.
 - `Pages > Character Detail` composite story (3 variants: Overview / Loading / PrehistoricCharacter) mounting the Shell from Batch B and consuming `TemporalDisplay` in two roles: compact span in the identity header, block format with `showExact` in the Temporal scope section
 - Demonstrates adaptive empty-state rendering (no bio, no physical description, no death date)
 - Token findings from E.2: era hues and surface/foreground tokens cover all needs; no new tokens required. Two deferred items crystallized:
-  - **`Button` destructive variant** — blocked on inline className override in the danger zone; add the variant to `button.tsx` in Batch G (editor primitives will need it for delete confirms)
-  - **Importance gradient tokens** (1–10 single-hue scale) — significance level currently renders as plain text; tokens and visual treatment land in Batch F when the list primitive consumes them
+  - **`Button` destructive variant** — implemented in Batch G (`button.tsx`) for delete-confirm surfaces
+  - **Importance gradient tokens** (1–10 single-hue scale) — implemented in Batch F list surfaces
 
-### Batch F — List primitives
+### Batch F — List primitives ✅ landed in [#160](https://github.com/shaes-farm/time-traveler/pull/160)
 
 Originally Batch D.
 
@@ -256,12 +256,15 @@ Originally Batch D.
 
 Originally Batch E.
 
+This batch tracks the refreshed scope from [#40](https://github.com/shaes-farm/time-traveler/issues/40) as an editor-primitives/documentation batch centered on `TemporalInput` and related editor controls. Route integration is intentionally excluded from Batch G and tracked separately.
+
 - `ChipInput` for `TEXT[]` fields (aliases, cultural_context, characteristics, tags)
 - `SlugField` with locked-by-default + manual unlock + warning per Batch 1 decision
 - `TemporalInput` composite popover (era picker, year/month/day, precision, uncertainty) using `TemporalDisplay` for the trigger button preview
 - `SaveDropdown` with curated-set "Save and add another" per Batch 5 decision
 - Auto-save toolbar indicator ("Draft saved at H:MM PM") per [#127](https://github.com/shaes-farm/time-traveler/issues/127) reconciliation
 - Composite stories: `Pages > Character Editor`, `Pages > Event Editor`
+- Supporting stories added for newly landed primitives consumed by editor/list surfaces: `Textarea`, `Checkbox`, `Slider`, `Table`, `DataTable`, `FilterRail`
 
 ### Batch H — Relationship editor
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,6 +53,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packages/ui/src/components/autosave-indicator.stories.tsx
+++ b/packages/ui/src/components/autosave-indicator.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { AutosaveIndicator } from "./autosave-indicator";
+
+const meta = {
+  title: "Components/Autosave Indicator",
+  component: AutosaveIndicator,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof AutosaveIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Saving: Story = {
+  args: {
+    isSaving: true,
+  },
+};
+
+export const Saved: Story = {
+  args: {
+    savedAt: new Date("2026-05-27T14:34:00Z"),
+  },
+};

--- a/packages/ui/src/components/autosave-indicator.test.tsx
+++ b/packages/ui/src/components/autosave-indicator.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AutosaveIndicator } from "./autosave-indicator";
+
+describe("AutosaveIndicator", () => {
+  it("shows the default label when nothing has been saved yet", () => {
+    render(<AutosaveIndicator />);
+    expect(screen.getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("shows the saving state", () => {
+    render(<AutosaveIndicator isSaving />);
+    expect(screen.getByText("Saving draft...")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/autosave-indicator.tsx
+++ b/packages/ui/src/components/autosave-indicator.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+export interface AutosaveIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  savedAt?: Date | string | null;
+  isSaving?: boolean;
+  label?: string;
+}
+
+const formatSavedAt = (value: Date | string): string => {
+  const date = value instanceof Date ? value : new Date(value);
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+};
+
+export function AutosaveIndicator({
+  savedAt,
+  isSaving = false,
+  label = "Draft saved",
+  className,
+  ...props
+}: AutosaveIndicatorProps) {
+  const text = isSaving
+    ? "Saving draft..."
+    : savedAt != null
+      ? `${label} at ${formatSavedAt(savedAt)}`
+      : label;
+
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "inline-flex items-center rounded-full border border-border bg-surface px-3 py-1 text-sm text-foreground-muted",
+        className,
+      )}
+      {...props}
+    >
+      {text}
+    </div>
+  );
+}

--- a/packages/ui/src/components/button.stories.tsx
+++ b/packages/ui/src/components/button.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["primary", "secondary", "ghost"],
+      options: ["primary", "secondary", "destructive", "ghost"],
     },
     size: {
       control: "select",
@@ -41,6 +41,14 @@ export const Secondary: Story = {
   },
 };
 
+export const Destructive: Story = {
+  args: {
+    variant: "destructive",
+    size: "md",
+    children: "Delete",
+  },
+};
+
 export const Ghost: Story = {
   args: {
     variant: "ghost",
@@ -55,6 +63,7 @@ export const AllVariants: Story = {
     <div className="flex gap-3">
       <Button variant="primary">Primary</Button>
       <Button variant="secondary">Secondary</Button>
+      <Button variant="destructive">Destructive</Button>
       <Button variant="ghost">Ghost</Button>
     </div>
   ),

--- a/packages/ui/src/components/button.test.tsx
+++ b/packages/ui/src/components/button.test.tsx
@@ -24,6 +24,11 @@ describe("Button", () => {
     expect(screen.getByRole("button")).toHaveClass("bg-surface");
   });
 
+  it("applies the destructive variant", () => {
+    render(<Button variant="destructive">Delete</Button>);
+    expect(screen.getByRole("button")).toHaveClass("bg-destructive");
+  });
+
   it("applies the ghost variant", () => {
     render(<Button variant="ghost">Skip</Button>);
     expect(screen.getByRole("button")).toHaveClass("hover:bg-surface");

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -6,10 +6,9 @@ import { cn } from "../lib/utils";
  * Button — the first design-system primitive (smoke test for the
  * Tailwind 4 + token pipeline).
  *
- * Variants currently cover only the foundational tokens defined in
- * `packages/ui/src/styles/tokens.css`. Additional variants
- * (destructive, link, etc.) will land alongside the screens that need
- * them in later batches.
+ * Variants currently cover the foundational tokens defined in
+ * `packages/ui/src/styles/tokens.css`. Additional variants land alongside
+ * the screens and primitives that need them.
  */
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20 disabled:pointer-events-none disabled:opacity-50",
@@ -19,6 +18,8 @@ const buttonVariants = cva(
         primary: "bg-primary text-primary-foreground hover:bg-primary/90",
         secondary:
           "border border-border bg-surface text-foreground hover:bg-surface-2",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         ghost: "text-foreground hover:bg-surface",
       },
       size: {

--- a/packages/ui/src/components/character-editor.stories.tsx
+++ b/packages/ui/src/components/character-editor.stories.tsx
@@ -1,0 +1,605 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  BookOpen,
+  Calendar,
+  Clock,
+  FolderTree,
+  GitBranch,
+  Image as ImageIcon,
+  LayoutDashboard,
+  UploadCloud,
+  Users,
+} from "lucide-react";
+import type { TemporalData } from "@repo/services/schemas/temporal.js";
+import { useUiStore } from "@repo/ui/stores";
+import { AutosaveIndicator } from "./autosave-indicator";
+import { Button } from "./button";
+import { ChipInput } from "./chip-input";
+import { Label } from "./label";
+import { SaveDropdown } from "./save-dropdown";
+import { Separator } from "./separator";
+import { Shell, type ShellNavItem, type ShellQuickCreateItem } from "./shell";
+import { SlugField } from "./slug-field";
+import { TemporalInput } from "./temporal-input";
+import { Textarea } from "./textarea";
+
+// ─── Shell fixture data ───────────────────────────────────────────────────────
+
+const NAV: ShellNavItem[] = [
+  { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Timelines", href: "/timelines", icon: GitBranch },
+  { label: "Events", href: "/events", icon: Calendar },
+  { label: "Characters", href: "/characters", icon: Users },
+  { label: "Periods", href: "/periods", icon: Clock },
+  { label: "Stories", href: "/stories", icon: BookOpen },
+  { label: "Categories", href: "/categories", icon: FolderTree },
+  { label: "Media", href: "/media", icon: ImageIcon },
+];
+
+const QUICK_CREATE: ShellQuickCreateItem[] = [
+  { label: "Character", href: "/characters/new" },
+  { label: "Event", href: "/events/new" },
+  { label: "Period", href: "/periods/new" },
+  { label: "Story", href: "/stories/new" },
+  { label: "Timeline", href: "/timelines/new" },
+  { label: "Category", href: "/categories/new" },
+  { label: "Media", href: "/media/new" },
+  { label: "Relationship", href: "/relationships/new" },
+];
+
+const SHELL_USER = { name: "Admin User", email: "admin@example.com" };
+
+// ─── Form types ───────────────────────────────────────────────────────────────
+
+type CharacterType =
+  | "human"
+  | "animal"
+  | "mythological"
+  | "fictional"
+  | "organization"
+  | "divine"
+  | "artifact";
+
+type Significance = "low" | "medium" | "high" | "critical";
+
+interface CharacterFormState {
+  name: string;
+  characterType: CharacterType;
+  slug: string;
+  aliases: string[];
+  culturalContext: string[];
+  biography: string;
+  physicalDescription: string;
+  birthDate: TemporalData | null;
+  deathDate: TemporalData | null;
+  significance: Significance;
+  published: boolean;
+}
+
+const BLANK_FORM: CharacterFormState = {
+  name: "",
+  characterType: "human",
+  slug: "",
+  aliases: [],
+  culturalContext: [],
+  biography: "",
+  physicalDescription: "",
+  birthDate: null,
+  deathDate: null,
+  significance: "medium",
+  published: false,
+};
+
+const MARIE_CURIE_FORM: CharacterFormState = {
+  name: "Marie Curie",
+  characterType: "human",
+  slug: "marie-curie",
+  aliases: ["Maria Skłodowska", "Madame Curie"],
+  culturalContext: ["Polish", "French"],
+  biography:
+    "Polish-French physicist and chemist. Pioneer of radioactivity research. " +
+    "First woman to win a Nobel Prize, first person to win in two scientific fields.",
+  physicalDescription: "Dark hair, gray eyes, slight build.",
+  birthDate: {
+    year: 1867,
+    era: "CE",
+    precision: "exact",
+    month: 11,
+    day: 7,
+  },
+  deathDate: {
+    year: 1934,
+    era: "CE",
+    precision: "exact",
+    month: 7,
+    day: 4,
+  },
+  significance: "critical",
+  published: true,
+};
+
+// ─── Layout primitives ────────────────────────────────────────────────────────
+
+const SECTION_HEADING_CLASS =
+  "mb-1.5 font-display text-sm font-normal text-foreground";
+const LABEL_CLASS = "mb-1.5 block text-sm font-medium text-foreground";
+const INPUT_CLASS =
+  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+const RADIO_LABEL_CLASS =
+  "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground has-[:checked]:bg-surface has-[:checked]:text-foreground";
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-4">
+      <h2 className={SECTION_HEADING_CLASS}>{children}</h2>
+      <Separator />
+    </div>
+  );
+}
+
+// ─── Character type radio grid ────────────────────────────────────────────────
+
+const CHARACTER_TYPES: { value: CharacterType; label: string }[] = [
+  { value: "human", label: "Human" },
+  { value: "animal", label: "Animal" },
+  { value: "mythological", label: "Mythological" },
+  { value: "fictional", label: "Fictional" },
+  { value: "organization", label: "Organization" },
+  { value: "divine", label: "Divine" },
+  { value: "artifact", label: "Artifact" },
+];
+
+function CharacterTypeRadio({
+  value,
+  onChange,
+}: {
+  value: CharacterType;
+  onChange: (v: CharacterType) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-0.5">
+      {CHARACTER_TYPES.map((t) => (
+        <label key={t.value} className={RADIO_LABEL_CLASS}>
+          <input
+            type="radio"
+            name="character-type"
+            value={t.value}
+            checked={value === t.value}
+            onChange={() => {
+              onChange(t.value);
+            }}
+            className="accent-primary h-3.5 w-3.5 shrink-0"
+          />
+          <span>{t.label}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+// ─── Significance radio group ─────────────────────────────────────────────────
+
+const SIGNIFICANCE_OPTIONS: { value: Significance; label: string }[] = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "critical", label: "Critical" },
+];
+
+function SignificanceRadio({
+  value,
+  onChange,
+}: {
+  value: Significance;
+  onChange: (v: Significance) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-0.5">
+      {SIGNIFICANCE_OPTIONS.map((s) => (
+        <label key={s.value} className={RADIO_LABEL_CLASS}>
+          <input
+            type="radio"
+            name="significance"
+            value={s.value}
+            checked={value === s.value}
+            onChange={() => {
+              onChange(s.value);
+            }}
+            className="accent-primary h-3.5 w-3.5 shrink-0"
+          />
+          <span>{s.label}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+// ─── Published toggle ─────────────────────────────────────────────────────────
+
+function PublishedToggle({
+  value,
+  onChange,
+}: {
+  value: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center gap-2.5 text-sm text-foreground">
+      <input
+        type="checkbox"
+        checked={value}
+        onChange={(e) => {
+          onChange(e.target.checked);
+        }}
+        className="accent-primary h-4 w-4 rounded"
+      />
+      <span>{value ? "Published" : "Draft — publish on save"}</span>
+    </label>
+  );
+}
+
+// ─── Main page component ──────────────────────────────────────────────────────
+
+interface CharacterEditorPageProps {
+  mode: "create" | "edit";
+  initialForm: CharacterFormState;
+  isSaving?: boolean;
+  savedAt?: Date | null;
+}
+
+function CharacterEditorPage({
+  mode,
+  initialForm,
+  isSaving = false,
+  savedAt = null,
+}: CharacterEditorPageProps) {
+  const [form, setForm] = React.useState<CharacterFormState>(initialForm);
+  const [autosaveAt, setAutosaveAt] = React.useState<Date | null>(savedAt);
+  const [autosaving, setAutosaving] = React.useState(isSaving);
+
+  const set = <K extends keyof CharacterFormState>(
+    key: K,
+    value: CharacterFormState[K],
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSave = () => {
+    setAutosaving(true);
+    window.setTimeout(() => {
+      setAutosaving(false);
+      setAutosaveAt(new Date());
+    }, 800);
+  };
+
+  const breadcrumbs =
+    mode === "create"
+      ? [
+          { label: "Characters", href: "/characters" },
+          { label: "New character" },
+        ]
+      : [
+          { label: "Characters", href: "/characters" },
+          { label: form.name || "Edit character" },
+        ];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* ── Toolbar ─────────────────────────────────────────────────────── */}
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-6 py-3">
+        <nav className="flex items-center gap-1 text-sm text-foreground-muted">
+          {breadcrumbs.map((crumb, i) => (
+            <React.Fragment key={crumb.label}>
+              {i > 0 && (
+                <span aria-hidden className="mx-1">
+                  ▸
+                </span>
+              )}
+              {crumb.href ? (
+                <button type="button" className="hover:text-foreground">
+                  {crumb.label}
+                </button>
+              ) : (
+                <span className="text-foreground">{crumb.label}</span>
+              )}
+            </React.Fragment>
+          ))}
+        </nav>
+
+        <div className="flex items-center gap-3">
+          <AutosaveIndicator isSaving={autosaving} savedAt={autosaveAt} />
+          <Button variant="ghost" size="sm">
+            Cancel
+          </Button>
+          <SaveDropdown
+            onSave={handleSave}
+            onSaveAndAddAnother={mode === "create" ? handleSave : undefined}
+            onSaveAsDraft={form.published ? handleSave : undefined}
+            onSaveAndPublish={!form.published ? handleSave : undefined}
+          />
+        </div>
+      </div>
+
+      {/* ── Body ────────────────────────────────────────────────────────── */}
+      <div className="flex flex-1 overflow-auto">
+        {/* Left column ── main form */}
+        <div className="flex-1 space-y-8 overflow-auto px-6 py-6">
+          {/* Identity section */}
+          <section>
+            <SectionHeading>Identity</SectionHeading>
+            <div className="space-y-5">
+              {/* Name */}
+              <div>
+                <Label htmlFor="char-name" className={LABEL_CLASS}>
+                  Name{" "}
+                  <span aria-label="required" className="text-destructive">
+                    *
+                  </span>
+                </Label>
+                <input
+                  id="char-name"
+                  className={INPUT_CLASS}
+                  value={form.name}
+                  onChange={(e) => {
+                    set("name", e.target.value);
+                  }}
+                  placeholder="Character name"
+                />
+              </div>
+
+              {/* Character type */}
+              <div>
+                <Label className={LABEL_CLASS}>
+                  Character type{" "}
+                  <span aria-label="required" className="text-destructive">
+                    *
+                  </span>
+                </Label>
+                <CharacterTypeRadio
+                  value={form.characterType}
+                  onChange={(v) => {
+                    set("characterType", v);
+                  }}
+                />
+              </div>
+
+              {/* Aliases */}
+              <div>
+                <ChipInput
+                  label="Aliases"
+                  value={form.aliases}
+                  onChange={(v) => {
+                    set("aliases", v);
+                  }}
+                  placeholder="Add alias"
+                  description="Press Enter or comma to add. Backspace removes the last alias."
+                />
+              </div>
+
+              {/* Cultural context */}
+              <div>
+                <ChipInput
+                  label="Cultural context"
+                  value={form.culturalContext}
+                  onChange={(v) => {
+                    set("culturalContext", v);
+                  }}
+                  placeholder="Add context"
+                />
+              </div>
+
+              {/* Biography */}
+              <div>
+                <Label htmlFor="char-bio" className={LABEL_CLASS}>
+                  Biography
+                </Label>
+                <Textarea
+                  id="char-bio"
+                  value={form.biography}
+                  onChange={(e) => {
+                    set("biography", e.target.value);
+                  }}
+                  placeholder="Write a biography…"
+                  className="min-h-[120px]"
+                />
+              </div>
+
+              {/* Physical description */}
+              <div>
+                <Label htmlFor="char-physical" className={LABEL_CLASS}>
+                  Physical description
+                </Label>
+                <Textarea
+                  id="char-physical"
+                  value={form.physicalDescription}
+                  onChange={(e) => {
+                    set("physicalDescription", e.target.value);
+                  }}
+                  placeholder="Describe physical appearance…"
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Temporal scope section */}
+          <section>
+            <SectionHeading>Temporal scope</SectionHeading>
+            <div className="space-y-4">
+              <TemporalInput
+                label="Birth date"
+                value={form.birthDate}
+                onChange={(v) => {
+                  set("birthDate", v);
+                }}
+              />
+              <TemporalInput
+                label="Death date"
+                value={form.deathDate}
+                onChange={(v) => {
+                  set("deathDate", v);
+                }}
+              />
+            </div>
+          </section>
+
+          {/* Profile media section */}
+          <section>
+            <SectionHeading>Profile media</SectionHeading>
+            <div className="flex h-28 items-center justify-center rounded-md border border-dashed border-border bg-surface/50 text-sm text-foreground-muted">
+              <div className="flex flex-col items-center gap-2">
+                <UploadCloud className="h-5 w-5 opacity-50" aria-hidden />
+                <span>Drop image or click to upload</span>
+              </div>
+            </div>
+          </section>
+
+          {/* Advanced (collapsed disclosure) */}
+          <section>
+            <details>
+              <summary className="cursor-pointer select-none text-sm text-foreground-muted hover:text-foreground">
+                ▸ Advanced (profile_data, metadata)
+              </summary>
+              <div className="mt-3 rounded-md border border-border bg-surface/30 px-4 py-3 text-xs text-foreground-muted">
+                JSON editor for <code>profile_data</code> and{" "}
+                <code>metadata</code> — power-user only.
+              </div>
+            </details>
+          </section>
+        </div>
+
+        {/* Right column ── metadata rail (fixed width, does not scroll) */}
+        <aside className="w-72 shrink-0 space-y-6 border-l border-border px-5 py-6">
+          {/* Slug */}
+          <div>
+            <SlugField
+              label="Slug"
+              value={form.slug}
+              onChange={(v) => {
+                set("slug", v);
+              }}
+              sourceValue={form.name}
+              mode={mode}
+              warning={
+                mode === "edit"
+                  ? "Changing the slug will break existing links to this character."
+                  : undefined
+              }
+              description="Auto-generated from name."
+            />
+          </div>
+
+          {/* Significance */}
+          <div>
+            <Label className={LABEL_CLASS}>Significance</Label>
+            <SignificanceRadio
+              value={form.significance}
+              onChange={(v) => {
+                set("significance", v);
+              }}
+            />
+          </div>
+
+          {/* Published */}
+          <div>
+            <Label className={LABEL_CLASS}>Published</Label>
+            <PublishedToggle
+              value={form.published}
+              onChange={(v) => {
+                set("published", v);
+              }}
+            />
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+// ─── Store reset ──────────────────────────────────────────────────────────────
+
+const shellLoaders = [
+  async () => {
+    useUiStore.setState({
+      sidebarOpen: true,
+      sidebarWidth: 280,
+      activeModal: null,
+      modalData: {},
+      toasts: [],
+    });
+    return {};
+  },
+];
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta = {
+  title: "Pages/Character Editor",
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+type Story = StoryObj;
+
+// ─── Stories ──────────────────────────────────────────────────────────────────
+
+export const CreateNew: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <Shell
+      nav={NAV}
+      currentPath="/characters"
+      user={SHELL_USER}
+      quickCreateItems={QUICK_CREATE}
+      breadcrumbs={[
+        { label: "Characters", href: "/characters" },
+        { label: "New character" },
+      ]}
+    >
+      <CharacterEditorPage mode="create" initialForm={BLANK_FORM} />
+    </Shell>
+  ),
+};
+
+export const EditExisting: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <Shell
+      nav={NAV}
+      currentPath="/characters"
+      user={SHELL_USER}
+      quickCreateItems={QUICK_CREATE}
+      breadcrumbs={[
+        { label: "Characters", href: "/characters" },
+        { label: "Marie Curie" },
+      ]}
+    >
+      <CharacterEditorPage
+        mode="edit"
+        initialForm={MARIE_CURIE_FORM}
+        savedAt={new Date("2026-05-27T14:34:00Z")}
+      />
+    </Shell>
+  ),
+};
+
+export const AutosaveInProgress: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <Shell
+      nav={NAV}
+      currentPath="/characters"
+      user={SHELL_USER}
+      quickCreateItems={QUICK_CREATE}
+      breadcrumbs={[
+        { label: "Characters", href: "/characters" },
+        { label: "Marie Curie" },
+      ]}
+    >
+      <CharacterEditorPage
+        mode="edit"
+        initialForm={MARIE_CURIE_FORM}
+        isSaving
+      />
+    </Shell>
+  ),
+};

--- a/packages/ui/src/components/checkbox.stories.tsx
+++ b/packages/ui/src/components/checkbox.stories.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Checkbox } from "./checkbox";
+import { Label } from "./label";
+
+const meta = {
+  title: "Components/Checkbox",
+  component: Checkbox,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function CheckboxWithLabel(args: React.ComponentProps<typeof Checkbox>) {
+  return (
+    <div className="flex items-center gap-2">
+      <Checkbox id="story-checkbox" {...args} />
+      <Label htmlFor="story-checkbox" className="font-normal">
+        Published
+      </Label>
+    </div>
+  );
+}
+
+export const Unchecked: Story = {
+  args: {
+    checked: false,
+    onCheckedChange: () => {},
+  },
+  render: (args) => <CheckboxWithLabel {...args} />,
+};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+    onCheckedChange: () => {},
+  },
+  render: (args) => <CheckboxWithLabel {...args} />,
+};
+
+export const Disabled: Story = {
+  args: {
+    checked: true,
+    disabled: true,
+    onCheckedChange: () => {},
+  },
+  render: (args) => <CheckboxWithLabel {...args} />,
+};

--- a/packages/ui/src/components/chip-input.stories.tsx
+++ b/packages/ui/src/components/chip-input.stories.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ChipInput } from "./chip-input";
+
+const meta = {
+  title: "Components/Chip Input",
+  component: ChipInput,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof ChipInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ChipInputStory() {
+  const [chips, setChips] = useState(["aliases", "cultural context"]);
+
+  return <ChipInput label="Tags" value={chips} onChange={setChips} />;
+}
+
+export const Default: Story = {
+  args: {
+    value: [],
+    onChange: () => {},
+  },
+  render: () => <ChipInputStory />,
+};

--- a/packages/ui/src/components/chip-input.test.tsx
+++ b/packages/ui/src/components/chip-input.test.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChipInput } from "./chip-input";
+
+function ChipInputHarness() {
+  const [chips, setChips] = useState(["alpha"]);
+
+  return <ChipInput label="Tags" value={chips} onChange={setChips} />;
+}
+
+describe("ChipInput", () => {
+  it("adds chips with Enter and removes the last chip with Backspace", async () => {
+    const user = userEvent.setup();
+    render(<ChipInputHarness />);
+
+    const input = screen.getByLabelText("Tags");
+    await user.type(input, "beta{Enter}");
+    expect(screen.getByText("beta")).toBeInTheDocument();
+
+    await user.keyboard("{Backspace}");
+    expect(screen.queryByText("beta")).not.toBeInTheDocument();
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+  });
+
+  it("removes a chip from the chip action button", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <ChipInput label="Tags" value={["alpha", "beta"]} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove beta" }));
+    expect(onChange).toHaveBeenCalledWith(["alpha"]);
+  });
+});

--- a/packages/ui/src/components/chip-input.tsx
+++ b/packages/ui/src/components/chip-input.tsx
@@ -15,7 +15,6 @@ export interface ChipInputProps extends Omit<
   onChange: (value: string[]) => void;
   label?: string;
   description?: string;
-  allowDuplicates?: boolean;
 }
 
 const normalizeChip = (chip: string): string => chip.trim();
@@ -30,7 +29,6 @@ export const ChipInput = React.forwardRef<HTMLInputElement, ChipInputProps>(
       onChange,
       label,
       description,
-      allowDuplicates = false,
       className,
       id,
       onKeyDown,
@@ -74,7 +72,7 @@ export const ChipInput = React.forwardRef<HTMLInputElement, ChipInputProps>(
 
         for (const chip of chips) {
           const exists = next.some((entry) => sameChip(entry, chip));
-          if (!allowDuplicates && exists) continue;
+          if (exists) continue;
           next.push(chip);
           added += 1;
         }
@@ -83,7 +81,7 @@ export const ChipInput = React.forwardRef<HTMLInputElement, ChipInputProps>(
           commitChips(next, `${added} chip${added === 1 ? "" : "s"} added`);
         }
       },
-      [allowDuplicates, commitChips, value],
+      [commitChips, value],
     );
 
     const removeChip = React.useCallback(

--- a/packages/ui/src/components/chip-input.tsx
+++ b/packages/ui/src/components/chip-input.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+
+import { Button } from "./button";
+import { Input } from "./input";
+import { cn } from "@repo/ui/lib/utils";
+
+export interface ChipInputProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof Input>,
+  "value" | "onChange"
+> {
+  value: string[];
+  onChange: (value: string[]) => void;
+  label?: string;
+  description?: string;
+  allowDuplicates?: boolean;
+}
+
+const normalizeChip = (chip: string): string => chip.trim();
+
+const sameChip = (left: string, right: string): boolean =>
+  left.localeCompare(right, undefined, { sensitivity: "accent" }) === 0;
+
+export const ChipInput = React.forwardRef<HTMLInputElement, ChipInputProps>(
+  (
+    {
+      value,
+      onChange,
+      label,
+      description,
+      allowDuplicates = false,
+      className,
+      id,
+      onKeyDown,
+      onPaste,
+      placeholder = "Add item",
+      ...props
+    },
+    ref,
+  ) => {
+    const [inputValue, setInputValue] = React.useState("");
+    const [announcement, setAnnouncement] = React.useState("");
+    const inputId = React.useId();
+    const helperId = React.useId();
+    const resolvedId = id ?? inputId;
+    const filteredDescription = description
+      ? `${resolvedId}-description`
+      : undefined;
+
+    const announce = React.useCallback((message: string) => {
+      setAnnouncement(message);
+    }, []);
+
+    const commitChips = React.useCallback(
+      (next: string[], message?: string) => {
+        onChange(next);
+        if (message) {
+          announce(message);
+        }
+      },
+      [announce, onChange],
+    );
+
+    const addFromText = React.useCallback(
+      (text: string) => {
+        const chips = text.split(",").map(normalizeChip).filter(Boolean);
+
+        if (chips.length === 0) return;
+
+        const next = [...value];
+        let added = 0;
+
+        for (const chip of chips) {
+          const exists = next.some((entry) => sameChip(entry, chip));
+          if (!allowDuplicates && exists) continue;
+          next.push(chip);
+          added += 1;
+        }
+
+        if (added > 0) {
+          commitChips(next, `${added} chip${added === 1 ? "" : "s"} added`);
+        }
+      },
+      [allowDuplicates, commitChips, value],
+    );
+
+    const removeChip = React.useCallback(
+      (chip: string) => {
+        commitChips(
+          value.filter((entry) => entry !== chip),
+          `${chip} removed`,
+        );
+      },
+      [commitChips, value],
+    );
+
+    const handleKeyDown = React.useCallback<
+      React.KeyboardEventHandler<HTMLInputElement>
+    >(
+      (event) => {
+        onKeyDown?.(event);
+        if (event.defaultPrevented) return;
+
+        if (event.key === "Enter" || event.key === ",") {
+          event.preventDefault();
+          const nextValue = normalizeChip(inputValue);
+          if (nextValue.length > 0) {
+            addFromText(nextValue);
+            setInputValue("");
+          }
+          return;
+        }
+
+        if (
+          event.key === "Backspace" &&
+          inputValue.length === 0 &&
+          value.length > 0
+        ) {
+          event.preventDefault();
+          const next = value.slice(0, -1);
+          const removed = value[value.length - 1];
+          if (removed != null) {
+            commitChips(next, `${removed} removed`);
+          }
+        }
+      },
+      [addFromText, commitChips, inputValue, onKeyDown, value],
+    );
+
+    const handlePaste = React.useCallback<
+      React.ClipboardEventHandler<HTMLInputElement>
+    >(
+      (event) => {
+        onPaste?.(event);
+        if (event.defaultPrevented) return;
+
+        const pasted = event.clipboardData.getData("text");
+        if (!pasted.includes(",")) return;
+        event.preventDefault();
+        addFromText(pasted);
+      },
+      [addFromText, onPaste],
+    );
+
+    return (
+      <div className="space-y-2">
+        {label && (
+          <label
+            htmlFor={resolvedId}
+            className="text-sm font-medium text-foreground"
+          >
+            {label}
+          </label>
+        )}
+        <div
+          className={cn(
+            "flex min-h-10 flex-wrap items-center gap-2 rounded-md border border-border bg-background px-3 py-2",
+            className,
+          )}
+        >
+          {value.map((chip) => (
+            <span
+              key={chip}
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-2 py-1 text-sm text-foreground"
+            >
+              <span>{chip}</span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-5 w-5 rounded-full p-0"
+                onClick={() => removeChip(chip)}
+                aria-label={`Remove ${chip}`}
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            </span>
+          ))}
+          <Input
+            {...props}
+            ref={ref}
+            id={resolvedId}
+            value={inputValue}
+            placeholder={placeholder}
+            className={cn(
+              "h-auto min-h-7 flex-1 border-0 bg-transparent p-0 shadow-none focus-visible:ring-0",
+              props.disabled && "cursor-not-allowed",
+            )}
+            aria-describedby={
+              description ? filteredDescription : props["aria-describedby"]
+            }
+            onChange={(event) => setInputValue(event.target.value)}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+          />
+        </div>
+        {description && (
+          <p id={filteredDescription} className="text-xs text-foreground-muted">
+            {description}
+          </p>
+        )}
+        <p aria-live="polite" className="sr-only">
+          {announcement}
+        </p>
+        <span id={helperId} className="sr-only">
+          Chip input
+        </span>
+      </div>
+    );
+  },
+);
+ChipInput.displayName = "ChipInput";

--- a/packages/ui/src/components/data-table.stories.tsx
+++ b/packages/ui/src/components/data-table.stories.tsx
@@ -1,0 +1,125 @@
+import * as React from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Badge } from "./badge";
+import { DataTable, createSelectColumn } from "./data-table";
+import { StatusBadge } from "./status-badge";
+
+interface CharacterRow {
+  id: string;
+  name: string;
+  type: string;
+  era: string;
+  status: "published" | "draft" | "shared";
+  events: number;
+}
+
+const rows: CharacterRow[] = [
+  {
+    id: "1",
+    name: "Marie Curie",
+    type: "Human",
+    era: "CE",
+    status: "published",
+    events: 12,
+  },
+  {
+    id: "2",
+    name: "Ra",
+    type: "Mythological",
+    era: "BCE",
+    status: "published",
+    events: 8,
+  },
+  {
+    id: "3",
+    name: "Don Quixote",
+    type: "Fictional",
+    era: "CE",
+    status: "draft",
+    events: 5,
+  },
+];
+
+const columns: ColumnDef<CharacterRow>[] = [
+  createSelectColumn<CharacterRow>(),
+  {
+    accessorKey: "name",
+    header: "Name",
+    cell: ({ row }) => (
+      <span className="font-medium text-foreground">{row.original.name}</span>
+    ),
+  },
+  {
+    accessorKey: "type",
+    header: "Type",
+    cell: ({ getValue }) => (
+      <Badge variant="outline" className="text-xs">
+        {getValue() as string}
+      </Badge>
+    ),
+  },
+  {
+    accessorKey: "era",
+    header: "Era",
+    cell: ({ getValue }) => (
+      <span className="font-mono text-xs text-foreground-muted">
+        {getValue() as string}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ getValue }) => (
+      <StatusBadge status={getValue() as CharacterRow["status"]} />
+    ),
+  },
+  {
+    accessorKey: "events",
+    header: "Events",
+    cell: ({ getValue }) => (
+      <span className="tabular-nums text-foreground-muted">
+        {getValue() as number}
+      </span>
+    ),
+  },
+];
+
+const meta = {
+  title: "Components/DataTable",
+  parameters: { layout: "padded" },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ClickableTable() {
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+
+  return (
+    <div className="space-y-3">
+      <DataTable
+        columns={columns}
+        data={rows}
+        onRowClick={(row) => setSelectedId(row.id)}
+      />
+      <p className="text-sm text-foreground-muted">
+        Selected row: {selectedId ?? "None"}
+      </p>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <DataTable columns={columns} data={rows} />,
+};
+
+export const RowClick: Story = {
+  render: () => <ClickableTable />,
+};
+
+export const EmptyState: Story = {
+  render: () => <DataTable columns={columns} data={[]} />,
+};

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      "z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
       className,
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
         className,
       )}
       {...props}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     {...props}

--- a/packages/ui/src/components/event-editor.stories.tsx
+++ b/packages/ui/src/components/event-editor.stories.tsx
@@ -1,0 +1,892 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  BookOpen,
+  Calendar,
+  Clock,
+  FolderTree,
+  GitBranch,
+  Image as ImageIcon,
+  LayoutDashboard,
+  Minus,
+  Plus,
+  Users,
+  X,
+} from "lucide-react";
+import type { TemporalData } from "@repo/services/schemas/temporal.js";
+import { useUiStore } from "@repo/ui/stores";
+import { AutosaveIndicator } from "./autosave-indicator";
+import { Avatar, AvatarFallback } from "./avatar";
+import { Button } from "./button";
+import { ChipInput } from "./chip-input";
+import { Label } from "./label";
+import { SaveDropdown } from "./save-dropdown";
+import { Separator } from "./separator";
+import { Shell, type ShellNavItem, type ShellQuickCreateItem } from "./shell";
+import { SlugField } from "./slug-field";
+import { Slider } from "./slider";
+import { TemporalInput } from "./temporal-input";
+import { Textarea } from "./textarea";
+
+// ─── Shell fixture data ───────────────────────────────────────────────────────
+
+const NAV: ShellNavItem[] = [
+  { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Timelines", href: "/timelines", icon: GitBranch },
+  { label: "Events", href: "/events", icon: Calendar },
+  { label: "Characters", href: "/characters", icon: Users },
+  { label: "Periods", href: "/periods", icon: Clock },
+  { label: "Stories", href: "/stories", icon: BookOpen },
+  { label: "Categories", href: "/categories", icon: FolderTree },
+  { label: "Media", href: "/media", icon: ImageIcon },
+];
+
+const QUICK_CREATE: ShellQuickCreateItem[] = [
+  { label: "Character", href: "/characters/new" },
+  { label: "Event", href: "/events/new" },
+  { label: "Period", href: "/periods/new" },
+  { label: "Story", href: "/stories/new" },
+  { label: "Timeline", href: "/timelines/new" },
+  { label: "Category", href: "/categories/new" },
+  { label: "Media", href: "/media/new" },
+  { label: "Relationship", href: "/relationships/new" },
+];
+
+const SHELL_USER = { name: "Admin User", email: "admin@example.com" };
+
+// ─── Form types ───────────────────────────────────────────────────────────────
+
+type EventType =
+  | "milestone"
+  | "period"
+  | "incident"
+  | "discovery"
+  | "creation"
+  | "destruction"
+  | "transformation"
+  | "migration"
+  | "conflict"
+  | "ceremony";
+
+type ParticipantRole =
+  | "protagonist"
+  | "antagonist"
+  | "witness"
+  | "victim"
+  | "beneficiary"
+  | "organizer"
+  | "participant"
+  | "bystander";
+
+type ParticipantSignificance = "primary" | "secondary" | "minor" | "background";
+
+interface Participant {
+  id: string;
+  name: string;
+  initials: string;
+  role: ParticipantRole;
+  significance: ParticipantSignificance;
+  note: string;
+}
+
+interface EventFormState {
+  title: string;
+  slug: string;
+  summary: string;
+  detail: string;
+  eventType: EventType;
+  startDate: TemporalData | null;
+  endDate: TemporalData | null;
+  location: string;
+  latDeg: string;
+  lngDeg: string;
+  parentEvent: string;
+  timeline: string;
+  participants: Participant[];
+  categories: string[];
+  importance: number;
+  published: boolean;
+}
+
+const BLANK_FORM: EventFormState = {
+  title: "",
+  slug: "",
+  summary: "",
+  detail: "",
+  eventType: "milestone",
+  startDate: null,
+  endDate: null,
+  location: "",
+  latDeg: "",
+  lngDeg: "",
+  parentEvent: "",
+  timeline: "",
+  participants: [],
+  categories: [],
+  importance: 5,
+  published: false,
+};
+
+const POLONIUM_FORM: EventFormState = {
+  title: "Discovery of polonium",
+  slug: "discovery-of-polonium",
+  summary:
+    "Marie and Pierre Curie isolate polonium, the first new element identified through radioactivity research.",
+  detail:
+    "In 1898, Marie and Pierre Curie announced the discovery of a new radioactive element, " +
+    "which they named polonium after Marie's homeland. This marked the first element discovered " +
+    "through the novel technique of tracking radioactivity.",
+  eventType: "discovery",
+  startDate: { year: 1898, era: "CE", precision: "exact" },
+  endDate: null,
+  location: "Paris, France",
+  latDeg: "48.8566",
+  lngDeg: "2.3522",
+  parentEvent: "Curies' radium research",
+  timeline: "Curie biography",
+  participants: [
+    {
+      id: "1",
+      name: "Marie Curie",
+      initials: "MC",
+      role: "protagonist",
+      significance: "primary",
+      note: "Led the isolation of polonium",
+    },
+    {
+      id: "2",
+      name: "Pierre Curie",
+      initials: "PC",
+      role: "protagonist",
+      significance: "primary",
+      note: "",
+    },
+  ],
+  categories: ["Physics", "Discovery"],
+  importance: 8,
+  published: true,
+};
+
+// ─── Layout primitives ────────────────────────────────────────────────────────
+
+const LABEL_CLASS = "mb-1.5 block text-sm font-medium text-foreground";
+const INPUT_CLASS =
+  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+const SELECT_CLASS =
+  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-4">
+      <h2 className="mb-1.5 font-display text-sm font-normal text-foreground">
+        {children}
+      </h2>
+      <Separator />
+    </div>
+  );
+}
+
+// ─── Event type options ───────────────────────────────────────────────────────
+
+const EVENT_TYPE_OPTIONS: { value: EventType; label: string }[] = [
+  { value: "milestone", label: "Milestone" },
+  { value: "period", label: "Period" },
+  { value: "incident", label: "Incident" },
+  { value: "discovery", label: "Discovery" },
+  { value: "creation", label: "Creation" },
+  { value: "destruction", label: "Destruction" },
+  { value: "transformation", label: "Transformation" },
+  { value: "migration", label: "Migration" },
+  { value: "conflict", label: "Conflict" },
+  { value: "ceremony", label: "Ceremony" },
+];
+
+const ROLE_OPTIONS: { value: ParticipantRole; label: string }[] = [
+  { value: "protagonist", label: "Protagonist" },
+  { value: "antagonist", label: "Antagonist" },
+  { value: "witness", label: "Witness" },
+  { value: "victim", label: "Victim" },
+  { value: "beneficiary", label: "Beneficiary" },
+  { value: "organizer", label: "Organizer" },
+  { value: "participant", label: "Participant" },
+  { value: "bystander", label: "Bystander" },
+];
+
+const SIGNIFICANCE_OPTIONS: {
+  value: ParticipantSignificance;
+  label: string;
+}[] = [
+  { value: "primary", label: "Primary" },
+  { value: "secondary", label: "Secondary" },
+  { value: "minor", label: "Minor" },
+  { value: "background", label: "Background" },
+];
+
+// ─── Published toggle ─────────────────────────────────────────────────────────
+
+function PublishedToggle({
+  value,
+  onChange,
+}: {
+  value: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center gap-2.5 text-sm text-foreground">
+      <input
+        type="checkbox"
+        checked={value}
+        onChange={(e) => {
+          onChange(e.target.checked);
+        }}
+        className="accent-primary h-4 w-4 rounded"
+      />
+      <span>{value ? "Published" : "Draft — publish on save"}</span>
+    </label>
+  );
+}
+
+// ─── Participant card ─────────────────────────────────────────────────────────
+
+function ParticipantCard({
+  participant,
+  onChange,
+  onRemove,
+}: {
+  participant: Participant;
+  onChange: (updated: Participant) => void;
+  onRemove: () => void;
+}) {
+  const set = <K extends keyof Participant>(key: K, val: Participant[K]) => {
+    onChange({ ...participant, [key]: val });
+  };
+
+  return (
+    <div className="relative rounded-md border border-border bg-surface/40 px-4 py-3">
+      <button
+        type="button"
+        aria-label={`Remove ${participant.name}`}
+        onClick={onRemove}
+        className="absolute right-3 top-3 rounded text-foreground-muted hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden />
+      </button>
+
+      <div className="flex items-start gap-3">
+        <Avatar className="h-9 w-9 shrink-0">
+          <AvatarFallback className="text-xs">
+            {participant.initials}
+          </AvatarFallback>
+        </Avatar>
+
+        <div className="flex-1 space-y-2 pr-6">
+          <p className="text-sm font-medium text-foreground">
+            {participant.name}
+          </p>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="mb-1 block text-xs text-foreground-muted">
+                Role
+              </label>
+              <select
+                className={`${SELECT_CLASS} h-8 py-1 text-xs`}
+                value={participant.role}
+                onChange={(e) => {
+                  set("role", e.target.value as ParticipantRole);
+                }}
+              >
+                {ROLE_OPTIONS.map((r) => (
+                  <option key={r.value} value={r.value}>
+                    {r.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-foreground-muted">
+                Significance
+              </label>
+              <select
+                className={`${SELECT_CLASS} h-8 py-1 text-xs`}
+                value={participant.significance}
+                onChange={(e) => {
+                  set(
+                    "significance",
+                    e.target.value as ParticipantSignificance,
+                  );
+                }}
+              >
+                {SIGNIFICANCE_OPTIONS.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <input
+            className={`${INPUT_CLASS} h-8 py-1 text-xs`}
+            value={participant.note}
+            onChange={(e) => {
+              set("note", e.target.value);
+            }}
+            placeholder="Optional note for this participant's role…"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main page component ──────────────────────────────────────────────────────
+
+interface EventEditorPageProps {
+  mode: "create" | "edit";
+  initialForm: EventFormState;
+  isSaving?: boolean;
+  savedAt?: Date | null;
+}
+
+function EventEditorPage({
+  mode,
+  initialForm,
+  isSaving = false,
+  savedAt = null,
+}: EventEditorPageProps) {
+  const [form, setForm] = React.useState<EventFormState>(initialForm);
+  const [autosaveAt, setAutosaveAt] = React.useState<Date | null>(savedAt);
+  const [autosaving, setAutosaving] = React.useState(isSaving);
+
+  const set = <K extends keyof EventFormState>(
+    key: K,
+    value: EventFormState[K],
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSave = () => {
+    setAutosaving(true);
+    window.setTimeout(() => {
+      setAutosaving(false);
+      setAutosaveAt(new Date());
+    }, 800);
+  };
+
+  const updateParticipant = (id: string, updated: Participant) => {
+    setForm((prev) => ({
+      ...prev,
+      participants: prev.participants.map((p) => (p.id === id ? updated : p)),
+    }));
+  };
+
+  const removeParticipant = (id: string) => {
+    setForm((prev) => ({
+      ...prev,
+      participants: prev.participants.filter((p) => p.id !== id),
+    }));
+  };
+
+  const breadcrumbs =
+    mode === "create"
+      ? [{ label: "Events", href: "/events" }, { label: "New event" }]
+      : [
+          { label: "Events", href: "/events" },
+          { label: form.title || "Edit event" },
+        ];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* ── Toolbar ─────────────────────────────────────────────────────── */}
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-6 py-3">
+        <nav className="flex items-center gap-1 text-sm text-foreground-muted">
+          {breadcrumbs.map((crumb, i) => (
+            <React.Fragment key={crumb.label}>
+              {i > 0 && (
+                <span aria-hidden className="mx-1">
+                  ▸
+                </span>
+              )}
+              {crumb.href ? (
+                <button type="button" className="hover:text-foreground">
+                  {crumb.label}
+                </button>
+              ) : (
+                <span className="text-foreground">{crumb.label}</span>
+              )}
+            </React.Fragment>
+          ))}
+        </nav>
+
+        <div className="flex items-center gap-3">
+          <AutosaveIndicator isSaving={autosaving} savedAt={autosaveAt} />
+          <Button variant="ghost" size="sm">
+            Cancel
+          </Button>
+          <SaveDropdown
+            onSave={handleSave}
+            onSaveAndAddAnother={mode === "create" ? handleSave : undefined}
+            onSaveAsDraft={form.published ? handleSave : undefined}
+            onSaveAndPublish={!form.published ? handleSave : undefined}
+          />
+        </div>
+      </div>
+
+      {/* ── Body ────────────────────────────────────────────────────────── */}
+      <div className="flex flex-1 overflow-auto">
+        {/* Left column ── main form */}
+        <div className="flex-1 space-y-8 overflow-auto px-6 py-6">
+          {/* Identity section */}
+          <section>
+            <SectionHeading>Identity</SectionHeading>
+            <div className="space-y-5">
+              {/* Title */}
+              <div>
+                <Label htmlFor="event-title" className={LABEL_CLASS}>
+                  Title{" "}
+                  <span aria-label="required" className="text-destructive">
+                    *
+                  </span>
+                </Label>
+                <input
+                  id="event-title"
+                  className={INPUT_CLASS}
+                  value={form.title}
+                  onChange={(e) => {
+                    set("title", e.target.value);
+                  }}
+                  placeholder="Event title"
+                />
+              </div>
+
+              {/* Event type */}
+              <div>
+                <Label htmlFor="event-type" className={LABEL_CLASS}>
+                  Type{" "}
+                  <span aria-label="required" className="text-destructive">
+                    *
+                  </span>
+                </Label>
+                <select
+                  id="event-type"
+                  className={SELECT_CLASS}
+                  value={form.eventType}
+                  onChange={(e) => {
+                    set("eventType", e.target.value as EventType);
+                  }}
+                >
+                  {EVENT_TYPE_OPTIONS.map((t) => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Summary */}
+              <div>
+                <Label htmlFor="event-summary" className={LABEL_CLASS}>
+                  Summary
+                </Label>
+                <Textarea
+                  id="event-summary"
+                  value={form.summary}
+                  onChange={(e) => {
+                    set("summary", e.target.value);
+                  }}
+                  placeholder="One-paragraph summary…"
+                  className="min-h-[80px]"
+                />
+              </div>
+
+              {/* Detail */}
+              <div>
+                <Label htmlFor="event-detail" className={LABEL_CLASS}>
+                  Detail
+                </Label>
+                <Textarea
+                  id="event-detail"
+                  value={form.detail}
+                  onChange={(e) => {
+                    set("detail", e.target.value);
+                  }}
+                  placeholder="Long-form narrative…"
+                  className="min-h-[160px]"
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* When section */}
+          <section>
+            <SectionHeading>When</SectionHeading>
+            <div className="space-y-4">
+              <TemporalInput
+                label="Start date"
+                required
+                value={form.startDate}
+                onChange={(v) => {
+                  set("startDate", v);
+                }}
+              />
+              <TemporalInput
+                label="End date"
+                value={form.endDate}
+                onChange={(v) => {
+                  set("endDate", v);
+                }}
+              />
+            </div>
+          </section>
+
+          {/* Where section */}
+          <section>
+            <SectionHeading>Where</SectionHeading>
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="event-location" className={LABEL_CLASS}>
+                  Location
+                </Label>
+                <input
+                  id="event-location"
+                  className={INPUT_CLASS}
+                  value={form.location}
+                  onChange={(e) => {
+                    set("location", e.target.value);
+                  }}
+                  placeholder="Place name or description"
+                />
+              </div>
+              <div>
+                <Label className={LABEL_CLASS}>Coordinates</Label>
+                <div className="flex gap-3">
+                  <div className="flex-1">
+                    <input
+                      aria-label="Latitude"
+                      className={INPUT_CLASS}
+                      type="number"
+                      step="any"
+                      min={-90}
+                      max={90}
+                      value={form.latDeg}
+                      onChange={(e) => {
+                        set("latDeg", e.target.value);
+                      }}
+                      placeholder="Latitude"
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <input
+                      aria-label="Longitude"
+                      className={INPUT_CLASS}
+                      type="number"
+                      step="any"
+                      min={-180}
+                      max={180}
+                      value={form.lngDeg}
+                      onChange={(e) => {
+                        set("lngDeg", e.target.value);
+                      }}
+                      placeholder="Longitude"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* Lineage section */}
+          <section>
+            <SectionHeading>Lineage</SectionHeading>
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="event-parent" className={LABEL_CLASS}>
+                  Parent event
+                </Label>
+                <input
+                  id="event-parent"
+                  className={INPUT_CLASS}
+                  value={form.parentEvent}
+                  onChange={(e) => {
+                    set("parentEvent", e.target.value);
+                  }}
+                  placeholder="Search for a parent event…"
+                />
+              </div>
+              <div>
+                <Label htmlFor="event-timeline" className={LABEL_CLASS}>
+                  Timeline
+                </Label>
+                <input
+                  id="event-timeline"
+                  className={INPUT_CLASS}
+                  value={form.timeline}
+                  onChange={(e) => {
+                    set("timeline", e.target.value);
+                  }}
+                  placeholder="Search for a timeline…"
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Participants section */}
+          <section>
+            <SectionHeading>
+              Participants{" "}
+              {form.participants.length > 0 && (
+                <span className="text-foreground-muted">
+                  ({form.participants.length})
+                </span>
+              )}
+            </SectionHeading>
+            <div className="space-y-3">
+              {form.participants.map((p) => (
+                <ParticipantCard
+                  key={p.id}
+                  participant={p}
+                  onChange={(updated) => {
+                    updateParticipant(p.id, updated);
+                  }}
+                  onRemove={() => {
+                    removeParticipant(p.id);
+                  }}
+                />
+              ))}
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="gap-1.5"
+                onClick={() => {
+                  const next: Participant = {
+                    id: String(Date.now()),
+                    name: "New participant",
+                    initials: "NP",
+                    role: "participant",
+                    significance: "secondary",
+                    note: "",
+                  };
+                  setForm((prev) => ({
+                    ...prev,
+                    participants: [...prev.participants, next],
+                  }));
+                }}
+              >
+                <Plus className="h-3.5 w-3.5" aria-hidden />
+                Add participant
+              </Button>
+            </div>
+          </section>
+
+          {/* Categories section */}
+          <section>
+            <SectionHeading>Categories</SectionHeading>
+            <ChipInput
+              value={form.categories}
+              onChange={(v) => {
+                set("categories", v);
+              }}
+              placeholder="Add category"
+              description="Press Enter or comma to add."
+            />
+          </section>
+
+          {/* Media section */}
+          <section>
+            <SectionHeading>Media</SectionHeading>
+            <div className="flex items-center gap-3">
+              <div className="flex h-16 w-16 items-center justify-center rounded border border-dashed border-border bg-surface/50 text-foreground-muted">
+                <ImageIcon className="h-4 w-4 opacity-40" aria-hidden />
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="gap-1.5"
+              >
+                <Plus className="h-3.5 w-3.5" aria-hidden />
+                Attach
+              </Button>
+            </div>
+          </section>
+
+          {/* Advanced (collapsed disclosure) */}
+          <section>
+            <details>
+              <summary className="cursor-pointer select-none text-sm text-foreground-muted hover:text-foreground">
+                ▸ Advanced (metadata, spatial JSON)
+              </summary>
+              <div className="mt-3 rounded-md border border-border bg-surface/30 px-4 py-3 text-xs text-foreground-muted">
+                JSON editor for <code>metadata</code> and{" "}
+                <code>spatial_data</code> — power-user only.
+              </div>
+            </details>
+          </section>
+        </div>
+
+        {/* Right column ── metadata rail (fixed width, does not scroll) */}
+        <aside className="w-72 shrink-0 space-y-6 border-l border-border px-5 py-6">
+          {/* Slug */}
+          <div>
+            <SlugField
+              label="Slug"
+              value={form.slug}
+              onChange={(v) => {
+                set("slug", v);
+              }}
+              sourceValue={form.title}
+              mode={mode}
+              warning={
+                mode === "edit"
+                  ? "Changing the slug will break existing links to this event."
+                  : undefined
+              }
+              description="Auto-generated from title."
+            />
+          </div>
+
+          {/* Importance slider */}
+          <div>
+            <Label className={LABEL_CLASS}>Importance (1–10)</Label>
+            <div className="flex items-center gap-3 pt-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label="Decrease importance"
+                className="h-7 w-7 shrink-0 p-0"
+                onClick={() => {
+                  set("importance", Math.max(1, form.importance - 1));
+                }}
+              >
+                <Minus className="h-3.5 w-3.5" aria-hidden />
+              </Button>
+              <Slider
+                min={1}
+                max={10}
+                step={1}
+                value={[form.importance]}
+                onValueChange={([val]) => {
+                  if (val !== undefined) set("importance", val);
+                }}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label="Increase importance"
+                className="h-7 w-7 shrink-0 p-0"
+                onClick={() => {
+                  set("importance", Math.min(10, form.importance + 1));
+                }}
+              >
+                <Plus className="h-3.5 w-3.5" aria-hidden />
+              </Button>
+              <span className="w-4 shrink-0 text-right font-mono text-sm tabular-nums text-foreground">
+                {form.importance}
+              </span>
+            </div>
+          </div>
+
+          {/* Published */}
+          <div>
+            <Label className={LABEL_CLASS}>Published</Label>
+            <PublishedToggle
+              value={form.published}
+              onChange={(v) => {
+                set("published", v);
+              }}
+            />
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+// ─── Store reset ──────────────────────────────────────────────────────────────
+
+const shellLoaders = [
+  async () => {
+    useUiStore.setState({
+      sidebarOpen: true,
+      sidebarWidth: 280,
+      activeModal: null,
+      modalData: {},
+      toasts: [],
+    });
+    return {};
+  },
+];
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta = {
+  title: "Pages/Event Editor",
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+type Story = StoryObj;
+
+// ─── Stories ──────────────────────────────────────────────────────────────────
+
+export const CreateNew: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <Shell
+      nav={NAV}
+      currentPath="/events"
+      user={SHELL_USER}
+      quickCreateItems={QUICK_CREATE}
+      breadcrumbs={[
+        { label: "Events", href: "/events" },
+        { label: "New event" },
+      ]}
+    >
+      <EventEditorPage mode="create" initialForm={BLANK_FORM} />
+    </Shell>
+  ),
+};
+
+export const WithParticipants: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <Shell
+      nav={NAV}
+      currentPath="/events"
+      user={SHELL_USER}
+      quickCreateItems={QUICK_CREATE}
+      breadcrumbs={[
+        { label: "Events", href: "/events" },
+        { label: "Discovery of polonium" },
+      ]}
+    >
+      <EventEditorPage mode="create" initialForm={POLONIUM_FORM} />
+    </Shell>
+  ),
+};
+
+export const EditExisting: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <Shell
+      nav={NAV}
+      currentPath="/events"
+      user={SHELL_USER}
+      quickCreateItems={QUICK_CREATE}
+      breadcrumbs={[
+        { label: "Events", href: "/events" },
+        { label: "Discovery of polonium" },
+      ]}
+    >
+      <EventEditorPage
+        mode="edit"
+        initialForm={POLONIUM_FORM}
+        savedAt={new Date("2026-05-27T14:34:00Z")}
+      />
+    </Shell>
+  ),
+};

--- a/packages/ui/src/components/filter-rail.stories.tsx
+++ b/packages/ui/src/components/filter-rail.stories.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  FilterRail,
+  type FilterCheckboxOption,
+  type FilterGroup,
+  type RadioValue,
+} from "./filter-rail";
+
+const TYPE_OPTIONS: FilterCheckboxOption[] = [
+  { value: "human", label: "Human", count: 12 },
+  { value: "mythological", label: "Mythological", count: 4 },
+  { value: "fictional", label: "Fictional", count: 7 },
+  { value: "organization", label: "Organization", count: 3 },
+];
+
+const ERA_OPTIONS: FilterCheckboxOption[] = [
+  { value: "ce", label: "CE", count: 14 },
+  { value: "bce", label: "BCE", count: 6 },
+  { value: "kya", label: "KYA", count: 2 },
+];
+
+const meta = {
+  title: "Components/FilterRail",
+  component: FilterRail,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof FilterRail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function InteractiveFilterRail() {
+  const [types, setTypes] = React.useState<string[]>(["human"]);
+  const [eras, setEras] = React.useState<string[]>([]);
+  const [importance, setImportance] = React.useState<[number, number]>([3, 9]);
+  const [published, setPublished] = React.useState<RadioValue>("any");
+
+  const groups: FilterGroup[] = [
+    {
+      type: "checkbox",
+      id: "type",
+      label: "Character type",
+      options: TYPE_OPTIONS,
+      value: types,
+      onChange: setTypes,
+    },
+    {
+      type: "checkbox",
+      id: "era",
+      label: "Era",
+      options: ERA_OPTIONS,
+      value: eras,
+      onChange: setEras,
+    },
+    {
+      type: "range",
+      id: "importance",
+      label: "Importance",
+      min: 1,
+      max: 10,
+      value: importance,
+      onChange: setImportance,
+    },
+    {
+      type: "radio",
+      id: "published",
+      label: "Published",
+      value: published,
+      onChange: setPublished,
+      yesLabel: "Published",
+      noLabel: "Draft/Shared",
+    },
+  ];
+
+  function clearAll() {
+    setTypes([]);
+    setEras([]);
+    setImportance([1, 10]);
+    setPublished("any");
+  }
+
+  return (
+    <div className="max-w-xs border border-border bg-background">
+      <FilterRail groups={groups} onClearAll={clearAll} />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  args: { groups: [] },
+  render: () => <InteractiveFilterRail />,
+};
+
+export const NoActiveFilters: Story = {
+  args: { groups: [] },
+  render: () => {
+    const groups: FilterGroup[] = [
+      {
+        type: "checkbox",
+        id: "type",
+        label: "Character type",
+        options: TYPE_OPTIONS,
+        value: [],
+        onChange: () => {},
+      },
+      {
+        type: "radio",
+        id: "published",
+        label: "Published",
+        value: "any",
+        onChange: () => {},
+      },
+    ];
+
+    return (
+      <div className="max-w-xs border border-border bg-background">
+        <FilterRail groups={groups} onClearAll={() => {}} />
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/components/save-dropdown.stories.tsx
+++ b/packages/ui/src/components/save-dropdown.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SaveDropdown } from "./save-dropdown";
+
+const meta = {
+  title: "Components/Save Dropdown",
+  component: SaveDropdown,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof SaveDropdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onSave: () => {},
+    onSaveAndAddAnother: () => {},
+    onSaveAsDraft: () => {},
+    onSaveAndPublish: () => {},
+  },
+};

--- a/packages/ui/src/components/save-dropdown.test.tsx
+++ b/packages/ui/src/components/save-dropdown.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SaveDropdown } from "./save-dropdown";
+
+describe("SaveDropdown", () => {
+  it("invokes the primary save action", async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+    render(<SaveDropdown onSave={onSave} onSaveAndAddAnother={() => {}} />);
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it("shows the split-button menu actions", async () => {
+    const onSaveAndAddAnother = vi.fn();
+    const onSaveAsDraft = vi.fn();
+    const onSaveAndPublish = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <SaveDropdown
+        onSave={() => {}}
+        onSaveAndAddAnother={onSaveAndAddAnother}
+        onSaveAsDraft={onSaveAsDraft}
+        onSaveAndPublish={onSaveAndPublish}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "More save actions" }));
+    await user.click(
+      screen.getByRole("menuitem", { name: "Save and add another" }),
+    );
+    expect(onSaveAndAddAnother).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/components/save-dropdown.tsx
+++ b/packages/ui/src/components/save-dropdown.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDown } from "lucide-react";
+
+import { Button } from "./button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+import { cn } from "@repo/ui/lib/utils";
+
+export interface SaveDropdownProps {
+  onSave: () => void;
+  onSaveAndAddAnother?: () => void;
+  onSaveAsDraft?: () => void;
+  onSaveAndPublish?: () => void;
+  saveLabel?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function SaveDropdown({
+  onSave,
+  onSaveAndAddAnother,
+  onSaveAsDraft,
+  onSaveAndPublish,
+  saveLabel = "Save",
+  disabled = false,
+  className,
+}: SaveDropdownProps) {
+  const hasMenuItems =
+    onSaveAndAddAnother != null ||
+    onSaveAsDraft != null ||
+    onSaveAndPublish != null;
+
+  return (
+    <div className={cn("inline-flex items-stretch", className)}>
+      <Button type="button" onClick={onSave} disabled={disabled}>
+        {saveLabel}
+      </Button>
+      {hasMenuItems && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              disabled={disabled}
+              className="rounded-l-none border-l-0 px-2"
+              aria-label="More save actions"
+            >
+              <ChevronDown className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {onSaveAndAddAnother && (
+              <DropdownMenuItem onSelect={() => onSaveAndAddAnother()}>
+                Save and add another
+              </DropdownMenuItem>
+            )}
+            {onSaveAsDraft && (
+              <DropdownMenuItem onSelect={() => onSaveAsDraft()}>
+                Save as draft
+              </DropdownMenuItem>
+            )}
+            {onSaveAndPublish && (
+              <DropdownMenuItem onSelect={() => onSaveAndPublish()}>
+                Save and publish
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/select.stories.tsx
+++ b/packages/ui/src/components/select.stories.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
+import { Label } from "./label";
+
+const meta = {
+  title: "Components/Select",
+  component: Select,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof Select>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function EraSelectHarness({ disabled = false }: { disabled?: boolean }) {
+  const [value, setValue] = React.useState<string>("CE");
+  return (
+    <Select value={value} onValueChange={setValue} disabled={disabled}>
+      <SelectTrigger className="w-48">
+        <SelectValue placeholder="Pick an era" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="CE">CE — modern era</SelectItem>
+        <SelectItem value="BCE">BCE — historical</SelectItem>
+        <SelectItem value="KYA">KYA — ancient</SelectItem>
+        <SelectItem value="MYA">MYA — deep historical</SelectItem>
+        <SelectItem value="BYA">BYA — cosmic</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+export const Default: Story = {
+  render: () => <EraSelectHarness />,
+};
+
+export const Disabled: Story = {
+  render: () => <EraSelectHarness disabled />,
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <Label htmlFor="story-select">Era</Label>
+      <EraSelectHarness />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-(--radix-select-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-select-content-transform-origin)",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,
@@ -88,7 +88,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+            "h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)",
         )}
       >
         {children}

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/packages/ui/src/components/slider.stories.tsx
+++ b/packages/ui/src/components/slider.stories.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Slider } from "./slider";
+
+const meta = {
+  title: "Components/Slider",
+  component: Slider,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof Slider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function SingleValueSlider() {
+  const [value, setValue] = React.useState<number[]>([35]);
+
+  return (
+    <div className="w-80 space-y-3">
+      <Slider
+        min={0}
+        max={100}
+        step={1}
+        value={value}
+        onValueChange={setValue}
+      />
+      <p className="text-sm text-foreground-muted">Importance: {value[0]}</p>
+    </div>
+  );
+}
+
+function RangeSlider() {
+  const [value, setValue] = React.useState<number[]>([1200, 1800]);
+
+  return (
+    <div className="w-80 space-y-3">
+      <Slider
+        min={0}
+        max={2000}
+        step={10}
+        value={value}
+        onValueChange={setValue}
+      />
+      <p className="text-sm text-foreground-muted">
+        Range: {value[0]} - {value[1]}
+      </p>
+    </div>
+  );
+}
+
+export const Single: Story = {
+  render: () => <SingleValueSlider />,
+};
+
+export const Range: Story = {
+  render: () => <RangeSlider />,
+};
+
+export const Disabled: Story = {
+  args: {
+    defaultValue: [60],
+    disabled: true,
+  },
+  render: (args) => <Slider className="w-80" {...args} />,
+};

--- a/packages/ui/src/components/slug-field.stories.tsx
+++ b/packages/ui/src/components/slug-field.stories.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SlugField } from "./slug-field";
+
+const meta = {
+  title: "Components/Slug Field",
+  component: SlugField,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof SlugField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function SlugFieldStory() {
+  const [source, setSource] = useState("A Fresh Character");
+  const [slug, setSlug] = useState("");
+
+  return (
+    <div className="space-y-4">
+      <label className="block space-y-1 text-sm">
+        <span className="font-medium">Source title</span>
+        <input
+          className="h-10 w-full rounded-md border border-border bg-background px-3"
+          value={source}
+          onChange={(event) => setSource(event.target.value)}
+        />
+      </label>
+      <SlugField
+        value={slug}
+        onChange={setSlug}
+        sourceValue={source}
+        existingSlugs={["a-fresh-character"]}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    value: "",
+    onChange: () => {},
+    sourceValue: "",
+  },
+  render: () => <SlugFieldStory />,
+};

--- a/packages/ui/src/components/slug-field.test.tsx
+++ b/packages/ui/src/components/slug-field.test.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { SlugField } from "./slug-field";
+
+function SlugFieldHarness() {
+  const [source, setSource] = useState("Great Title");
+  const [slug, setSlug] = useState("");
+
+  return (
+    <>
+      <input
+        aria-label="Source title"
+        value={source}
+        onChange={(event) => setSource(event.target.value)}
+      />
+      <SlugField
+        value={slug}
+        onChange={setSlug}
+        sourceValue={source}
+        existingSlugs={["great-title"]}
+        debounceMs={0}
+      />
+    </>
+  );
+}
+
+describe("SlugField", () => {
+  it("auto-generates and resolves collisions in create mode", async () => {
+    const user = userEvent.setup();
+    render(<SlugFieldHarness />);
+
+    const slugInput = screen.getByLabelText("Slug");
+    await waitFor(() => expect(slugInput).toHaveValue("great-title-2"));
+
+    await user.clear(slugInput);
+    await user.type(slugInput, "manual-slug");
+    expect(slugInput).toHaveValue("manual-slug");
+
+    await user.clear(screen.getByLabelText("Source title"));
+    await user.type(screen.getByLabelText("Source title"), "Another Title");
+    expect(slugInput).toHaveValue("manual-slug");
+
+    await user.click(screen.getByRole("button", { name: "Regenerate" }));
+    await waitFor(() => expect(slugInput).toHaveValue("another-title"));
+  });
+
+  it("starts locked in edit mode until unlocked", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SlugField
+        mode="edit"
+        value="existing-slug"
+        onChange={() => {}}
+        sourceValue="Existing title"
+      />,
+    );
+
+    const slugInput = screen.getByLabelText("Slug");
+    expect(slugInput).toHaveAttribute("readonly");
+
+    await user.click(screen.getByRole("button", { name: "Edit slug" }));
+    expect(slugInput).not.toHaveAttribute("readonly");
+  });
+});

--- a/packages/ui/src/components/slug-field.tsx
+++ b/packages/ui/src/components/slug-field.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import * as React from "react";
+
+import { Button } from "./button";
+import { Input } from "./input";
+import { cn } from "@repo/ui/lib/utils";
+import { generateSlug, resolveCollision } from "@repo/services/utils/slug.js";
+
+export interface SlugFieldProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof Input>,
+  "value" | "onChange"
+> {
+  value: string;
+  onChange: (value: string) => void;
+  sourceValue: string;
+  mode?: "create" | "edit";
+  existingSlugs?: string[];
+  debounceMs?: number;
+  label?: string;
+  description?: string;
+  warning?: string;
+}
+
+export function SlugField({
+  value,
+  onChange,
+  sourceValue,
+  mode = "create",
+  existingSlugs = [],
+  debounceMs = 300,
+  label = "Slug",
+  description,
+  warning,
+  className,
+  disabled,
+  id,
+  ...props
+}: SlugFieldProps) {
+  const generatedId = React.useId();
+  const resolvedId = id ?? generatedId;
+  const [isUnlocked, setIsUnlocked] = React.useState(() => mode === "create");
+  const [isLinked, setIsLinked] = React.useState(() => mode === "create");
+  const [isDirty, setIsDirty] = React.useState(false);
+
+  React.useEffect(() => {
+    if (mode !== "create" || !isLinked || isDirty) return;
+    if (sourceValue.trim().length === 0) return;
+
+    const timeout = window.setTimeout(() => {
+      try {
+        const generated = resolveCollision(
+          generateSlug(sourceValue),
+          existingSlugs,
+        );
+        if (generated !== value) {
+          onChange(generated);
+        }
+      } catch {
+        // Empty/emoji-only titles are expected during intermediate editing.
+      }
+    }, debounceMs);
+
+    return () => window.clearTimeout(timeout);
+  }, [
+    debounceMs,
+    existingSlugs,
+    isDirty,
+    isLinked,
+    mode,
+    onChange,
+    sourceValue,
+    value,
+  ]);
+
+  const regenerate = React.useCallback(() => {
+    try {
+      const generated = resolveCollision(
+        generateSlug(sourceValue),
+        existingSlugs,
+      );
+      onChange(generated);
+      setIsLinked(true);
+      setIsDirty(false);
+    } catch {
+      setIsLinked(true);
+    }
+  }, [existingSlugs, onChange, sourceValue]);
+
+  const handleChange = (nextValue: string) => {
+    onChange(nextValue);
+    setIsDirty(mode === "create");
+    setIsLinked(false);
+  };
+
+  const readOnly = mode === "edit" && !isUnlocked;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <label
+          htmlFor={resolvedId}
+          className="text-sm font-medium text-foreground"
+        >
+          {label}
+        </label>
+        {mode === "edit" ? (
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => setIsUnlocked((current) => !current)}
+          >
+            {isUnlocked ? "Lock slug" : "Edit slug"}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={regenerate}
+            disabled={sourceValue.trim().length === 0}
+          >
+            Regenerate
+          </Button>
+        )}
+      </div>
+      <Input
+        {...props}
+        id={resolvedId}
+        value={value}
+        onChange={(event) => handleChange(event.target.value)}
+        readOnly={readOnly}
+        disabled={disabled}
+        className={cn(readOnly && "bg-surface/60", className)}
+      />
+      <p className="text-xs text-foreground-muted">
+        {mode === "edit"
+          ? (warning ??
+            "Changing the slug will break existing links to this record.")
+          : isLinked
+            ? (description ??
+              "Linked to the source field until you edit it manually.")
+            : (description ??
+              "Manual edits break the live link until you regenerate.")}
+      </p>
+    </div>
+  );
+}

--- a/packages/ui/src/components/table.stories.tsx
+++ b/packages/ui/src/components/table.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table";
+
+const meta = {
+  title: "Components/Table",
+  component: Table,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof Table>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Table className="w-[42rem]">
+      <TableCaption>Character significance and timeline coverage</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Type</TableHead>
+          <TableHead>Era</TableHead>
+          <TableHead className="text-right">Events</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell className="font-medium">Marie Curie</TableCell>
+          <TableCell>Human</TableCell>
+          <TableCell>CE</TableCell>
+          <TableCell className="text-right">12</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell className="font-medium">Ra</TableCell>
+          <TableCell>Mythological</TableCell>
+          <TableCell>BCE</TableCell>
+          <TableCell className="text-right">8</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell className="font-medium">Don Quixote</TableCell>
+          <TableCell>Fictional</TableCell>
+          <TableCell>CE</TableCell>
+          <TableCell className="text-right">5</TableCell>
+        </TableRow>
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={3}>Total</TableCell>
+          <TableCell className="text-right">25</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  ),
+};

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -73,7 +73,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground",
       className,
     )}
     {...props}
@@ -85,11 +85,7 @@ const TableCell = React.forwardRef<
   HTMLTableCellElement,
   React.TdHTMLAttributes<HTMLTableCellElement>
 >(({ className, ...props }, ref) => (
-  <td
-    ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
-    {...props}
-  />
+  <td ref={ref} className={cn("p-4 align-middle", className)} {...props} />
 ));
 TableCell.displayName = "TableCell";
 

--- a/packages/ui/src/components/temporal-display.tsx
+++ b/packages/ui/src/components/temporal-display.tsx
@@ -43,7 +43,7 @@ export interface TemporalDisplayProps extends Omit<
   showExact?: boolean;
 }
 
-const ERA_COLOR: Record<Era, string> = {
+export const ERA_COLOR: Record<Era, string> = {
   CE: "text-era-ce",
   BCE: "text-era-bce",
   KYA: "text-era-kya",
@@ -51,7 +51,7 @@ const ERA_COLOR: Record<Era, string> = {
   BYA: "text-era-bya",
 };
 
-const PRECISION_LABEL: Record<Precision, string | null> = {
+export const PRECISION_LABEL: Record<Precision, string | null> = {
   exact: "exact",
   circa: "circa",
   approximate: "approximate",

--- a/packages/ui/src/components/temporal-input.stories.tsx
+++ b/packages/ui/src/components/temporal-input.stories.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { TemporalInput } from "./temporal-input";
+import type { TemporalData } from "@repo/services/schemas/temporal.js";
+
+const meta = {
+  title: "Components/Temporal Input",
+  component: TemporalInput,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof TemporalInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function TemporalInputStory() {
+  const [value, setValue] = useState<TemporalData | null>({
+    year: 2024,
+    era: "CE",
+    precision: "exact",
+  });
+
+  return <TemporalInput label="Date" value={value} onChange={setValue} />;
+}
+
+export const Default: Story = {
+  args: {
+    value: null,
+    onChange: () => {},
+  },
+  render: () => <TemporalInputStory />,
+};

--- a/packages/ui/src/components/temporal-input.stories.tsx
+++ b/packages/ui/src/components/temporal-input.stories.tsx
@@ -7,28 +7,137 @@ import type { TemporalData } from "@repo/services/schemas/temporal.js";
 const meta = {
   title: "Components/Temporal Input",
   component: TemporalInput,
-  parameters: {
-    layout: "padded",
-  },
+  parameters: { layout: "padded" },
+  args: { value: null, onChange: () => {} },
 } satisfies Meta<typeof TemporalInput>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-function TemporalInputStory() {
-  const [value, setValue] = useState<TemporalData | null>({
-    year: 2024,
-    era: "CE",
-    precision: "exact",
-  });
-
-  return <TemporalInput label="Date" value={value} onChange={setValue} />;
+function TemporalInputHarness({
+  seed,
+  label = "Date",
+  required = false,
+  disabled = false,
+  error,
+}: {
+  seed: TemporalData | null;
+  label?: string;
+  required?: boolean;
+  disabled?: boolean;
+  error?: string;
+}) {
+  const [value, setValue] = useState<TemporalData | null>(seed);
+  return (
+    <div className="max-w-md">
+      <TemporalInput
+        label={label}
+        value={value}
+        onChange={setValue}
+        required={required}
+        disabled={disabled}
+        error={error}
+      />
+    </div>
+  );
 }
 
-export const Default: Story = {
-  args: {
-    value: null,
-    onChange: () => {},
-  },
-  render: () => <TemporalInputStory />,
+export const Empty: Story = {
+  render: () => <TemporalInputHarness seed={null} label="Birth date" />,
+};
+
+export const Modern: Story = {
+  render: () => (
+    <TemporalInputHarness
+      label="Birth"
+      seed={{
+        year: 1867,
+        month: 11,
+        day: 7,
+        era: "CE",
+        precision: "exact",
+      }}
+    />
+  ),
+};
+
+export const Historical: Story = {
+  render: () => (
+    <TemporalInputHarness
+      label="Assassination"
+      seed={{ year: 44, era: "BCE", precision: "circa" }}
+    />
+  ),
+};
+
+export const Ancient: Story = {
+  render: () => (
+    <TemporalInputHarness
+      label="Emergence"
+      seed={{
+        year: 160,
+        era: "KYA",
+        precision: "approximate",
+        uncertainty: 10_000,
+      }}
+    />
+  ),
+};
+
+export const Geological: Story = {
+  render: () => (
+    <TemporalInputHarness
+      label="Extinction event"
+      seed={{
+        year: 66,
+        era: "MYA",
+        precision: "approximate",
+        uncertainty: 1_000_000,
+        geological_period: "Cretaceous–Paleogene boundary",
+        dating_method: "Radiometric",
+        confidence_level: "high",
+        source: "Wikipedia: K–Pg boundary",
+      }}
+    />
+  ),
+};
+
+export const Cosmic: Story = {
+  render: () => (
+    <TemporalInputHarness
+      label="Big Bang"
+      seed={{
+        year: 14,
+        era: "BYA",
+        precision: "estimated",
+        cosmological_epoch: "Inflation",
+      }}
+    />
+  ),
+};
+
+export const Required: Story = {
+  render: () => (
+    <TemporalInputHarness seed={null} label="Start date" required />
+  ),
+};
+
+export const WithError: Story = {
+  render: () => (
+    <TemporalInputHarness
+      label="Date"
+      seed={{ year: 300_000, era: "CE", precision: "exact" }}
+      error="This date exceeds the supported CE range."
+    />
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <TemporalInputHarness
+      label="Locked date"
+      seed={{ year: 1789, era: "CE", precision: "exact" }}
+      disabled
+    />
+  ),
 };

--- a/packages/ui/src/components/temporal-input.test.tsx
+++ b/packages/ui/src/components/temporal-input.test.tsx
@@ -1,15 +1,50 @@
 import { useState } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { TemporalInput } from "./temporal-input";
 import type { TemporalData } from "@repo/services/schemas/temporal.js";
 
-function TemporalInputHarness() {
-  const [value, setValue] = useState<TemporalData | null>(null);
+function TemporalInputHarness({
+  seed = null,
+  onChange,
+}: {
+  seed?: TemporalData | null;
+  onChange?: (v: TemporalData | null) => void;
+}) {
+  const [value, setValue] = useState<TemporalData | null>(seed);
+  return (
+    <TemporalInput
+      label="Date"
+      value={value}
+      onChange={(v) => {
+        setValue(v);
+        onChange?.(v);
+      }}
+    />
+  );
+}
 
-  return <TemporalInput label="Date" value={value} onChange={setValue} />;
+/** Open the era Select dropdown and click the option matching `era`. */
+async function pickEra(user: ReturnType<typeof userEvent.setup>, era: string) {
+  await user.click(screen.getByRole("combobox", { name: "Era" }));
+  const option = await screen.findByRole("option", {
+    name: new RegExp(`^${era}`),
+  });
+  await user.click(option);
+}
+
+/** Open the precision Select dropdown and click the option. */
+async function pickPrecision(
+  user: ReturnType<typeof userEvent.setup>,
+  precision: string,
+) {
+  await user.click(screen.getByRole("combobox", { name: "Precision" }));
+  const option = await screen.findByRole("option", {
+    name: new RegExp(precision, "i"),
+  });
+  await user.click(option);
 }
 
 describe("TemporalInput", () => {
@@ -32,9 +67,173 @@ describe("TemporalInput", () => {
     render(<TemporalInputHarness />);
 
     await user.click(screen.getByRole("button", { name: /add date/i }));
-    await user.selectOptions(screen.getByLabelText("Era"), "MYA");
+    await pickEra(user, "MYA");
 
     expect(screen.queryByLabelText("Month")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Day")).not.toBeInTheDocument();
+  });
+
+  it("cancel reverts in-progress edits", async () => {
+    const user = userEvent.setup();
+    render(
+      <TemporalInputHarness
+        seed={{ year: 1867, era: "CE", precision: "exact" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /1867 CE/i }));
+    const yearInput = screen.getByLabelText("Year");
+    await user.clear(yearInput);
+    await user.type(yearInput, "1900");
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    // Trigger still reflects the original committed value, not the draft.
+    expect(
+      screen.getByRole("button", { name: /1867 CE/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("apply commits the draft to the parent", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<TemporalInputHarness onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+    await user.type(screen.getByLabelText("Year"), "1789");
+    await user.click(screen.getByRole("button", { name: /^apply$/i }));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ year: 1789, era: "CE" }),
+      );
+    });
+  });
+
+  it("apply is disabled when validation fails", async () => {
+    const user = userEvent.setup();
+    render(<TemporalInputHarness />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+    // No year entered → invalid → Apply disabled.
+    expect(screen.getByRole("button", { name: /^apply$/i })).toBeDisabled();
+  });
+
+  it("era change from CE to MYA shows a clear notice", async () => {
+    const user = userEvent.setup();
+    render(
+      <TemporalInputHarness
+        seed={{
+          year: 1867,
+          month: 11,
+          day: 7,
+          era: "CE",
+          precision: "exact",
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /1867 CE/i }));
+    await pickEra(user, "MYA");
+
+    expect(
+      screen.getByText(/month, day, and time were cleared for MYA dates/i),
+    ).toBeInTheDocument();
+  });
+
+  it("rejects non-integer year entry", async () => {
+    const user = userEvent.setup();
+    render(<TemporalInputHarness />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+    const yearInput = screen.getByLabelText("Year") as HTMLInputElement;
+    await user.type(yearInput, "1.5");
+
+    // Integer guard rejects the decimal — input keeps the integer part only.
+    expect(yearInput.value).not.toBe("1.5");
+  });
+
+  it("surfaces a field-level error when CE year is out of range", async () => {
+    const user = userEvent.setup();
+    render(<TemporalInputHarness />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+    await user.type(screen.getByLabelText("Year"), "1500000000");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/CE year must be <= 1000000000/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows a precision warning when 'exact' is paired with a prehistoric era", async () => {
+    const user = userEvent.setup();
+    render(<TemporalInputHarness />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+    await pickEra(user, "KYA");
+
+    // The era switch lands precision on "exact" still; the warning should appear.
+    expect(
+      screen.getByText(/exact precision is rarely honest at the KYA scale/i),
+    ).toBeInTheDocument();
+  });
+
+  it("time-of-day disclosure toggles open/closed", async () => {
+    const user = userEvent.setup();
+    render(<TemporalInputHarness />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+
+    const summary = screen.getByText(/time of day/i);
+    const disclosure = summary.closest("details");
+    expect(disclosure).not.toBeNull();
+    expect(disclosure).not.toHaveAttribute("open");
+
+    await user.click(summary);
+    expect(disclosure).toHaveAttribute("open");
+
+    // Fields render inside the disclosure either way (HTML <details> only
+    // hides content visually); confirm they exist once the section opens.
+    expect(screen.getByLabelText("Hour")).toBeInTheDocument();
+    expect(screen.getByLabelText("Minute")).toBeInTheDocument();
+    expect(screen.getByLabelText("Second")).toBeInTheDocument();
+  });
+
+  it("source field updates the model on apply", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<TemporalInputHarness onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+    await user.type(screen.getByLabelText("Year"), "1867");
+
+    // Open the Dating method & source disclosure, then type in Source.
+    await user.click(screen.getByText(/dating method & source/i));
+    await user.type(screen.getByLabelText("Source"), "Encyclopedia");
+
+    await user.click(screen.getByRole("button", { name: /^apply$/i }));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ source: "Encyclopedia" }),
+      );
+    });
+  });
+
+  it("changing precision via the Select updates the preview", async () => {
+    const user = userEvent.setup();
+    render(<TemporalInputHarness />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+    await user.type(screen.getByLabelText("Year"), "1867");
+    await pickPrecision(user, "circa");
+
+    // Preview row (inside popover) should reflect "circa".
+    const popover = screen.getByText("Preview:").closest("div");
+    expect(popover).not.toBeNull();
+    expect(
+      within(popover as HTMLElement).getByText(/circa/i),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/temporal-input.test.tsx
+++ b/packages/ui/src/components/temporal-input.test.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { TemporalInput } from "./temporal-input";
+import type { TemporalData } from "@repo/services/schemas/temporal.js";
+
+function TemporalInputHarness() {
+  const [value, setValue] = useState<TemporalData | null>(null);
+
+  return <TemporalInput label="Date" value={value} onChange={setValue} />;
+}
+
+describe("TemporalInput", () => {
+  it("updates the preview for a CE date", async () => {
+    const user = userEvent.setup();
+    render(<TemporalInputHarness />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+    await user.type(screen.getByLabelText("Year"), "2024");
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /2024 CE/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("hides month and day fields for prehistoric eras", async () => {
+    const user = userEvent.setup();
+    render(<TemporalInputHarness />);
+
+    await user.click(screen.getByRole("button", { name: /add date/i }));
+    await user.selectOptions(screen.getByLabelText("Era"), "MYA");
+
+    expect(screen.queryByLabelText("Month")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Day")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/temporal-input.tsx
+++ b/packages/ui/src/components/temporal-input.tsx
@@ -1,0 +1,458 @@
+"use client";
+
+import * as React from "react";
+
+import { TemporalDisplay } from "./temporal-display";
+import { Button } from "./button";
+import { Input } from "./input";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { cn } from "@repo/ui/lib/utils";
+import {
+  temporalDataSchema,
+  type Era,
+  type Precision,
+  type TemporalData,
+} from "@repo/services/schemas/temporal.js";
+
+export interface TemporalInputProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "onChange"
+> {
+  value: TemporalData | null;
+  onChange: (value: TemporalData | null) => void;
+  label?: string;
+  required?: boolean;
+  error?: string;
+  showPreview?: boolean;
+  disabled?: boolean;
+}
+
+type TemporalDraft = {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  minute?: number;
+  second?: number;
+  era: Era;
+  precision: Precision;
+  uncertainty?: number;
+  geological_period?: string;
+  geological_epoch?: string;
+  cosmological_epoch?: string;
+  display_format?: TemporalData["display_format"];
+  dating_method?: string;
+  confidence_level?: TemporalData["confidence_level"];
+  source?: string;
+};
+
+const createDraft = (value: TemporalData | null): TemporalDraft => ({
+  year: value?.year,
+  month: value?.month ?? undefined,
+  day: value?.day ?? undefined,
+  hour: value?.hour ?? undefined,
+  minute: value?.minute ?? undefined,
+  second: value?.second ?? undefined,
+  era: value?.era ?? "CE",
+  precision: value?.precision ?? "exact",
+  uncertainty: value?.uncertainty ?? undefined,
+  geological_period: value?.geological_period ?? undefined,
+  geological_epoch: value?.geological_epoch ?? undefined,
+  cosmological_epoch: value?.cosmological_epoch ?? undefined,
+  display_format: value?.display_format ?? undefined,
+  dating_method: value?.dating_method ?? undefined,
+  confidence_level: value?.confidence_level ?? undefined,
+  source: value?.source ?? undefined,
+});
+
+const maybeParse = (draft: TemporalDraft): TemporalData | null => {
+  const result = temporalDataSchema.safeParse(draft);
+  return result.success ? result.data : null;
+};
+
+const fieldClassName =
+  "h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20";
+
+export function TemporalInput({
+  value,
+  onChange,
+  label = "Date",
+  required = false,
+  error,
+  showPreview = true,
+  disabled = false,
+  className,
+  ...props
+}: TemporalInputProps) {
+  const [open, setOpen] = React.useState(false);
+  const [draft, setDraft] = React.useState<TemporalDraft>(() =>
+    createDraft(value),
+  );
+  const [hasInteracted, setHasInteracted] = React.useState(false);
+
+  const candidate = React.useMemo(() => maybeParse(draft), [draft]);
+  const previewValue = candidate ?? value;
+
+  const updateDraft = React.useCallback(
+    <K extends keyof TemporalDraft>(key: K, nextValue: TemporalDraft[K]) => {
+      setHasInteracted(true);
+      setDraft((current) => {
+        const next = { ...current, [key]: nextValue } as TemporalDraft;
+
+        if (next.era === "CE" || next.era === "BCE") {
+          // Keep CE/BCE fields intact.
+        } else {
+          next.month = undefined;
+          next.day = undefined;
+          next.hour = undefined;
+          next.minute = undefined;
+          next.second = undefined;
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const clear = React.useCallback(() => {
+    setHasInteracted(true);
+    setDraft(createDraft(null));
+    onChange(null);
+  }, [onChange]);
+
+  const showErrors = hasInteracted && candidate == null;
+
+  return (
+    <div className={cn("space-y-2", className)} {...props}>
+      <div className="flex items-center justify-between gap-3">
+        <label className="text-sm font-medium text-foreground">
+          {label}
+          {required ? <span className="text-foreground-muted"> *</span> : null}
+        </label>
+        <div className="flex items-center gap-2">
+          {value && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={clear}
+              disabled={disabled}
+            >
+              Clear
+            </Button>
+          )}
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <Button type="button" variant="secondary" disabled={disabled}>
+                {previewValue ? (
+                  <TemporalDisplay value={previewValue} format="compact" />
+                ) : (
+                  <span>+ Add date</span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-152 space-y-4">
+              {showPreview && (
+                <div className="rounded-md border border-border bg-surface px-3 py-2 text-sm">
+                  {candidate ? (
+                    <TemporalDisplay
+                      value={candidate}
+                      format="block"
+                      showExact
+                    />
+                  ) : (
+                    <span className="text-foreground-muted">
+                      Finish the required fields to preview the date.
+                    </span>
+                  )}
+                </div>
+              )}
+
+              <div className="grid gap-3 md:grid-cols-2">
+                <label className="space-y-1 text-sm">
+                  <span className="block font-medium">Era</span>
+                  <select
+                    className={cn(fieldClassName, "w-full")}
+                    value={draft.era}
+                    onChange={(event) =>
+                      updateDraft("era", event.target.value as Era)
+                    }
+                  >
+                    {(["CE", "BCE", "KYA", "MYA", "BYA"] as const).map(
+                      (era) => (
+                        <option key={era} value={era}>
+                          {era}
+                        </option>
+                      ),
+                    )}
+                  </select>
+                </label>
+                <label className="space-y-1 text-sm">
+                  <span className="block font-medium">Precision</span>
+                  <select
+                    className={cn(fieldClassName, "w-full")}
+                    value={draft.precision}
+                    onChange={(event) =>
+                      updateDraft("precision", event.target.value as Precision)
+                    }
+                  >
+                    {(
+                      [
+                        "exact",
+                        "circa",
+                        "approximate",
+                        "estimated",
+                        "geological",
+                      ] as const
+                    ).map((precision) => (
+                      <option key={precision} value={precision}>
+                        {precision}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-3">
+                <label className="space-y-1 text-sm md:col-span-1">
+                  <span className="block font-medium">Year</span>
+                  <Input
+                    type="number"
+                    inputMode="numeric"
+                    min={1}
+                    step={1}
+                    value={draft.year ?? ""}
+                    onChange={(event) =>
+                      updateDraft(
+                        "year",
+                        event.target.value === ""
+                          ? undefined
+                          : Number(event.target.value),
+                      )
+                    }
+                  />
+                </label>
+                {draft.era === "CE" || draft.era === "BCE" ? (
+                  <>
+                    <label className="space-y-1 text-sm">
+                      <span className="block font-medium">Month</span>
+                      <Input
+                        type="number"
+                        inputMode="numeric"
+                        min={1}
+                        max={12}
+                        value={draft.month ?? ""}
+                        onChange={(event) =>
+                          updateDraft(
+                            "month",
+                            event.target.value === ""
+                              ? undefined
+                              : Number(event.target.value),
+                          )
+                        }
+                      />
+                    </label>
+                    <label className="space-y-1 text-sm">
+                      <span className="block font-medium">Day</span>
+                      <Input
+                        type="number"
+                        inputMode="numeric"
+                        min={1}
+                        max={31}
+                        value={draft.day ?? ""}
+                        onChange={(event) =>
+                          updateDraft(
+                            "day",
+                            event.target.value === ""
+                              ? undefined
+                              : Number(event.target.value),
+                          )
+                        }
+                      />
+                    </label>
+                  </>
+                ) : (
+                  <div className="md:col-span-2 rounded-md border border-dashed border-border px-3 py-2 text-sm text-foreground-muted">
+                    Month and day are hidden for prehistoric eras.
+                  </div>
+                )}
+              </div>
+
+              {(draft.era === "CE" || draft.era === "BCE") && (
+                <div className="grid gap-3 md:grid-cols-3">
+                  <label className="space-y-1 text-sm">
+                    <span className="block font-medium">Hour</span>
+                    <Input
+                      type="number"
+                      inputMode="numeric"
+                      min={0}
+                      max={23}
+                      value={draft.hour ?? ""}
+                      onChange={(event) =>
+                        updateDraft(
+                          "hour",
+                          event.target.value === ""
+                            ? undefined
+                            : Number(event.target.value),
+                        )
+                      }
+                    />
+                  </label>
+                  <label className="space-y-1 text-sm">
+                    <span className="block font-medium">Minute</span>
+                    <Input
+                      type="number"
+                      inputMode="numeric"
+                      min={0}
+                      max={59}
+                      value={draft.minute ?? ""}
+                      onChange={(event) =>
+                        updateDraft(
+                          "minute",
+                          event.target.value === ""
+                            ? undefined
+                            : Number(event.target.value),
+                        )
+                      }
+                    />
+                  </label>
+                  <label className="space-y-1 text-sm">
+                    <span className="block font-medium">Second</span>
+                    <Input
+                      type="number"
+                      inputMode="decimal"
+                      min={0}
+                      max={59}
+                      value={draft.second ?? ""}
+                      onChange={(event) =>
+                        updateDraft(
+                          "second",
+                          event.target.value === ""
+                            ? undefined
+                            : Number(event.target.value),
+                        )
+                      }
+                    />
+                  </label>
+                </div>
+              )}
+
+              {(draft.era === "KYA" ||
+                draft.era === "MYA" ||
+                draft.era === "BYA") && (
+                <div className="grid gap-3 md:grid-cols-2">
+                  <label className="space-y-1 text-sm">
+                    <span className="block font-medium">
+                      Uncertainty (years)
+                    </span>
+                    <Input
+                      type="number"
+                      inputMode="decimal"
+                      min={0}
+                      step="any"
+                      value={draft.uncertainty ?? ""}
+                      onChange={(event) =>
+                        updateDraft(
+                          "uncertainty",
+                          event.target.value === ""
+                            ? undefined
+                            : Number(event.target.value),
+                        )
+                      }
+                    />
+                  </label>
+                  <label className="space-y-1 text-sm">
+                    <span className="block font-medium">Dating method</span>
+                    <Input
+                      value={draft.dating_method ?? ""}
+                      onChange={(event) =>
+                        updateDraft(
+                          "dating_method",
+                          event.target.value || undefined,
+                        )
+                      }
+                    />
+                  </label>
+                </div>
+              )}
+
+              {(draft.era === "MYA" || draft.era === "BYA") && (
+                <div className="grid gap-3 md:grid-cols-2">
+                  <label className="space-y-1 text-sm">
+                    <span className="block font-medium">Geological period</span>
+                    <Input
+                      value={draft.geological_period ?? ""}
+                      onChange={(event) =>
+                        updateDraft(
+                          "geological_period",
+                          event.target.value || undefined,
+                        )
+                      }
+                    />
+                  </label>
+                  <label className="space-y-1 text-sm">
+                    <span className="block font-medium">Geological epoch</span>
+                    <Input
+                      value={draft.geological_epoch ?? ""}
+                      onChange={(event) =>
+                        updateDraft(
+                          "geological_epoch",
+                          event.target.value || undefined,
+                        )
+                      }
+                    />
+                  </label>
+                </div>
+              )}
+
+              {draft.era === "BYA" && (
+                <label className="space-y-1 text-sm">
+                  <span className="block font-medium">Cosmological epoch</span>
+                  <Input
+                    value={draft.cosmological_epoch ?? ""}
+                    onChange={(event) =>
+                      updateDraft(
+                        "cosmological_epoch",
+                        event.target.value || undefined,
+                      )
+                    }
+                  />
+                </label>
+              )}
+
+              {showErrors && (
+                <p className="text-sm text-destructive">
+                  {error ??
+                    "Complete the required fields to save this temporal value."}
+                </p>
+              )}
+
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  onClick={() => {
+                    if (candidate != null) {
+                      onChange(candidate);
+                    }
+                    setOpen(false);
+                  }}
+                >
+                  Done
+                </Button>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+      {value && showPreview ? (
+        <div className="text-sm text-foreground-muted">
+          <TemporalDisplay value={value} format="inline" showExact />
+        </div>
+      ) : (
+        <p className="text-xs text-foreground-muted">
+          {required ? "Required temporal value." : "Optional temporal value."}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/temporal-input.tsx
+++ b/packages/ui/src/components/temporal-input.tsx
@@ -266,7 +266,7 @@ function DatingMethodSourceDisclosure({
 }) {
   return (
     <DisclosureSection title="Dating method & source (optional)">
-      <div className="grid gap-3 md:grid-cols-2">
+      <div className="grid grid-cols-2 gap-3">
         <label className="space-y-1 text-sm">
           <span className="block font-medium">Method</span>
           <Input
@@ -525,7 +525,7 @@ export function TemporalInput({
               <Separator />
 
               {/* Era + Precision row */}
-              <div className="grid gap-3 md:grid-cols-2">
+              <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1 text-sm">
                   <span className="block font-medium">Era</span>
                   <EraSelectField
@@ -551,7 +551,7 @@ export function TemporalInput({
 
               {/* Year + (Month/Day for CE/BCE) or (Uncertainty for prehistoric) */}
               {draft.era === "CE" || draft.era === "BCE" ? (
-                <div className="grid gap-3 md:grid-cols-3">
+                <div className="grid grid-cols-3 gap-3">
                   <label className="space-y-1 text-sm">
                     <span className="block font-medium">Year</span>
                     <Input
@@ -606,7 +606,7 @@ export function TemporalInput({
                   </label>
                 </div>
               ) : (
-                <div className="grid gap-3 md:grid-cols-2">
+                <div className="grid grid-cols-2 gap-3">
                   <label className="space-y-1 text-sm">
                     <span className="block font-medium">Year</span>
                     <Input
@@ -655,7 +655,7 @@ export function TemporalInput({
               {(draft.era === "CE" || draft.era === "BCE") && (
                 <div className="space-y-3">
                   <DisclosureSection title="Time of day (optional)">
-                    <div className="grid gap-3 md:grid-cols-3">
+                    <div className="grid grid-cols-3 gap-3">
                       <label className="space-y-1 text-sm">
                         <span className="block font-medium">Hour</span>
                         <Input

--- a/packages/ui/src/components/temporal-input.tsx
+++ b/packages/ui/src/components/temporal-input.tsx
@@ -104,16 +104,33 @@ const maybeParse = (draft: TemporalDraft): TemporalData | null => {
 
 type FieldErrors = Partial<Record<"year" | "era", string>>;
 
-const getFieldErrors = (draft: TemporalDraft): FieldErrors => {
+interface ValidationState {
+  fieldErrors: FieldErrors;
+  /**
+   * First non-year/era issue, formatted as "field: message". Used by the
+   * catch-all error row so users see *what* failed when validation rejects a
+   * field that has no inline error slot of its own (month/day/hour/etc.).
+   */
+  genericError: string | null;
+}
+
+const getValidationState = (draft: TemporalDraft): ValidationState => {
   const result = temporalDataSchema.safeParse(draft);
-  if (result.success) return {};
-  const errors: FieldErrors = {};
+  if (result.success) return { fieldErrors: {}, genericError: null };
+  const fieldErrors: FieldErrors = {};
+  let genericError: string | null = null;
   for (const issue of result.error.issues) {
     const key = issue.path[0];
-    if (key === "year" && !errors.year) errors.year = issue.message;
-    if (key === "era" && !errors.era) errors.era = issue.message;
+    if (key === "year" && !fieldErrors.year) {
+      fieldErrors.year = issue.message;
+    } else if (key === "era" && !fieldErrors.era) {
+      fieldErrors.era = issue.message;
+    } else if (genericError == null) {
+      genericError =
+        typeof key === "string" ? `${key}: ${issue.message}` : issue.message;
+    }
   }
-  return errors;
+  return { fieldErrors, genericError };
 };
 
 const numericInputClass = "tabular-nums";
@@ -390,8 +407,11 @@ export function TemporalInput({
 
   const candidate = React.useMemo(() => maybeParse(draft), [draft]);
   const previewValue = candidate ?? value;
-  const fieldErrors = React.useMemo(
-    () => (hasInteracted ? getFieldErrors(draft) : {}),
+  const { fieldErrors, genericError } = React.useMemo(
+    () =>
+      hasInteracted
+        ? getValidationState(draft)
+        : { fieldErrors: {} as FieldErrors, genericError: null },
     [draft, hasInteracted],
   );
 
@@ -758,13 +778,15 @@ export function TemporalInput({
                 </div>
               )}
 
-              {/* Catch-all error message — only when there's no per-field error and parse failed */}
+              {/* Catch-all error — surfaces the first non-year/era schema
+                  issue so users can recover (e.g. "day: ... invalid for month"). */}
               {hasInteracted &&
                 candidate == null &&
                 !fieldErrors.year &&
                 !fieldErrors.era && (
                   <p className="text-sm text-destructive">
                     {error ??
+                      genericError ??
                       "Complete the required fields to save this temporal value."}
                   </p>
                 )}

--- a/packages/ui/src/components/temporal-input.tsx
+++ b/packages/ui/src/components/temporal-input.tsx
@@ -2,13 +2,26 @@
 
 import * as React from "react";
 
-import { TemporalDisplay } from "./temporal-display";
+import {
+  ERA_COLOR,
+  PRECISION_LABEL,
+  TemporalDisplay,
+} from "./temporal-display";
 import { Button } from "./button";
 import { Input } from "./input";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { Separator } from "./separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
 import { cn } from "@repo/ui/lib/utils";
 import {
   temporalDataSchema,
+  type ConfidenceLevel,
   type Era,
   type Precision,
   type TemporalData,
@@ -40,11 +53,31 @@ type TemporalDraft = {
   geological_period?: string;
   geological_epoch?: string;
   cosmological_epoch?: string;
-  display_format?: TemporalData["display_format"];
   dating_method?: string;
-  confidence_level?: TemporalData["confidence_level"];
+  confidence_level?: ConfidenceLevel;
   source?: string;
 };
+
+const ERAS = ["CE", "BCE", "KYA", "MYA", "BYA"] as const;
+const PRECISIONS: Precision[] = [
+  "exact",
+  "circa",
+  "approximate",
+  "estimated",
+  "geological",
+];
+const CONFIDENCE_LEVELS: ConfidenceLevel[] = ["high", "medium", "low"];
+
+const ERA_DESCRIPTION: Record<Era, string> = {
+  CE: "Common Era",
+  BCE: "Before Common Era",
+  KYA: "Thousand years ago",
+  MYA: "Million years ago",
+  BYA: "Billion years ago",
+};
+
+const isPrehistoric = (era: Era) =>
+  era === "KYA" || era === "MYA" || era === "BYA";
 
 const createDraft = (value: TemporalData | null): TemporalDraft => ({
   year: value?.year,
@@ -59,7 +92,6 @@ const createDraft = (value: TemporalData | null): TemporalDraft => ({
   geological_period: value?.geological_period ?? undefined,
   geological_epoch: value?.geological_epoch ?? undefined,
   cosmological_epoch: value?.cosmological_epoch ?? undefined,
-  display_format: value?.display_format ?? undefined,
   dating_method: value?.dating_method ?? undefined,
   confidence_level: value?.confidence_level ?? undefined,
   source: value?.source ?? undefined,
@@ -70,8 +102,255 @@ const maybeParse = (draft: TemporalDraft): TemporalData | null => {
   return result.success ? result.data : null;
 };
 
-const fieldClassName =
-  "h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20";
+type FieldErrors = Partial<Record<"year" | "era", string>>;
+
+const getFieldErrors = (draft: TemporalDraft): FieldErrors => {
+  const result = temporalDataSchema.safeParse(draft);
+  if (result.success) return {};
+  const errors: FieldErrors = {};
+  for (const issue of result.error.issues) {
+    const key = issue.path[0];
+    if (key === "year" && !errors.year) errors.year = issue.message;
+    if (key === "era" && !errors.era) errors.era = issue.message;
+  }
+  return errors;
+};
+
+const numericInputClass = "tabular-nums";
+
+// ─── DisclosureSection (native <details> with rotating ▸) ────────────────────
+
+function DisclosureSection({
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  return (
+    <details
+      open={defaultOpen}
+      className="group [&_summary::-webkit-details-marker]:hidden"
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-1.5 text-sm text-foreground-muted transition-colors hover:text-foreground">
+        <span
+          aria-hidden
+          className="inline-block w-3 text-center transition-transform group-open:rotate-90"
+        >
+          ▸
+        </span>
+        {title}
+      </summary>
+      <div className="mt-3 space-y-3 pl-4">{children}</div>
+    </details>
+  );
+}
+
+// ─── FieldError ──────────────────────────────────────────────────────────────
+
+function FieldError({ message }: { message: string | undefined }) {
+  if (!message) return null;
+  return <p className="text-xs text-destructive">{message}</p>;
+}
+
+// ─── EraSelect ───────────────────────────────────────────────────────────────
+
+function EraSelectField({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: Era;
+  onChange: (v: Era) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(v) => onChange(v as Era)}
+      disabled={disabled}
+    >
+      <SelectTrigger aria-label="Era">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {ERAS.map((era) => (
+          <SelectItem key={era} value={era}>
+            <span className="flex items-center gap-2">
+              <span className={cn("font-mono text-xs", ERA_COLOR[era])}>
+                {era}
+              </span>
+              <span className="text-foreground-muted">
+                {ERA_DESCRIPTION[era]}
+              </span>
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+// ─── PrecisionSelect ─────────────────────────────────────────────────────────
+
+function PrecisionSelectField({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: Precision;
+  onChange: (v: Precision) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(v) => onChange(v as Precision)}
+      disabled={disabled}
+    >
+      <SelectTrigger aria-label="Precision">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {PRECISIONS.map((p) => (
+          <SelectItem key={p} value={p}>
+            <span className="capitalize">{PRECISION_LABEL[p] ?? p}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+// ─── ConfidenceSelect ────────────────────────────────────────────────────────
+
+function ConfidenceSelectField({
+  value,
+  onChange,
+}: {
+  value: ConfidenceLevel | undefined;
+  onChange: (v: ConfidenceLevel | undefined) => void;
+}) {
+  return (
+    <Select
+      value={value ?? undefined}
+      onValueChange={(v) => onChange(v as ConfidenceLevel)}
+    >
+      <SelectTrigger aria-label="Confidence">
+        <SelectValue placeholder="(none)" />
+      </SelectTrigger>
+      <SelectContent>
+        {CONFIDENCE_LEVELS.map((c) => (
+          <SelectItem key={c} value={c}>
+            <span className="capitalize">{c}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+// ─── Dating method & source disclosure (shared) ──────────────────────────────
+
+function DatingMethodSourceDisclosure({
+  draft,
+  updateDraft,
+}: {
+  draft: TemporalDraft;
+  updateDraft: <K extends keyof TemporalDraft>(
+    key: K,
+    value: TemporalDraft[K],
+  ) => void;
+}) {
+  return (
+    <DisclosureSection title="Dating method & source (optional)">
+      <div className="grid gap-3 md:grid-cols-2">
+        <label className="space-y-1 text-sm">
+          <span className="block font-medium">Method</span>
+          <Input
+            placeholder="(none)"
+            value={draft.dating_method ?? ""}
+            onChange={(e) =>
+              updateDraft("dating_method", e.target.value || undefined)
+            }
+          />
+        </label>
+        <div className="space-y-1 text-sm">
+          <span className="block font-medium">Confidence</span>
+          <ConfidenceSelectField
+            value={draft.confidence_level}
+            onChange={(v) => updateDraft("confidence_level", v)}
+          />
+        </div>
+      </div>
+      <label className="block space-y-1 text-sm">
+        <span className="block font-medium">Source</span>
+        <Input
+          placeholder="(none)"
+          value={draft.source ?? ""}
+          onChange={(e) => updateDraft("source", e.target.value || undefined)}
+        />
+      </label>
+    </DisclosureSection>
+  );
+}
+
+// ─── Geological context (always-visible for prehistoric) ─────────────────────
+
+function GeologicalContext({
+  draft,
+  updateDraft,
+}: {
+  draft: TemporalDraft;
+  updateDraft: <K extends keyof TemporalDraft>(
+    key: K,
+    value: TemporalDraft[K],
+  ) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium">Geological context</p>
+      <div className="space-y-2">
+        <label className="grid grid-cols-[8rem_1fr] items-center gap-3 text-sm">
+          <span className="text-foreground-muted">Period</span>
+          <Input
+            placeholder="(none)"
+            value={draft.geological_period ?? ""}
+            onChange={(e) =>
+              updateDraft("geological_period", e.target.value || undefined)
+            }
+          />
+        </label>
+        <label className="grid grid-cols-[8rem_1fr] items-center gap-3 text-sm">
+          <span className="text-foreground-muted">Epoch</span>
+          <Input
+            placeholder="(none)"
+            value={draft.geological_epoch ?? ""}
+            onChange={(e) =>
+              updateDraft("geological_epoch", e.target.value || undefined)
+            }
+          />
+        </label>
+        {(draft.era === "MYA" || draft.era === "BYA") && (
+          <label className="grid grid-cols-[8rem_1fr] items-center gap-3 text-sm">
+            <span className="text-foreground-muted">Cosmological</span>
+            <Input
+              placeholder="(none)"
+              value={draft.cosmological_epoch ?? ""}
+              onChange={(e) =>
+                updateDraft("cosmological_epoch", e.target.value || undefined)
+              }
+            />
+          </label>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main TemporalInput component ────────────────────────────────────────────
 
 export function TemporalInput({
   value,
@@ -89,29 +368,85 @@ export function TemporalInput({
     createDraft(value),
   );
   const [hasInteracted, setHasInteracted] = React.useState(false);
+  const [eraChangeNotice, setEraChangeNotice] = React.useState<string | null>(
+    null,
+  );
+  const committedRef = React.useRef<TemporalData | null>(value);
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      // Snapshot committed value + reset draft each time the popover opens,
+      // so cancel/discard always falls back to the parent's last-saved value.
+      if (nextOpen) {
+        setDraft(createDraft(value));
+        setHasInteracted(false);
+        setEraChangeNotice(null);
+        committedRef.current = value;
+      }
+      setOpen(nextOpen);
+    },
+    [value],
+  );
 
   const candidate = React.useMemo(() => maybeParse(draft), [draft]);
   const previewValue = candidate ?? value;
+  const fieldErrors = React.useMemo(
+    () => (hasInteracted ? getFieldErrors(draft) : {}),
+    [draft, hasInteracted],
+  );
 
   const updateDraft = React.useCallback(
     <K extends keyof TemporalDraft>(key: K, nextValue: TemporalDraft[K]) => {
       setHasInteracted(true);
+      setEraChangeNotice(null);
       setDraft((current) => {
         const next = { ...current, [key]: nextValue } as TemporalDraft;
-
-        if (next.era === "CE" || next.era === "BCE") {
-          // Keep CE/BCE fields intact.
-        } else {
-          next.month = undefined;
-          next.day = undefined;
-          next.hour = undefined;
-          next.minute = undefined;
-          next.second = undefined;
+        if (key === "era") {
+          const newEra = nextValue as Era;
+          if (isPrehistoric(newEra)) {
+            const hadSubYearData =
+              current.month != null ||
+              current.day != null ||
+              current.hour != null ||
+              current.minute != null ||
+              current.second != null;
+            next.month = undefined;
+            next.day = undefined;
+            next.hour = undefined;
+            next.minute = undefined;
+            next.second = undefined;
+            if (hadSubYearData) {
+              setEraChangeNotice(
+                `Month, day, and time were cleared for ${newEra} dates.`,
+              );
+            }
+          }
+          // Clear cosmological_epoch when leaving BYA/MYA → KYA (KYA can't have it)
+          if (newEra === "KYA") {
+            next.cosmological_epoch = undefined;
+          }
         }
         return next;
       });
     },
     [],
+  );
+
+  const handleYearChange = React.useCallback(
+    (raw: string) => {
+      if (raw === "") {
+        updateDraft("year", undefined);
+        return;
+      }
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+        // Reject non-integer entries; field stays at last valid value.
+        setHasInteracted(true);
+        return;
+      }
+      updateDraft("year", parsed);
+    },
+    [updateDraft],
   );
 
   const clear = React.useCallback(() => {
@@ -120,7 +455,25 @@ export function TemporalInput({
     onChange(null);
   }, [onChange]);
 
-  const showErrors = hasInteracted && candidate == null;
+  const cancel = React.useCallback(() => {
+    setDraft(createDraft(committedRef.current));
+    setHasInteracted(false);
+    setEraChangeNotice(null);
+    setOpen(false);
+  }, []);
+
+  const apply = React.useCallback(() => {
+    setHasInteracted(true);
+    if (candidate != null) {
+      onChange(candidate);
+      committedRef.current = candidate;
+      setOpen(false);
+    }
+    // If parse failed, leave popover open so field errors surface.
+  }, [candidate, onChange]);
+
+  const showPrecisionWarning =
+    isPrehistoric(draft.era) && draft.precision === "exact";
 
   return (
     <div className={cn("space-y-2", className)} {...props}>
@@ -141,7 +494,7 @@ export function TemporalInput({
               Clear
             </Button>
           )}
-          <Popover open={open} onOpenChange={setOpen}>
+          <Popover open={open} onOpenChange={handleOpenChange}>
             <PopoverTrigger asChild>
               <Button type="button" variant="secondary" disabled={disabled}>
                 {previewValue ? (
@@ -151,224 +504,140 @@ export function TemporalInput({
                 )}
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-152 space-y-4">
-              {showPreview && (
-                <div className="rounded-md border border-border bg-surface px-3 py-2 text-sm">
-                  {candidate ? (
-                    <TemporalDisplay
-                      value={candidate}
-                      format="block"
-                      showExact
-                    />
-                  ) : (
-                    <span className="text-foreground-muted">
-                      Finish the required fields to preview the date.
-                    </span>
-                  )}
-                </div>
-              )}
-
-              <div className="grid gap-3 md:grid-cols-2">
-                <label className="space-y-1 text-sm">
-                  <span className="block font-medium">Era</span>
-                  <select
-                    className={cn(fieldClassName, "w-full")}
-                    value={draft.era}
-                    onChange={(event) =>
-                      updateDraft("era", event.target.value as Era)
-                    }
-                  >
-                    {(["CE", "BCE", "KYA", "MYA", "BYA"] as const).map(
-                      (era) => (
-                        <option key={era} value={era}>
-                          {era}
-                        </option>
-                      ),
-                    )}
-                  </select>
-                </label>
-                <label className="space-y-1 text-sm">
-                  <span className="block font-medium">Precision</span>
-                  <select
-                    className={cn(fieldClassName, "w-full")}
-                    value={draft.precision}
-                    onChange={(event) =>
-                      updateDraft("precision", event.target.value as Precision)
-                    }
-                  >
-                    {(
-                      [
-                        "exact",
-                        "circa",
-                        "approximate",
-                        "estimated",
-                        "geological",
-                      ] as const
-                    ).map((precision) => (
-                      <option key={precision} value={precision}>
-                        {precision}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              </div>
-
-              <div className="grid gap-3 md:grid-cols-3">
-                <label className="space-y-1 text-sm md:col-span-1">
-                  <span className="block font-medium">Year</span>
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    min={1}
-                    step={1}
-                    value={draft.year ?? ""}
-                    onChange={(event) =>
-                      updateDraft(
-                        "year",
-                        event.target.value === ""
-                          ? undefined
-                          : Number(event.target.value),
-                      )
-                    }
+            <PopoverContent className="w-[min(36rem,calc(100vw-2rem))] space-y-4">
+              {/* Preview row */}
+              <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm">
+                <span className="font-medium text-foreground-muted">
+                  Preview:
+                </span>
+                {candidate ? (
+                  <TemporalDisplay
+                    value={candidate}
+                    format="inline"
+                    showExact
                   />
-                </label>
-                {draft.era === "CE" || draft.era === "BCE" ? (
-                  <>
-                    <label className="space-y-1 text-sm">
-                      <span className="block font-medium">Month</span>
-                      <Input
-                        type="number"
-                        inputMode="numeric"
-                        min={1}
-                        max={12}
-                        value={draft.month ?? ""}
-                        onChange={(event) =>
-                          updateDraft(
-                            "month",
-                            event.target.value === ""
-                              ? undefined
-                              : Number(event.target.value),
-                          )
-                        }
-                      />
-                    </label>
-                    <label className="space-y-1 text-sm">
-                      <span className="block font-medium">Day</span>
-                      <Input
-                        type="number"
-                        inputMode="numeric"
-                        min={1}
-                        max={31}
-                        value={draft.day ?? ""}
-                        onChange={(event) =>
-                          updateDraft(
-                            "day",
-                            event.target.value === ""
-                              ? undefined
-                              : Number(event.target.value),
-                          )
-                        }
-                      />
-                    </label>
-                  </>
                 ) : (
-                  <div className="md:col-span-2 rounded-md border border-dashed border-border px-3 py-2 text-sm text-foreground-muted">
-                    Month and day are hidden for prehistoric eras.
-                  </div>
+                  <span className="italic text-foreground-muted">
+                    Finish required fields to preview.
+                  </span>
                 )}
               </div>
+              <Separator />
 
-              {(draft.era === "CE" || draft.era === "BCE") && (
+              {/* Era + Precision row */}
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-1 text-sm">
+                  <span className="block font-medium">Era</span>
+                  <EraSelectField
+                    value={draft.era}
+                    onChange={(v) => updateDraft("era", v)}
+                  />
+                  <FieldError message={fieldErrors.era} />
+                </div>
+                <div className="space-y-1 text-sm">
+                  <span className="block font-medium">Precision</span>
+                  <PrecisionSelectField
+                    value={draft.precision}
+                    onChange={(v) => updateDraft("precision", v)}
+                  />
+                  {showPrecisionWarning && (
+                    <p className="text-xs text-foreground-muted">
+                      Exact precision is rarely honest at the {draft.era} scale
+                      — consider “approximate” or “estimated”.
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* Year + (Month/Day for CE/BCE) or (Uncertainty for prehistoric) */}
+              {draft.era === "CE" || draft.era === "BCE" ? (
                 <div className="grid gap-3 md:grid-cols-3">
                   <label className="space-y-1 text-sm">
-                    <span className="block font-medium">Hour</span>
+                    <span className="block font-medium">Year</span>
                     <Input
                       type="number"
                       inputMode="numeric"
-                      min={0}
-                      max={23}
-                      value={draft.hour ?? ""}
-                      onChange={(event) =>
+                      min={1}
+                      step={1}
+                      className={numericInputClass}
+                      value={draft.year ?? ""}
+                      onChange={(e) => handleYearChange(e.target.value)}
+                      aria-invalid={fieldErrors.year ? true : undefined}
+                    />
+                    <FieldError message={fieldErrors.year} />
+                  </label>
+                  <label className="space-y-1 text-sm">
+                    <span className="block font-medium">Month</span>
+                    <Input
+                      type="number"
+                      inputMode="numeric"
+                      min={1}
+                      max={12}
+                      className={numericInputClass}
+                      value={draft.month ?? ""}
+                      onChange={(e) =>
                         updateDraft(
-                          "hour",
-                          event.target.value === ""
+                          "month",
+                          e.target.value === ""
                             ? undefined
-                            : Number(event.target.value),
+                            : Number(e.target.value),
                         )
                       }
                     />
                   </label>
                   <label className="space-y-1 text-sm">
-                    <span className="block font-medium">Minute</span>
+                    <span className="block font-medium">Day</span>
                     <Input
                       type="number"
                       inputMode="numeric"
-                      min={0}
-                      max={59}
-                      value={draft.minute ?? ""}
-                      onChange={(event) =>
+                      min={1}
+                      max={31}
+                      className={numericInputClass}
+                      value={draft.day ?? ""}
+                      onChange={(e) =>
                         updateDraft(
-                          "minute",
-                          event.target.value === ""
+                          "day",
+                          e.target.value === ""
                             ? undefined
-                            : Number(event.target.value),
-                        )
-                      }
-                    />
-                  </label>
-                  <label className="space-y-1 text-sm">
-                    <span className="block font-medium">Second</span>
-                    <Input
-                      type="number"
-                      inputMode="decimal"
-                      min={0}
-                      max={59}
-                      value={draft.second ?? ""}
-                      onChange={(event) =>
-                        updateDraft(
-                          "second",
-                          event.target.value === ""
-                            ? undefined
-                            : Number(event.target.value),
+                            : Number(e.target.value),
                         )
                       }
                     />
                   </label>
                 </div>
-              )}
-
-              {(draft.era === "KYA" ||
-                draft.era === "MYA" ||
-                draft.era === "BYA") && (
+              ) : (
                 <div className="grid gap-3 md:grid-cols-2">
                   <label className="space-y-1 text-sm">
+                    <span className="block font-medium">Year</span>
+                    <Input
+                      type="number"
+                      inputMode="numeric"
+                      min={1}
+                      step={1}
+                      className={numericInputClass}
+                      value={draft.year ?? ""}
+                      onChange={(e) => handleYearChange(e.target.value)}
+                      aria-invalid={fieldErrors.year ? true : undefined}
+                    />
+                    <FieldError message={fieldErrors.year} />
+                  </label>
+                  <label className="space-y-1 text-sm">
                     <span className="block font-medium">
-                      Uncertainty (years)
+                      Uncertainty (± years)
                     </span>
                     <Input
                       type="number"
                       inputMode="decimal"
                       min={0}
                       step="any"
+                      className={numericInputClass}
                       value={draft.uncertainty ?? ""}
-                      onChange={(event) =>
+                      onChange={(e) =>
                         updateDraft(
                           "uncertainty",
-                          event.target.value === ""
+                          e.target.value === ""
                             ? undefined
-                            : Number(event.target.value),
-                        )
-                      }
-                    />
-                  </label>
-                  <label className="space-y-1 text-sm">
-                    <span className="block font-medium">Dating method</span>
-                    <Input
-                      value={draft.dating_method ?? ""}
-                      onChange={(event) =>
-                        updateDraft(
-                          "dating_method",
-                          event.target.value || undefined,
+                            : Number(e.target.value),
                         )
                       }
                     />
@@ -376,74 +645,150 @@ export function TemporalInput({
                 </div>
               )}
 
-              {(draft.era === "MYA" || draft.era === "BYA") && (
-                <div className="grid gap-3 md:grid-cols-2">
-                  <label className="space-y-1 text-sm">
-                    <span className="block font-medium">Geological period</span>
-                    <Input
-                      value={draft.geological_period ?? ""}
-                      onChange={(event) =>
-                        updateDraft(
-                          "geological_period",
-                          event.target.value || undefined,
-                        )
-                      }
-                    />
-                  </label>
-                  <label className="space-y-1 text-sm">
-                    <span className="block font-medium">Geological epoch</span>
-                    <Input
-                      value={draft.geological_epoch ?? ""}
-                      onChange={(event) =>
-                        updateDraft(
-                          "geological_epoch",
-                          event.target.value || undefined,
-                        )
-                      }
-                    />
-                  </label>
-                </div>
-              )}
-
-              {draft.era === "BYA" && (
-                <label className="space-y-1 text-sm">
-                  <span className="block font-medium">Cosmological epoch</span>
-                  <Input
-                    value={draft.cosmological_epoch ?? ""}
-                    onChange={(event) =>
-                      updateDraft(
-                        "cosmological_epoch",
-                        event.target.value || undefined,
-                      )
-                    }
-                  />
-                </label>
-              )}
-
-              {showErrors && (
-                <p className="text-sm text-destructive">
-                  {error ??
-                    "Complete the required fields to save this temporal value."}
+              {eraChangeNotice && (
+                <p className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-foreground-muted">
+                  {eraChangeNotice}
                 </p>
               )}
 
-              <div className="flex justify-end">
+              {/* CE/BCE disclosures: Time of day, Uncertainty, Dating method & source */}
+              {(draft.era === "CE" || draft.era === "BCE") && (
+                <div className="space-y-3">
+                  <DisclosureSection title="Time of day (optional)">
+                    <div className="grid gap-3 md:grid-cols-3">
+                      <label className="space-y-1 text-sm">
+                        <span className="block font-medium">Hour</span>
+                        <Input
+                          type="number"
+                          inputMode="numeric"
+                          min={0}
+                          max={23}
+                          className={numericInputClass}
+                          value={draft.hour ?? ""}
+                          onChange={(e) =>
+                            updateDraft(
+                              "hour",
+                              e.target.value === ""
+                                ? undefined
+                                : Number(e.target.value),
+                            )
+                          }
+                        />
+                      </label>
+                      <label className="space-y-1 text-sm">
+                        <span className="block font-medium">Minute</span>
+                        <Input
+                          type="number"
+                          inputMode="numeric"
+                          min={0}
+                          max={59}
+                          className={numericInputClass}
+                          value={draft.minute ?? ""}
+                          onChange={(e) =>
+                            updateDraft(
+                              "minute",
+                              e.target.value === ""
+                                ? undefined
+                                : Number(e.target.value),
+                            )
+                          }
+                        />
+                      </label>
+                      <label className="space-y-1 text-sm">
+                        <span className="block font-medium">Second</span>
+                        <Input
+                          type="number"
+                          inputMode="decimal"
+                          min={0}
+                          max={59}
+                          className={numericInputClass}
+                          value={draft.second ?? ""}
+                          onChange={(e) =>
+                            updateDraft(
+                              "second",
+                              e.target.value === ""
+                                ? undefined
+                                : Number(e.target.value),
+                            )
+                          }
+                        />
+                      </label>
+                    </div>
+                  </DisclosureSection>
+
+                  <DisclosureSection title="Uncertainty (optional)">
+                    <label className="block space-y-1 text-sm">
+                      <span className="block font-medium">
+                        Uncertainty (± years)
+                      </span>
+                      <Input
+                        type="number"
+                        inputMode="decimal"
+                        min={0}
+                        step="any"
+                        className={numericInputClass}
+                        value={draft.uncertainty ?? ""}
+                        onChange={(e) =>
+                          updateDraft(
+                            "uncertainty",
+                            e.target.value === ""
+                              ? undefined
+                              : Number(e.target.value),
+                          )
+                        }
+                      />
+                    </label>
+                  </DisclosureSection>
+
+                  <DatingMethodSourceDisclosure
+                    draft={draft}
+                    updateDraft={updateDraft}
+                  />
+                </div>
+              )}
+
+              {/* Prehistoric: Geological context always shown; dating-method disclosure */}
+              {isPrehistoric(draft.era) && (
+                <div className="space-y-4">
+                  <GeologicalContext draft={draft} updateDraft={updateDraft} />
+                  <DatingMethodSourceDisclosure
+                    draft={draft}
+                    updateDraft={updateDraft}
+                  />
+                </div>
+              )}
+
+              {/* Catch-all error message — only when there's no per-field error and parse failed */}
+              {hasInteracted &&
+                candidate == null &&
+                !fieldErrors.year &&
+                !fieldErrors.era && (
+                  <p className="text-sm text-destructive">
+                    {error ??
+                      "Complete the required fields to save this temporal value."}
+                  </p>
+                )}
+
+              <Separator />
+
+              {/* Footer */}
+              <div className="flex items-center justify-end gap-2">
+                <Button type="button" variant="ghost" onClick={cancel}>
+                  Cancel
+                </Button>
                 <Button
                   type="button"
-                  onClick={() => {
-                    if (candidate != null) {
-                      onChange(candidate);
-                    }
-                    setOpen(false);
-                  }}
+                  onClick={apply}
+                  disabled={candidate == null}
                 >
-                  Done
+                  Apply
                 </Button>
               </div>
             </PopoverContent>
           </Popover>
         </div>
       </div>
+
       {value && showPreview ? (
         <div className="text-sm text-foreground-muted">
           <TemporalDisplay value={value} format="inline" showExact />

--- a/packages/ui/src/components/textarea.stories.tsx
+++ b/packages/ui/src/components/textarea.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Textarea } from "./textarea";
+
+const meta = {
+  title: "Components/Textarea",
+  component: Textarea,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "Write a short biography...",
+  },
+  render: (args) => <Textarea className="w-[28rem]" {...args} />,
+};
+
+export const WithValue: Story = {
+  args: {
+    defaultValue:
+      "Marie Curie was a Polish and naturalized-French physicist and chemist.",
+  },
+  render: (args) => <Textarea className="w-[28rem]" {...args} />,
+};
+
+export const Disabled: Story = {
+  args: {
+    defaultValue: "Read-only text area",
+    disabled: true,
+  },
+  render: (args) => <Textarea className="w-[28rem]" {...args} />,
+};

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => (
+  <textarea
+    className={cn(
+      "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -14,8 +14,13 @@ export default defineConfig({
       reporter: ["text", "html", "lcov"],
       // Scope to files that have tests. Expand this list as test coverage grows.
       include: [
+        "src/components/autosave-indicator.tsx",
+        "src/components/chip-input.tsx",
         "src/components/button.tsx",
+        "src/components/save-dropdown.tsx",
+        "src/components/slug-field.tsx",
         "src/components/temporal-display.tsx",
+        "src/components/temporal-input.tsx",
         "src/hooks/use-categories.tsx",
         "src/hooks/use-character-relationships.tsx",
         "src/hooks/use-characters.tsx",

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -1,1 +1,25 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+// jsdom shims for Radix UI primitives (Select, Popover, etc.) which rely on
+// DOM APIs that jsdom doesn't implement. Without these, any test that mounts
+// a Radix Select trigger or opens a portal-based menu throws at render time.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+if (typeof Element !== "undefined") {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = vi.fn();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.10
         version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-separator':
         specifier: ^1.1.8
         version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1584,6 +1587,19 @@ packages:
 
   '@radix-ui/react-scroll-area@1.2.10':
     resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5262,6 +5278,35 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.15)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.15)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)


### PR DESCRIPTION
## Summary

This PR completes the Batch G editor-primitives work for issue #40 by implementing the reusable edit controls centered on `TemporalInput`, wiring them into composite editor stories, and updating planning docs to reflect the finalized Batch G scope.

Close #40

## Why

The admin editor surfaces needed production-ready primitives for temporal fields, slug workflows, chip/tag arrays, autosave status, and save action variants. This PR delivers those controls and demonstrates them in realistic page-level stories (`Character Editor`, `Event Editor`) so the UX can be reviewed end-to-end in Storybook.

## Scope Completed for #40

1. Implemented editor primitives:
- `TemporalInput`
- `SlugField`
- `ChipInput`
- `SaveDropdown`
- `AutosaveIndicator`
- `Textarea` (supporting primitive used by editors)

2. Added/updated required supporting UI behavior:
- `Button` destructive variant support
- Tailwind v4 compatibility cleanup in dropdown/table utility components where needed

3. Added composite editor stories:
- `Pages > Character Editor`
- `Pages > Event Editor`

4. Added missing stories for newly introduced/supporting components:
- `Textarea`, `Checkbox`, `Slider`, `Table`, `DataTable`, `FilterRail`
- Stories for each new editor primitive above

5. Added test coverage for new primitives:
- `TemporalInput`
- `SlugField`
- `ChipInput`
- `SaveDropdown`
- `AutosaveIndicator`
- Coverage include config updated to enforce these paths

6. Updated planning documentation:
- Batch G scope clarified around editor primitives/TemporalInput + docs refresh
- Batch statuses reconciled (including Batch F done, Batch G in review)
- Route integration explicitly tracked outside Batch G

## Behavioral Highlights

- `TemporalInput` uses a draft-edit model with explicit commit actions (`Done`/`Clear`) to avoid render-phase state update issues and provide predictable form behavior.
- `SlugField` supports create/edit modes with lock/unlock behavior and generation/collision flow.
- `ChipInput` supports keyboard add/remove behavior and comma-separated paste parsing.
- `SaveDropdown` exposes primary and alternate save actions for editor workflows.
- Composite stories exercise the primitives in realistic shell/page contexts with representative editor state.

## Validation

Executed and passing:

1. `pnpm run check-types`
2. `pnpm run lint`
3. `pnpm run build`
4. `pnpm run test:coverage`

## Non-goals / Explicitly Out of Scope

1. Editor route integration in admin (`/characters/new`, `/events/new`) is not part of this PR’s Batch G scope.
2. Relationship editor (Batch H) work is not included.

## Risk / Review Notes

1. Largest files are the composite stories (intentional: rich fixture coverage for reviewer confidence).
2. No schema/API contract changes.
3. Changes are UI-layer and Storybook/test/documentation focused, minimizing backend risk.
