### PR TITLE
feat(ui): Batch H — Relationships editor (closes fidelity-2 sweep)

### DIFF
--- a/docs/design/admin/fidelity-2-plan.md
+++ b/docs/design/admin/fidelity-2-plan.md
@@ -30,16 +30,16 @@ The fidelity-1 design review filed three follow-up issues; all are resolved or o
 
 The original fidelity-2 outline didn't reference the foundational GitHub issues that gate the admin app's bootstrap. This revision aligns each batch with the open issues it closes, so the work shows up against the project plan and doesn't grow a parallel paper trail.
 
-| Batch                                  | Closes / advances                                                                                                                                                        | Status      |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| **[A](#batch-a--foundations)**         | [#37](https://github.com/shaes-farm/time-traveler/issues/37) (shadcn + Tailwind theme)                                                                                   | done        |
-| **[B](#batch-b--app-shell)**           | [#38](https://github.com/shaes-farm/time-traveler/issues/38) (app shell + route groups + sidebar/header)                                                                 | done        |
-| **[C](#batch-c--auth-infrastructure)** | [#35](https://github.com/shaes-farm/time-traveler/issues/35) (Supabase Auth), [#36](https://github.com/shaes-farm/time-traveler/issues/36) (`proxy.ts` route protection) | done        |
-| **[D](#batch-d--auth-ui)**             | [#39](https://github.com/shaes-farm/time-traveler/issues/39) (login, register, magic link, password reset)                                                               | done        |
-| **[E](#batch-e--temporal-primitive)**  | originally Batch B; reads against PRD §4 / system-design §4                                                                                                              | done        |
-| **[F](#batch-f--list-primitives)**     | originally Batch D                                                                                                                                                       | done        |
-| **[G](#batch-g--editor-primitives)**   | [#40](https://github.com/shaes-farm/time-traveler/issues/40) (TemporalInput/editor primitives + docs refresh)                                                            | in review   |
-| **[H](#batch-h--relationship-editor)** | originally Batch F; finishes the [#119](https://github.com/shaes-farm/time-traveler/issues/119) UX                                                                       | not started |
+| Batch                                  | Closes / advances                                                                                                                                                        | Status |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
+| **[A](#batch-a--foundations)**         | [#37](https://github.com/shaes-farm/time-traveler/issues/37) (shadcn + Tailwind theme)                                                                                   | done   |
+| **[B](#batch-b--app-shell)**           | [#38](https://github.com/shaes-farm/time-traveler/issues/38) (app shell + route groups + sidebar/header)                                                                 | done   |
+| **[C](#batch-c--auth-infrastructure)** | [#35](https://github.com/shaes-farm/time-traveler/issues/35) (Supabase Auth), [#36](https://github.com/shaes-farm/time-traveler/issues/36) (`proxy.ts` route protection) | done   |
+| **[D](#batch-d--auth-ui)**             | [#39](https://github.com/shaes-farm/time-traveler/issues/39) (login, register, magic link, password reset)                                                               | done   |
+| **[E](#batch-e--temporal-primitive)**  | originally Batch B; reads against PRD §4 / system-design §4                                                                                                              | done   |
+| **[F](#batch-f--list-primitives)**     | originally Batch D                                                                                                                                                       | done   |
+| **[G](#batch-g--editor-primitives)**   | [#40](https://github.com/shaes-farm/time-traveler/issues/40) (TemporalInput/editor primitives + docs refresh)                                                            | done   |
+| **[H](#batch-h--relationship-editor)** | originally Batch F; finishes the [#119](https://github.com/shaes-farm/time-traveler/issues/119) UX                                                                       | done   |
 
 Why app shell + auth before the temporal primitive: the TemporalDisplay primitive is the highest-leverage component visually, but every later batch (lists, editors, relationships) renders inside the protected shell. Building the chrome first means later composite stories can mount their primitives in a real shell context instead of a Storybook-only frame, and the auth + proxy work unblocks any future "go look at the running admin app" verification step. The TemporalDisplay still lands before list/editor work, which is where it actually gets consumed.
 
@@ -252,7 +252,7 @@ Originally Batch D.
 - Composite stories: `Pages > Characters List`, `Pages > Events List` (mounted in the Shell)
 - Per the [wireframe decisions](02-wireframes/03-characters-list.md): hover-card thumbnails (no dedicated thumbnail column), labels-only filter chips this fidelity, no card view (per [#127](https://github.com/shaes-farm/time-traveler/issues/127))
 
-### Batch G — Editor primitives
+### Batch G — Editor primitives ✅ landed in [#161](https://github.com/shaes-farm/time-traveler/pull/161)
 
 Originally Batch E.
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",

--- a/packages/ui/src/components/data-table.test.tsx
+++ b/packages/ui/src/components/data-table.test.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { Badge } from "./badge";
+import { DataTable, createSelectColumn } from "./data-table";
+import { StatusBadge } from "./status-badge";
+
+interface RowData {
+  id: string;
+  name: string;
+  status: "published" | "draft";
+  count: number;
+}
+
+const ROWS: RowData[] = [
+  { id: "2", name: "Zed", status: "draft", count: 2 },
+  { id: "1", name: "Ada", status: "published", count: 10 },
+];
+
+const COLUMNS: ColumnDef<RowData>[] = [
+  createSelectColumn<RowData>(),
+  {
+    accessorKey: "name",
+    header: "Name",
+    cell: ({ row }) => <span>{row.original.name}</span>,
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ getValue }) => (
+      <StatusBadge status={getValue() as RowData["status"]} />
+    ),
+  },
+  {
+    accessorKey: "count",
+    header: "Count",
+    cell: ({ getValue }) => (
+      <Badge variant="outline">{getValue() as number}</Badge>
+    ),
+  },
+];
+
+describe("DataTable", () => {
+  it("renders an empty-state row when there is no data", () => {
+    render(<DataTable columns={COLUMNS} data={[]} />);
+
+    expect(screen.getByText("No results.")).toBeInTheDocument();
+  });
+
+  it("sorts rows when a sortable header is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DataTable columns={COLUMNS} data={ROWS} />);
+
+    await user.click(screen.getByRole("button", { name: /name/i }));
+
+    const [headerRow, firstBodyRow, secondBodyRow] = screen.getAllByRole("row");
+    expect(headerRow).toBeInTheDocument();
+    expect(within(firstBodyRow!).getByText("Ada")).toBeInTheDocument();
+    expect(within(secondBodyRow!).getByText("Zed")).toBeInTheDocument();
+  });
+
+  it("calls onRowClick when a row is selected and keeps selection controls in place", async () => {
+    const user = userEvent.setup();
+    const onRowClick = vi.fn();
+
+    render(<DataTable columns={COLUMNS} data={ROWS} onRowClick={onRowClick} />);
+
+    await user.click(screen.getByText("Ada"));
+    expect(onRowClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "1" }),
+    );
+
+    expect(
+      screen.getByRole("checkbox", { name: /select all/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("checkbox", { name: /select row/i }),
+    ).toHaveLength(2);
+  });
+});

--- a/packages/ui/src/components/filter-rail.test.tsx
+++ b/packages/ui/src/components/filter-rail.test.tsx
@@ -1,0 +1,119 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { FilterGroup, RadioValue } from "./filter-rail";
+import { FilterRail } from "./filter-rail";
+
+vi.mock("./slider", () => ({
+  Slider: ({
+    value,
+    onValueChange,
+  }: {
+    value: [number, number];
+    onValueChange: (next: [number, number]) => void;
+  }) => (
+    <button
+      type="button"
+      role="slider"
+      onClick={() => onValueChange([value[0] + 1, value[1] + 1])}
+    >
+      Mock Slider
+    </button>
+  ),
+}));
+
+function FilterRailHarness() {
+  const [types, setTypes] = React.useState<string[]>([]);
+  const [importance, setImportance] = React.useState<[number, number]>([2, 8]);
+  const [published, setPublished] = React.useState<RadioValue>("any");
+
+  const groups: FilterGroup[] = [
+    {
+      type: "checkbox",
+      id: "type",
+      label: "Character type",
+      options: [
+        { value: "human", label: "Human", count: 3 },
+        { value: "organization", label: "Organization", count: 1 },
+      ],
+      value: types,
+      onChange: setTypes,
+    },
+    {
+      type: "range",
+      id: "importance",
+      label: "Importance",
+      min: 1,
+      max: 10,
+      value: importance,
+      onChange: setImportance,
+      formatLabel: (value) => `${value}/10`,
+    },
+    {
+      type: "radio",
+      id: "published",
+      label: "Published",
+      value: published,
+      onChange: setPublished,
+      yesLabel: "Published",
+      noLabel: "Draft",
+    },
+  ];
+
+  return (
+    <FilterRail
+      groups={groups}
+      onClearAll={() => {
+        setTypes([]);
+        setImportance([1, 10]);
+        setPublished("any");
+      }}
+    />
+  );
+}
+
+describe("FilterRail", () => {
+  it("toggles checkbox filters and reveals clear-all when active", async () => {
+    const user = userEvent.setup();
+    render(<FilterRailHarness />);
+
+    const humanCheckbox = screen.getAllByRole("checkbox")[0]!;
+    await user.click(humanCheckbox);
+
+    expect(
+      screen.getByRole("button", { name: /clear all/i }),
+    ).toBeInTheDocument();
+    expect(humanCheckbox).toBeChecked();
+  });
+
+  it("updates the range group via keyboard interaction", async () => {
+    const user = userEvent.setup();
+    render(<FilterRailHarness />);
+
+    const slider = screen.getAllByRole("slider")[0]!;
+    await user.click(slider);
+
+    expect(screen.getByText(/Importance/i)).toBeInTheDocument();
+    expect(screen.getByText(/3\/10/i)).toBeInTheDocument();
+    expect(screen.getByText(/9\/10/i)).toBeInTheDocument();
+  });
+
+  it("switches radio options and clears all active filters", async () => {
+    const user = userEvent.setup();
+    render(<FilterRailHarness />);
+
+    await user.click(screen.getByRole("button", { name: /published/i }));
+    expect(
+      screen.getByRole("button", { name: /clear all/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /clear all/i }));
+
+    const humanCheckbox = screen.getAllByRole("checkbox")[0]!;
+    expect(humanCheckbox).not.toBeChecked();
+    expect(screen.getByText(/1\/10/i)).toBeInTheDocument();
+    expect(screen.getByText(/10\/10/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/radio-group.stories.tsx
+++ b/packages/ui/src/components/radio-group.stories.tsx
@@ -1,0 +1,100 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RadioGroup, RadioGroupItem } from "./radio-group";
+import { Label } from "./label";
+
+const meta = {
+  title: "Components/Radio Group",
+  component: RadioGroup,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof RadioGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ColorPickerHarness({ disabled = false }: { disabled?: boolean }) {
+  const [value, setValue] = React.useState("amber");
+  return (
+    <RadioGroup
+      value={value}
+      onValueChange={setValue}
+      disabled={disabled}
+      className="gap-2"
+    >
+      <div className="flex items-center gap-2">
+        <RadioGroupItem id="amber" value="amber" />
+        <Label htmlFor="amber" className="font-normal">
+          Amber
+        </Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <RadioGroupItem id="teal" value="teal" />
+        <Label htmlFor="teal" className="font-normal">
+          Teal
+        </Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <RadioGroupItem id="magenta" value="magenta" />
+        <Label htmlFor="magenta" className="font-normal">
+          Magenta
+        </Label>
+      </div>
+    </RadioGroup>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ColorPickerHarness />,
+};
+
+export const Disabled: Story = {
+  render: () => <ColorPickerHarness disabled />,
+};
+
+/**
+ * Grouped via <fieldset>/<legend> — the pattern Batch H's
+ * RelationshipTypeSelector consumes. A single RadioGroup wraps multiple
+ * fieldsets so the radio semantics stay correct while the DOM still
+ * communicates the family-level grouping to assistive tech.
+ */
+export const Grouped: Story = {
+  render: () => {
+    function Wrapper() {
+      const [value, setValue] = React.useState("family");
+      return (
+        <RadioGroup value={value} onValueChange={setValue} className="gap-4">
+          <fieldset className="space-y-2 border-0 p-0">
+            <legend className="mb-1 text-xs uppercase tracking-wider text-foreground-muted">
+              Symmetric
+            </legend>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem id="g-family" value="family" />
+              <Label htmlFor="g-family" className="font-normal">
+                Family
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem id="g-friendship" value="friendship" />
+              <Label htmlFor="g-friendship" className="font-normal">
+                Friendship
+              </Label>
+            </div>
+          </fieldset>
+          <fieldset className="space-y-2 border-0 p-0">
+            <legend className="mb-1 text-xs uppercase tracking-wider text-foreground-muted">
+              Asymmetric
+            </legend>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem id="g-mentor" value="mentor_student" />
+              <Label htmlFor="g-mentor" className="font-normal">
+                Mentor / Student
+              </Label>
+            </div>
+          </fieldset>
+        </RadioGroup>
+      );
+    }
+    return <Wrapper />;
+  },
+};

--- a/packages/ui/src/components/radio-group.tsx
+++ b/packages/ui/src/components/radio-group.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Circle } from "lucide-react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/packages/ui/src/components/relationship-card.stories.tsx
+++ b/packages/ui/src/components/relationship-card.stories.tsx
@@ -1,0 +1,251 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { TemporalData } from "@repo/services/schemas/temporal.js";
+
+import { RelationshipCard } from "./relationship-card";
+
+const meta = {
+  title: "Components/Relationship Card",
+  component: RelationshipCard,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof RelationshipCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const T = (
+  data: Partial<TemporalData> & Pick<TemporalData, "year" | "era">,
+): TemporalData => ({ precision: "exact", ...data });
+
+const noop = () => {};
+
+// ─── Fixtures by type-family group ───────────────────────────────────────────
+
+export const Family: Story = {
+  args: {
+    otherCharacter: {
+      name: "Pierre Curie",
+      slug: "pierre-curie",
+      characterType: "human",
+      initials: "PC",
+    },
+    relationshipType: "family",
+  },
+  render: () => (
+    <RelationshipCard
+      otherCharacter={{
+        name: "Pierre Curie",
+        slug: "pierre-curie",
+        characterType: "human",
+        initials: "PC",
+      }}
+      relationshipType="family"
+      relationshipRole="spouse"
+      startTemporal={T({ year: 1895, era: "CE" })}
+      endTemporal={T({ year: 1906, era: "CE" })}
+      description="Marriage; collaborated on the discovery of polonium and radium."
+      onEdit={noop}
+      onDuplicate={noop}
+      onDelete={noop}
+    />
+  ),
+};
+
+export const Professional: Story = {
+  args: {
+    otherCharacter: {
+      name: "Université de Paris",
+      slug: "universite-de-paris",
+      characterType: "organization",
+      initials: "UP",
+    },
+    relationshipType: "professional",
+  },
+  render: () => (
+    <RelationshipCard
+      otherCharacter={{
+        name: "Université de Paris",
+        slug: "universite-de-paris",
+        characterType: "organization",
+        initials: "UP",
+      }}
+      relationshipType="professional"
+      relationshipRole="employer"
+      startTemporal={T({ year: 1906, era: "CE" })}
+      endTemporal={T({ year: 1934, era: "CE" })}
+      description="First female professor at the Sorbonne."
+      onEdit={noop}
+      onDuplicate={noop}
+      onDelete={noop}
+    />
+  ),
+};
+
+export const SocialPersonal: Story = {
+  args: {
+    otherCharacter: {
+      name: "Albert Einstein",
+      slug: "albert-einstein",
+      characterType: "human",
+      initials: "AE",
+    },
+    relationshipType: "friendship",
+  },
+  render: () => (
+    <RelationshipCard
+      otherCharacter={{
+        name: "Albert Einstein",
+        slug: "albert-einstein",
+        characterType: "human",
+        initials: "AE",
+      }}
+      relationshipType="friendship"
+      startTemporal={T({ year: 1909, era: "CE" })}
+      endTemporal={T({ year: 1934, era: "CE" })}
+      description="Met at the 1911 Solvay Conference; corresponded for years."
+      onEdit={noop}
+      onDelete={noop}
+    />
+  ),
+};
+
+export const Antagonistic: Story = {
+  args: {
+    otherCharacter: {
+      name: "Paul Langevin",
+      slug: "paul-langevin",
+      characterType: "human",
+      initials: "PL",
+    },
+    relationshipType: "rivalry",
+  },
+  render: () => (
+    <RelationshipCard
+      otherCharacter={{
+        name: "Paul Langevin",
+        slug: "paul-langevin",
+        characterType: "human",
+        initials: "PL",
+      }}
+      relationshipType="rivalry"
+      startTemporal={T({ year: 1910, era: "CE" })}
+      endTemporal={T({ year: 1911, era: "CE" })}
+      description="Public scandal following the affair and divorce proceedings."
+      onEdit={noop}
+      onDelete={noop}
+    />
+  ),
+};
+
+export const Asymmetric: Story = {
+  args: {
+    otherCharacter: {
+      name: "Henri Poincaré",
+      slug: "henri-poincare",
+      characterType: "human",
+      initials: "HP",
+    },
+    relationshipType: "mentor_student",
+  },
+  render: () => (
+    <RelationshipCard
+      otherCharacter={{
+        name: "Henri Poincaré",
+        slug: "henri-poincare",
+        characterType: "human",
+        initials: "HP",
+      }}
+      relationshipType="mentor_student"
+      directionLabel="Marie was mentored by Henri"
+      startTemporal={T({ year: 1895, era: "CE" })}
+      endTemporal={T({ year: 1903, era: "CE" })}
+      onEdit={noop}
+      onDelete={noop}
+    />
+  ),
+};
+
+// ─── State variants ──────────────────────────────────────────────────────────
+
+export const Reciprocal: Story = {
+  args: {
+    otherCharacter: {
+      name: "Irène Joliot-Curie",
+      slug: "irene-joliot-curie",
+      characterType: "human",
+      initials: "IJ",
+    },
+    relationshipType: "family",
+  },
+  render: () => (
+    <RelationshipCard
+      otherCharacter={{
+        name: "Irène Joliot-Curie",
+        slug: "irene-joliot-curie",
+        characterType: "human",
+        initials: "IJ",
+      }}
+      relationshipType="family"
+      relationshipRole="parent"
+      directionLabel="Marie is mother of Irène"
+      startTemporal={T({ year: 1897, era: "CE" })}
+      isReciprocal
+      onEdit={noop}
+      onDuplicate={noop}
+      onDelete={noop}
+    />
+  ),
+};
+
+export const Contradiction: Story = {
+  args: {
+    otherCharacter: {
+      name: "Pierre Curie",
+      slug: "pierre-curie",
+      characterType: "human",
+      initials: "PC",
+    },
+    relationshipType: "family",
+  },
+  render: () => (
+    <RelationshipCard
+      otherCharacter={{
+        name: "Pierre Curie",
+        slug: "pierre-curie",
+        characterType: "human",
+        initials: "PC",
+      }}
+      relationshipType="family"
+      relationshipRole="parent"
+      startTemporal={T({ year: 1895, era: "CE" })}
+      contradiction="Pierre Curie is also recorded as your spouse — confirm this is intentional."
+      onEdit={noop}
+      onDelete={noop}
+    />
+  ),
+};
+
+export const EmptyTemporal: Story = {
+  args: {
+    otherCharacter: {
+      name: "Frédéric Joliot-Curie",
+      slug: "frederic-joliot-curie",
+      characterType: "human",
+      initials: "FJ",
+    },
+    relationshipType: "family",
+  },
+  render: () => (
+    <RelationshipCard
+      otherCharacter={{
+        name: "Frédéric Joliot-Curie",
+        slug: "frederic-joliot-curie",
+        characterType: "human",
+        initials: "FJ",
+      }}
+      relationshipType="family"
+      relationshipRole="in_law"
+      onEdit={noop}
+      onDelete={noop}
+    />
+  ),
+};

--- a/packages/ui/src/components/relationship-card.test.tsx
+++ b/packages/ui/src/components/relationship-card.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { TemporalData } from "@repo/services/schemas/temporal.js";
+
+import { RelationshipCard } from "./relationship-card";
+
+const T = (
+  data: Partial<TemporalData> & Pick<TemporalData, "year" | "era">,
+): TemporalData => ({ precision: "exact", ...data });
+
+const baseProps = {
+  otherCharacter: {
+    name: "Pierre Curie",
+    slug: "pierre-curie",
+    characterType: "human",
+    initials: "PC",
+  },
+  relationshipType: "family",
+};
+
+describe("RelationshipCard", () => {
+  it("renders the other character's name and type label", () => {
+    render(
+      <RelationshipCard
+        {...baseProps}
+        startTemporal={T({ year: 1895, era: "CE" })}
+      />,
+    );
+
+    expect(screen.getByText("Pierre Curie")).toBeInTheDocument();
+    // type label is humanized + capitalized via Tailwind
+    expect(screen.getByText("family")).toBeInTheDocument();
+  });
+
+  it("renders the sub-role badge when relationshipRole is set", () => {
+    render(<RelationshipCard {...baseProps} relationshipRole="spouse" />);
+    expect(
+      screen.getByTestId("relationship-card-role-badge"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("spouse")).toBeInTheDocument();
+  });
+
+  it("omits the sub-role badge when relationshipRole is null", () => {
+    render(<RelationshipCard {...baseProps} />);
+    expect(
+      screen.queryByTestId("relationship-card-role-badge"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls action handlers from the dropdown menu", async () => {
+    const onEdit = vi.fn();
+    const onDuplicate = vi.fn();
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <RelationshipCard
+        {...baseProps}
+        onEdit={onEdit}
+        onDuplicate={onDuplicate}
+        onDelete={onDelete}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /actions for/i }));
+    await user.click(await screen.findByRole("menuitem", { name: "Edit" }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the contradiction Alert when the prop is set", () => {
+    render(
+      <RelationshipCard
+        {...baseProps}
+        contradiction="Pierre is also recorded as your spouse."
+      />,
+    );
+    expect(
+      screen.getByTestId("relationship-card-contradiction"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/also recorded as your spouse/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the Synced badge when isReciprocal is true", () => {
+    render(<RelationshipCard {...baseProps} isReciprocal />);
+    expect(
+      screen.getByTestId("relationship-card-synced-badge"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an 'ongoing or unknown' placeholder when no temporal data is set", () => {
+    render(<RelationshipCard {...baseProps} />);
+    expect(screen.getByText(/ongoing or unknown/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/relationship-card.tsx
+++ b/packages/ui/src/components/relationship-card.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import * as React from "react";
+import { AlertTriangle, Link2, MoreHorizontal } from "lucide-react";
+import type { TemporalData } from "@repo/services/schemas/temporal.js";
+
+import { Alert, AlertDescription } from "./alert";
+import { Avatar, AvatarFallback } from "./avatar";
+import { Badge } from "./badge";
+import { Button } from "./button";
+import { Card } from "./card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+import { TemporalDisplay } from "./temporal-display";
+import { cn } from "@repo/ui/lib/utils";
+
+export interface RelationshipCardOtherCharacter {
+  name: string;
+  slug: string;
+  characterType: string;
+  initials: string;
+}
+
+export interface RelationshipCardProps {
+  otherCharacter: RelationshipCardOtherCharacter;
+  /** One of the 11 relationship_type enum values. */
+  relationshipType: string;
+  /** Sub-role for family / professional / collaboration types only. */
+  relationshipRole?: string | null;
+  startTemporal?: TemporalData | null;
+  endTemporal?: TemporalData | null;
+  description?: string | null;
+  /**
+   * Narrative line for asymmetric types ("Marie is mother of Irène").
+   * Rendered in italic muted text beneath the type/role badges.
+   * The consumer computes this from the relationship + character context.
+   */
+  directionLabel?: string;
+  /** Soft warning copy; surfaces as a destructive Alert inside the card. */
+  contradiction?: string;
+  /** This row is the reciprocal of another; subtle "Synced" badge. */
+  isReciprocal?: boolean;
+  onEdit?: () => void;
+  onDuplicate?: () => void;
+  onDelete?: () => void;
+  className?: string;
+}
+
+const humanize = (value: string): string => value.replace(/_/g, " ");
+
+export const RelationshipCard = React.forwardRef<
+  HTMLDivElement,
+  RelationshipCardProps
+>(function RelationshipCard(
+  {
+    otherCharacter,
+    relationshipType,
+    relationshipRole,
+    startTemporal,
+    endTemporal,
+    description,
+    directionLabel,
+    contradiction,
+    isReciprocal,
+    onEdit,
+    onDuplicate,
+    onDelete,
+    className,
+  },
+  ref,
+) {
+  const hasTemporal = startTemporal != null || endTemporal != null;
+  const hasActions = onEdit != null || onDuplicate != null || onDelete != null;
+
+  return (
+    <Card
+      ref={ref}
+      className={cn("space-y-3 p-4", className)}
+      data-testid="relationship-card"
+    >
+      {contradiction && (
+        <Alert
+          variant="destructive"
+          className="border-destructive/40 bg-destructive/5 py-2"
+          data-testid="relationship-card-contradiction"
+        >
+          <AlertTriangle className="h-4 w-4" aria-hidden />
+          <AlertDescription className="text-xs">
+            {contradiction}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex items-start gap-4">
+        <Avatar className="h-12 w-12 shrink-0">
+          <AvatarFallback className="text-sm">
+            {otherCharacter.initials}
+          </AvatarFallback>
+        </Avatar>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          {/* Top row: identity + type/role badges */}
+          <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+            <div className="flex min-w-0 items-baseline gap-2">
+              <span className="truncate font-display text-base text-foreground">
+                {otherCharacter.name}
+              </span>
+              <Badge variant="outline" className="text-xs capitalize">
+                {otherCharacter.characterType}
+              </Badge>
+            </div>
+            <div className="flex flex-wrap items-center gap-1.5">
+              <Badge variant="default" className="capitalize">
+                {humanize(relationshipType)}
+              </Badge>
+              {relationshipRole && (
+                <Badge
+                  variant="secondary"
+                  className="capitalize"
+                  data-testid="relationship-card-role-badge"
+                >
+                  {humanize(relationshipRole)}
+                </Badge>
+              )}
+              {isReciprocal && (
+                <Badge
+                  variant="outline"
+                  className="gap-1 text-xs text-foreground-muted"
+                  data-testid="relationship-card-synced-badge"
+                >
+                  <Link2 className="h-3 w-3" aria-hidden />
+                  Synced
+                </Badge>
+              )}
+            </div>
+          </div>
+
+          {/* Direction label (asymmetric narrative) */}
+          {directionLabel && (
+            <p className="text-xs italic text-foreground-muted">
+              {directionLabel}
+            </p>
+          )}
+
+          {/* Temporal scope */}
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-xs uppercase tracking-wider text-foreground-subtle">
+              Span
+            </span>
+            {hasTemporal ? (
+              <TemporalDisplay
+                value={
+                  startTemporal ??
+                  (endTemporal as TemporalData) /* one of them is non-null */
+                }
+                endValue={
+                  startTemporal && endTemporal ? endTemporal : undefined
+                }
+                format="inline"
+              />
+            ) : (
+              <span className="text-xs italic text-foreground-muted">
+                ongoing or unknown
+              </span>
+            )}
+          </div>
+
+          {/* Description */}
+          {description && (
+            <p className="line-clamp-2 text-sm text-foreground-muted">
+              {description}
+            </p>
+          )}
+        </div>
+
+        {hasActions && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 shrink-0 p-0"
+                aria-label={`Actions for relationship with ${otherCharacter.name}`}
+              >
+                <MoreHorizontal className="h-4 w-4" aria-hidden />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {onEdit && (
+                <DropdownMenuItem onClick={onEdit}>Edit</DropdownMenuItem>
+              )}
+              {onDuplicate && (
+                <DropdownMenuItem onClick={onDuplicate}>
+                  Duplicate
+                </DropdownMenuItem>
+              )}
+              {(onEdit || onDuplicate) && onDelete && <DropdownMenuSeparator />}
+              {onDelete && (
+                <DropdownMenuItem
+                  onClick={onDelete}
+                  className="text-destructive focus:text-destructive"
+                >
+                  Delete
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+    </Card>
+  );
+});

--- a/packages/ui/src/components/relationship-card.tsx
+++ b/packages/ui/src/components/relationship-card.tsx
@@ -4,7 +4,6 @@ import * as React from "react";
 import { AlertTriangle, Link2, MoreHorizontal } from "lucide-react";
 import type { TemporalData } from "@repo/services/schemas/temporal.js";
 
-import { Alert, AlertDescription } from "./alert";
 import { Avatar, AvatarFallback } from "./avatar";
 import { Badge } from "./badge";
 import { Button } from "./button";
@@ -84,16 +83,14 @@ export const RelationshipCard = React.forwardRef<
       data-testid="relationship-card"
     >
       {contradiction && (
-        <Alert
-          variant="destructive"
-          className="border-destructive/40 bg-destructive/5 py-2"
+        <div
+          role="alert"
           data-testid="relationship-card-contradiction"
+          className="flex items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive"
         >
-          <AlertTriangle className="h-4 w-4" aria-hidden />
-          <AlertDescription className="text-xs">
-            {contradiction}
-          </AlertDescription>
-        </Alert>
+          <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden />
+          <span>{contradiction}</span>
+        </div>
       )}
 
       <div className="flex items-start gap-4">

--- a/packages/ui/src/components/relationship-type-selector.stories.tsx
+++ b/packages/ui/src/components/relationship-type-selector.stories.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  RelationshipTypeSelector,
+  type RelationshipType,
+} from "./relationship-type-selector";
+
+const meta = {
+  title: "Components/Relationship Type Selector",
+  component: RelationshipTypeSelector,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof RelationshipTypeSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function Harness({
+  initialType,
+  initialRole = null,
+}: {
+  initialType: RelationshipType;
+  initialRole?: string | null;
+}) {
+  const [type, setType] = React.useState<RelationshipType>(initialType);
+  const [role, setRole] = React.useState<string | null>(initialRole);
+
+  return (
+    <div className="max-w-sm">
+      <RelationshipTypeSelector
+        type={type}
+        role={role}
+        onChange={(next) => {
+          setType(next.type);
+          setRole(next.role);
+        }}
+      />
+      <p className="mt-4 font-mono text-xs text-foreground-muted">
+        Selected: <span className="text-foreground">{type}</span>
+        {role && (
+          <>
+            {" "}
+            · role=<span className="text-foreground">{role}</span>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    type: "friendship",
+    role: null,
+    onChange: () => {},
+  },
+  render: () => <Harness initialType="friendship" />,
+};
+
+export const Family: Story = {
+  args: {
+    type: "family",
+    role: "spouse",
+    onChange: () => {},
+  },
+  render: () => <Harness initialType="family" initialRole="spouse" />,
+};
+
+export const Professional: Story = {
+  args: {
+    type: "professional",
+    role: "employer",
+    onChange: () => {},
+  },
+  render: () => <Harness initialType="professional" initialRole="employer" />,
+};

--- a/packages/ui/src/components/relationship-type-selector.test.tsx
+++ b/packages/ui/src/components/relationship-type-selector.test.tsx
@@ -94,6 +94,44 @@ describe("RelationshipTypeSelector", () => {
     });
   });
 
+  it("preserves role across sub-roled types when the value is valid in both", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    // "other" is a member of every sub-role enum (family, professional,
+    // collaboration), so switching between them should carry it forward.
+    render(
+      <Harness
+        initialType="professional"
+        initialRole="other"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("family"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "family",
+      role: "other",
+    });
+  });
+
+  it("clears role when the current value is not valid for the next sub-roled type", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    // "spouse" exists in familyRoleEnum but not in professionalRoleEnum, so
+    // switching from family/spouse to professional must drop the role.
+    render(
+      <Harness initialType="family" initialRole="spouse" onChange={onChange} />,
+    );
+
+    await user.click(screen.getByLabelText("professional"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "professional",
+      role: null,
+    });
+  });
+
   it("shows family sub-roles in the Select when type is family", async () => {
     const user = userEvent.setup();
     render(<Harness initialType="family" />);

--- a/packages/ui/src/components/relationship-type-selector.test.tsx
+++ b/packages/ui/src/components/relationship-type-selector.test.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  RelationshipTypeSelector,
+  type RelationshipType,
+} from "./relationship-type-selector";
+
+function Harness({
+  initialType = "friendship" as RelationshipType,
+  initialRole = null as string | null,
+  onChange,
+}: {
+  initialType?: RelationshipType;
+  initialRole?: string | null;
+  onChange?: (next: { type: RelationshipType; role: string | null }) => void;
+}) {
+  const [type, setType] = useState<RelationshipType>(initialType);
+  const [role, setRole] = useState<string | null>(initialRole);
+  return (
+    <RelationshipTypeSelector
+      type={type}
+      role={role}
+      onChange={(next) => {
+        setType(next.type);
+        setRole(next.role);
+        onChange?.(next);
+      }}
+    />
+  );
+}
+
+describe("RelationshipTypeSelector", () => {
+  it("renders all 11 relationship types under their family legends", () => {
+    render(<Harness />);
+
+    // Each fieldset legend visible
+    expect(screen.getByText("Family")).toBeInTheDocument();
+    expect(screen.getByText("Professional")).toBeInTheDocument();
+    expect(screen.getByText("Social / Personal")).toBeInTheDocument();
+    expect(screen.getByText("Antagonistic")).toBeInTheDocument();
+    expect(screen.getByText("Asymmetric")).toBeInTheDocument();
+
+    // 11 radio items
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(11);
+  });
+
+  it("reveals the role Select when a sub-roled type is selected", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    // friendship is initial — no role select yet
+    expect(
+      screen.queryByTestId("relationship-type-role-select"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("family"));
+
+    expect(
+      screen.getByTestId("relationship-type-role-select"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the role Select for non-sub-roled types", async () => {
+    const user = userEvent.setup();
+    render(<Harness initialType="family" initialRole="spouse" />);
+
+    expect(
+      screen.getByTestId("relationship-type-role-select"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("friendship"));
+
+    expect(
+      screen.queryByTestId("relationship-type-role-select"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears role when switching from a sub-roled type to a non-sub-roled type", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness initialType="family" initialRole="spouse" onChange={onChange} />,
+    );
+
+    await user.click(screen.getByLabelText("friendship"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "friendship",
+      role: null,
+    });
+  });
+
+  it("shows family sub-roles in the Select when type is family", async () => {
+    const user = userEvent.setup();
+    render(<Harness initialType="family" />);
+
+    await user.click(screen.getByRole("combobox", { name: "Role" }));
+
+    expect(
+      await screen.findByRole("option", { name: "spouse" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "parent" })).toBeInTheDocument();
+  });
+
+  it("shows professional sub-roles in the Select when type is professional", async () => {
+    const user = userEvent.setup();
+    render(<Harness initialType="professional" />);
+
+    await user.click(screen.getByRole("combobox", { name: "Role" }));
+
+    expect(
+      await screen.findByRole("option", { name: "employer" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "employee" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/relationship-type-selector.tsx
+++ b/packages/ui/src/components/relationship-type-selector.tsx
@@ -83,8 +83,14 @@ export function RelationshipTypeSelector({
         value={type}
         onValueChange={(next) => {
           const nextType = next as RelationshipType;
-          // When moving to a non-sub-roled type, clear role.
-          const nextRole = typeAcceptsRole(nextType) ? (role ?? null) : null;
+          const nextRoleOptions = ROLE_OPTIONS[nextType];
+          const nextRole =
+            typeAcceptsRole(nextType) &&
+            role != null &&
+            nextRoleOptions?.includes(role)
+              ? role
+              : null;
+
           onChange({ type: nextType, role: nextRole });
         }}
         disabled={disabled}

--- a/packages/ui/src/components/relationship-type-selector.tsx
+++ b/packages/ui/src/components/relationship-type-selector.tsx
@@ -76,6 +76,10 @@ export function RelationshipTypeSelector({
 }: RelationshipTypeSelectorProps) {
   const roleOptions = ROLE_OPTIONS[type];
   const acceptsRole = typeAcceptsRole(type);
+  // Unique per-instance prefix so multiple selectors on the same page don't
+  // collide on id/htmlFor pairs (each fieldset/radio + the role select trigger).
+  const idPrefix = React.useId();
+  const roleSelectId = `${idPrefix}-role`;
 
   return (
     <div className={cn("space-y-4", className)}>
@@ -106,7 +110,7 @@ export function RelationshipTypeSelector({
               {family.legend}
             </legend>
             {family.types.map((typeValue) => {
-              const itemId = `relationship-type-${typeValue}`;
+              const itemId = `${idPrefix}-type-${typeValue}`;
               return (
                 <div key={typeValue} className="flex items-center gap-2">
                   <RadioGroupItem id={itemId} value={typeValue} />
@@ -128,7 +132,7 @@ export function RelationshipTypeSelector({
           className="space-y-1.5"
           data-testid="relationship-type-role-select"
         >
-          <Label htmlFor="relationship-type-role" className="text-sm">
+          <Label htmlFor={roleSelectId} className="text-sm">
             Role
           </Label>
           <Select
@@ -136,7 +140,7 @@ export function RelationshipTypeSelector({
             onValueChange={(next) => onChange({ type, role: next })}
             disabled={disabled}
           >
-            <SelectTrigger id="relationship-type-role" aria-label="Role">
+            <SelectTrigger id={roleSelectId} aria-label="Role">
               <SelectValue placeholder="Select a role" />
             </SelectTrigger>
             <SelectContent>

--- a/packages/ui/src/components/relationship-type-selector.tsx
+++ b/packages/ui/src/components/relationship-type-selector.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import * as React from "react";
+import {
+  collaborationRoleEnum,
+  familyRoleEnum,
+  professionalRoleEnum,
+  relationshipTypeEnum,
+  typeAcceptsRole,
+} from "@repo/services/schemas/character-relationship.js";
+import { z } from "zod";
+
+import { Label } from "./label";
+import { RadioGroup, RadioGroupItem } from "./radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
+import { cn } from "@repo/ui/lib/utils";
+
+export type RelationshipType = z.infer<typeof relationshipTypeEnum>;
+
+export interface RelationshipTypeSelectorProps {
+  type: RelationshipType;
+  role?: string | null;
+  onChange: (next: { type: RelationshipType; role: string | null }) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+// ─── Type → family grouping ──────────────────────────────────────────────────
+
+interface FamilyGroup {
+  legend: string;
+  types: RelationshipType[];
+}
+
+const TYPE_FAMILIES: FamilyGroup[] = [
+  { legend: "Family", types: ["family"] },
+  { legend: "Professional", types: ["professional", "collaboration"] },
+  { legend: "Social / Personal", types: ["friendship"] },
+  { legend: "Antagonistic", types: ["rivalry", "enemy"] },
+  {
+    legend: "Asymmetric",
+    types: [
+      "mentor_student",
+      "owner_pet",
+      "trainer_trainee",
+      "creator_creation",
+      "worship",
+    ],
+  },
+];
+
+// ─── Per-type sub-role enums ─────────────────────────────────────────────────
+
+const ROLE_OPTIONS: Partial<Record<RelationshipType, readonly string[]>> = {
+  family: familyRoleEnum.options,
+  professional: professionalRoleEnum.options,
+  collaboration: collaborationRoleEnum.options,
+};
+
+const humanize = (value: string): string => value.replace(/_/g, " ");
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function RelationshipTypeSelector({
+  type,
+  role,
+  onChange,
+  disabled,
+  className,
+}: RelationshipTypeSelectorProps) {
+  const roleOptions = ROLE_OPTIONS[type];
+  const acceptsRole = typeAcceptsRole(type);
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <RadioGroup
+        value={type}
+        onValueChange={(next) => {
+          const nextType = next as RelationshipType;
+          // When moving to a non-sub-roled type, clear role.
+          const nextRole = typeAcceptsRole(nextType) ? (role ?? null) : null;
+          onChange({ type: nextType, role: nextRole });
+        }}
+        disabled={disabled}
+        className="gap-4"
+      >
+        {TYPE_FAMILIES.map((family) => (
+          <fieldset
+            key={family.legend}
+            className="space-y-2 border-0 p-0"
+            data-testid={`relationship-type-family-${family.legend.toLowerCase().replace(/[^a-z]/g, "-")}`}
+          >
+            <legend className="mb-1 text-xs font-medium uppercase tracking-wider text-foreground-muted">
+              {family.legend}
+            </legend>
+            {family.types.map((typeValue) => {
+              const itemId = `relationship-type-${typeValue}`;
+              return (
+                <div key={typeValue} className="flex items-center gap-2">
+                  <RadioGroupItem id={itemId} value={typeValue} />
+                  <Label
+                    htmlFor={itemId}
+                    className="font-normal capitalize text-foreground"
+                  >
+                    {humanize(typeValue)}
+                  </Label>
+                </div>
+              );
+            })}
+          </fieldset>
+        ))}
+      </RadioGroup>
+
+      {acceptsRole && roleOptions && (
+        <div
+          className="space-y-1.5"
+          data-testid="relationship-type-role-select"
+        >
+          <Label htmlFor="relationship-type-role" className="text-sm">
+            Role
+          </Label>
+          <Select
+            value={role ?? undefined}
+            onValueChange={(next) => onChange({ type, role: next })}
+            disabled={disabled}
+          >
+            <SelectTrigger id="relationship-type-role" aria-label="Role">
+              <SelectValue placeholder="Select a role" />
+            </SelectTrigger>
+            <SelectContent>
+              {roleOptions.map((roleValue) => (
+                <SelectItem key={roleValue} value={roleValue}>
+                  <span className="capitalize">{humanize(roleValue)}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/relationships-editor.stories.tsx
+++ b/packages/ui/src/components/relationships-editor.stories.tsx
@@ -1,0 +1,720 @@
+import * as React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  BookOpen,
+  Calendar,
+  Clock,
+  FolderTree,
+  GitBranch,
+  Image as ImageIcon,
+  LayoutDashboard,
+  Plus,
+  Users,
+} from "lucide-react";
+import type { TemporalData } from "@repo/services/schemas/temporal.js";
+import { useUiStore } from "@repo/ui/stores";
+
+import { Button } from "./button";
+import { Card } from "./card";
+import { RelationshipCard } from "./relationship-card";
+import {
+  RelationshipTypeSelector,
+  type RelationshipType,
+} from "./relationship-type-selector";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "./sheet";
+import { Shell, type ShellNavItem, type ShellQuickCreateItem } from "./shell";
+import { Skeleton } from "./skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
+import { Separator } from "./separator";
+import { TemporalInput } from "./temporal-input";
+import { Textarea } from "./textarea";
+
+// ─── Shell fixture data ───────────────────────────────────────────────────────
+
+const NAV: ShellNavItem[] = [
+  { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Timelines", href: "/timelines", icon: GitBranch },
+  { label: "Events", href: "/events", icon: Calendar },
+  { label: "Characters", href: "/characters", icon: Users },
+  { label: "Periods", href: "/periods", icon: Clock },
+  { label: "Stories", href: "/stories", icon: BookOpen },
+  { label: "Categories", href: "/categories", icon: FolderTree },
+  { label: "Media", href: "/media", icon: ImageIcon },
+];
+
+const QUICK_CREATE: ShellQuickCreateItem[] = [
+  { label: "Character", href: "/characters/new" },
+  { label: "Event", href: "/events/new" },
+  { label: "Period", href: "/periods/new" },
+  { label: "Story", href: "/stories/new" },
+  { label: "Timeline", href: "/timelines/new" },
+  { label: "Category", href: "/categories/new" },
+  { label: "Media", href: "/media/new" },
+  { label: "Relationship", href: "/relationships/new" },
+];
+
+const SHELL_USER = { name: "Admin User", email: "admin@example.com" };
+
+const shellLoaders = [
+  async () => {
+    useUiStore.setState({
+      sidebarOpen: true,
+      sidebarWidth: 280,
+      activeModal: null,
+      modalData: {},
+      toasts: [],
+    });
+    return {};
+  },
+];
+
+// ─── Temporal helper ──────────────────────────────────────────────────────────
+
+const T = (
+  data: Partial<TemporalData> & Pick<TemporalData, "year" | "era">,
+): TemporalData => ({ precision: "exact", ...data });
+
+// ─── Type → family group mapping ──────────────────────────────────────────────
+
+type FamilyKey =
+  | "family"
+  | "professional"
+  | "social"
+  | "antagonistic"
+  | "asymmetric";
+
+const FAMILY_LABELS: Record<FamilyKey, string> = {
+  family: "Family",
+  professional: "Professional",
+  social: "Social / Personal",
+  antagonistic: "Antagonistic",
+  asymmetric: "Asymmetric",
+};
+
+const FAMILY_ORDER: FamilyKey[] = [
+  "family",
+  "professional",
+  "social",
+  "antagonistic",
+  "asymmetric",
+];
+
+const familyFor = (type: string): FamilyKey => {
+  if (type === "family") return "family";
+  if (type === "professional" || type === "collaboration")
+    return "professional";
+  if (type === "friendship") return "social";
+  if (type === "rivalry" || type === "enemy") return "antagonistic";
+  return "asymmetric";
+};
+
+// ─── Fixture: Marie Curie's relationships ─────────────────────────────────────
+
+interface RelationshipFixture {
+  id: string;
+  otherCharacter: {
+    name: string;
+    slug: string;
+    characterType: string;
+    initials: string;
+  };
+  relationshipType: string;
+  relationshipRole?: string | null;
+  startTemporal?: TemporalData | null;
+  endTemporal?: TemporalData | null;
+  description?: string | null;
+  directionLabel?: string;
+  isReciprocal?: boolean;
+  contradiction?: string;
+}
+
+const PIERRE: RelationshipFixture = {
+  id: "rel-pierre-spouse",
+  otherCharacter: {
+    name: "Pierre Curie",
+    slug: "pierre-curie",
+    characterType: "human",
+    initials: "PC",
+  },
+  relationshipType: "family",
+  relationshipRole: "spouse",
+  startTemporal: T({ year: 1895, era: "CE", month: 7, day: 26 }),
+  endTemporal: T({ year: 1906, era: "CE", month: 4, day: 19 }),
+  description:
+    "Marriage; collaborated on the discovery of polonium and radium; shared the 1903 Nobel Prize.",
+};
+
+const IRENE: RelationshipFixture = {
+  id: "rel-irene-parent",
+  otherCharacter: {
+    name: "Irène Joliot-Curie",
+    slug: "irene-joliot-curie",
+    characterType: "human",
+    initials: "IJ",
+  },
+  relationshipType: "family",
+  relationshipRole: "parent",
+  directionLabel: "Marie is mother of Irène",
+  startTemporal: T({ year: 1897, era: "CE", month: 9, day: 12 }),
+  description: "Daughter; later won the 1935 Nobel Prize in Chemistry herself.",
+  isReciprocal: true,
+};
+
+const EVE: RelationshipFixture = {
+  id: "rel-eve-parent",
+  otherCharacter: {
+    name: "Ève Curie",
+    slug: "eve-curie",
+    characterType: "human",
+    initials: "EC",
+  },
+  relationshipType: "family",
+  relationshipRole: "parent",
+  directionLabel: "Marie is mother of Ève",
+  startTemporal: T({ year: 1904, era: "CE", month: 12, day: 6 }),
+  description: "Daughter; journalist and biographer of her mother.",
+  isReciprocal: true,
+};
+
+const FREDERIC: RelationshipFixture = {
+  id: "rel-frederic-inlaw",
+  otherCharacter: {
+    name: "Frédéric Joliot-Curie",
+    slug: "frederic-joliot-curie",
+    characterType: "human",
+    initials: "FJ",
+  },
+  relationshipType: "family",
+  relationshipRole: "in_law",
+  startTemporal: T({ year: 1926, era: "CE" }),
+  description: "Son-in-law via Irène; co-recipient of the 1935 Nobel Prize.",
+};
+
+const BECQUEREL: RelationshipFixture = {
+  id: "rel-becquerel-research",
+  otherCharacter: {
+    name: "Antoine Henri Becquerel",
+    slug: "antoine-henri-becquerel",
+    characterType: "human",
+    initials: "AB",
+  },
+  relationshipType: "collaboration",
+  relationshipRole: "research_partner",
+  startTemporal: T({ year: 1896, era: "CE" }),
+  endTemporal: T({ year: 1908, era: "CE" }),
+  description: "Co-recipient of the 1903 Nobel Prize for radioactivity work.",
+};
+
+const SORBONNE: RelationshipFixture = {
+  id: "rel-sorbonne-employer",
+  otherCharacter: {
+    name: "Université de Paris",
+    slug: "universite-de-paris",
+    characterType: "organization",
+    initials: "UP",
+  },
+  relationshipType: "professional",
+  relationshipRole: "employer",
+  startTemporal: T({ year: 1906, era: "CE" }),
+  endTemporal: T({ year: 1934, era: "CE" }),
+  description: "First woman appointed professor at the Sorbonne.",
+};
+
+const POINCARE: RelationshipFixture = {
+  id: "rel-poincare-mentor",
+  otherCharacter: {
+    name: "Henri Poincaré",
+    slug: "henri-poincare",
+    characterType: "human",
+    initials: "HP",
+  },
+  relationshipType: "mentor_student",
+  directionLabel: "Marie was mentored by Henri",
+  startTemporal: T({ year: 1895, era: "CE" }),
+  endTemporal: T({ year: 1903, era: "CE" }),
+};
+
+const LANGEVIN: RelationshipFixture = {
+  id: "rel-langevin-rivalry",
+  otherCharacter: {
+    name: "Paul Langevin",
+    slug: "paul-langevin",
+    characterType: "human",
+    initials: "PL",
+  },
+  relationshipType: "rivalry",
+  startTemporal: T({ year: 1910, era: "CE" }),
+  endTemporal: T({ year: 1911, era: "CE" }),
+  description: "Public scandal following the affair and divorce proceedings.",
+};
+
+const EINSTEIN: RelationshipFixture = {
+  id: "rel-einstein-friend",
+  otherCharacter: {
+    name: "Albert Einstein",
+    slug: "albert-einstein",
+    characterType: "human",
+    initials: "AE",
+  },
+  relationshipType: "friendship",
+  startTemporal: T({ year: 1909, era: "CE" }),
+  endTemporal: T({ year: 1934, era: "CE" }),
+  description: "Met at the 1911 Solvay Conference; long correspondence.",
+};
+
+const MARIE_RELATIONSHIPS: RelationshipFixture[] = [
+  PIERRE,
+  IRENE,
+  EVE,
+  FREDERIC,
+  BECQUEREL,
+  SORBONNE,
+  POINCARE,
+  LANGEVIN,
+  EINSTEIN,
+];
+
+// Synthetic contradicting record for the WithContradiction story.
+const PIERRE_AS_PARENT_CONTRADICTION: RelationshipFixture = {
+  id: "rel-pierre-parent-contradiction",
+  otherCharacter: PIERRE.otherCharacter,
+  relationshipType: "family",
+  relationshipRole: "parent",
+  startTemporal: T({ year: 1895, era: "CE" }),
+  contradiction:
+    "Pierre Curie is also recorded as your spouse — confirm this is intentional.",
+};
+
+// Available characters for the Add sheet's "Other character" Select (excludes Marie).
+const AVAILABLE_CHARACTERS = [
+  { id: "pierre-curie", name: "Pierre Curie" },
+  { id: "irene-joliot-curie", name: "Irène Joliot-Curie" },
+  { id: "eve-curie", name: "Ève Curie" },
+  { id: "frederic-joliot-curie", name: "Frédéric Joliot-Curie" },
+  { id: "antoine-henri-becquerel", name: "Antoine Henri Becquerel" },
+  { id: "universite-de-paris", name: "Université de Paris" },
+  { id: "henri-poincare", name: "Henri Poincaré" },
+  { id: "paul-langevin", name: "Paul Langevin" },
+  { id: "albert-einstein", name: "Albert Einstein" },
+];
+
+// ─── Disclosure section (mirrors Batch G's pattern) ──────────────────────────
+
+function DisclosureSection({
+  legend,
+  count,
+  defaultOpen = true,
+  emptyHint,
+  children,
+}: {
+  legend: string;
+  count: number;
+  defaultOpen?: boolean;
+  emptyHint: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <details
+      open={defaultOpen}
+      className="group [&_summary::-webkit-details-marker]:hidden"
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-2 py-2 text-sm text-foreground-muted transition-colors hover:text-foreground">
+        <span
+          aria-hidden
+          className="inline-block w-3 text-center transition-transform group-open:rotate-90"
+        >
+          ▸
+        </span>
+        <span className="font-display text-base text-foreground">{legend}</span>
+        <span className="font-mono text-xs text-foreground-subtle">
+          ({count})
+        </span>
+      </summary>
+      <div className="mt-3 space-y-3 pl-5">
+        {count === 0 ? (
+          <p className="text-sm italic text-foreground-muted">{emptyHint}</p>
+        ) : (
+          children
+        )}
+      </div>
+    </details>
+  );
+}
+
+// ─── Add-relationship sheet ──────────────────────────────────────────────────
+
+interface AddRelationshipFormState {
+  otherCharacterId: string;
+  type: RelationshipType;
+  role: string | null;
+  start: TemporalData | null;
+  end: TemporalData | null;
+  description: string;
+}
+
+const EMPTY_FORM: AddRelationshipFormState = {
+  otherCharacterId: "",
+  type: "friendship",
+  role: null,
+  start: null,
+  end: null,
+  description: "",
+};
+
+function AddRelationshipSheet({
+  open,
+  onOpenChange,
+  initial = EMPTY_FORM,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initial?: AddRelationshipFormState;
+}) {
+  const [form, setForm] = React.useState<AddRelationshipFormState>(initial);
+
+  // Reset to initial whenever the sheet transitions to open (matches the
+  // TemporalInput popover pattern from Batch G).
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (next) setForm(initial);
+      onOpenChange(next);
+    },
+    [initial, onOpenChange],
+  );
+
+  const set = <K extends keyof AddRelationshipFormState>(
+    key: K,
+    value: AddRelationshipFormState[K],
+  ) => setForm((prev) => ({ ...prev, [key]: value }));
+
+  const canSave = form.otherCharacterId !== "" && form.type !== undefined;
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-[min(28rem,100vw)] flex-col gap-0 overflow-y-auto"
+      >
+        <SheetHeader>
+          <SheetTitle>Add relationship</SheetTitle>
+          <SheetDescription>
+            Add a relationship from Marie Curie&rsquo;s perspective. Reciprocal
+            edges are created automatically.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex flex-1 flex-col gap-5 px-6 py-4">
+          <div className="space-y-1.5">
+            <label
+              htmlFor="add-rel-other"
+              className="text-sm font-medium text-foreground"
+            >
+              Other character
+            </label>
+            <Select
+              value={form.otherCharacterId || undefined}
+              onValueChange={(v) => set("otherCharacterId", v)}
+            >
+              <SelectTrigger id="add-rel-other" aria-label="Other character">
+                <SelectValue placeholder="Pick a character" />
+              </SelectTrigger>
+              <SelectContent>
+                {AVAILABLE_CHARACTERS.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <p className="text-sm font-medium text-foreground">Relationship</p>
+            <RelationshipTypeSelector
+              type={form.type}
+              role={form.role}
+              onChange={(next) => {
+                set("type", next.type);
+                set("role", next.role);
+              }}
+            />
+          </div>
+
+          <Separator />
+
+          <TemporalInput
+            label="Start"
+            value={form.start}
+            onChange={(v) => set("start", v)}
+          />
+
+          <TemporalInput
+            label="End"
+            value={form.end}
+            onChange={(v) => set("end", v)}
+          />
+
+          <div className="space-y-1.5">
+            <label
+              htmlFor="add-rel-description"
+              className="text-sm font-medium text-foreground"
+            >
+              Description
+            </label>
+            <Textarea
+              id="add-rel-description"
+              rows={4}
+              maxLength={500}
+              value={form.description}
+              onChange={(e) => set("description", e.target.value)}
+              placeholder="Optional — describe this relationship from Marie's perspective."
+            />
+          </div>
+        </div>
+
+        <SheetFooter className="px-6 pb-6">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => handleOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            disabled={!canSave}
+            onClick={() => handleOpenChange(false)}
+          >
+            Save
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── Page component ──────────────────────────────────────────────────────────
+
+interface RelationshipsEditorPageProps {
+  relationships: RelationshipFixture[];
+  loading?: boolean;
+  initialSheetOpen?: boolean;
+  initialSheetForm?: AddRelationshipFormState;
+}
+
+function RelationshipsEditorPage({
+  relationships,
+  loading = false,
+  initialSheetOpen = false,
+  initialSheetForm,
+}: RelationshipsEditorPageProps) {
+  const [sheetOpen, setSheetOpen] = React.useState(initialSheetOpen);
+
+  const grouped = React.useMemo(() => {
+    const buckets: Record<FamilyKey, RelationshipFixture[]> = {
+      family: [],
+      professional: [],
+      social: [],
+      antagonistic: [],
+      asymmetric: [],
+    };
+    for (const rel of relationships) {
+      buckets[familyFor(rel.relationshipType)].push(rel);
+    }
+    return buckets;
+  }, [relationships]);
+
+  const total = relationships.length;
+  const populatedGroupCount = FAMILY_ORDER.filter(
+    (k) => grouped[k].length > 0,
+  ).length;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <header className="flex items-end justify-between gap-4 border-b border-border pb-4">
+        <div className="space-y-1">
+          <h1 className="font-display text-2xl text-foreground">
+            Relationships
+          </h1>
+          <p className="text-sm text-foreground-muted">
+            {total === 0
+              ? "No relationships yet — start by adding one."
+              : `${total} relationship${total === 1 ? "" : "s"} across ${populatedGroupCount} categor${populatedGroupCount === 1 ? "y" : "ies"}.`}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="primary"
+          className="gap-1.5"
+          onClick={() => setSheetOpen(true)}
+        >
+          <Plus className="h-4 w-4" aria-hidden />
+          Add relationship
+        </Button>
+      </header>
+
+      {loading ? (
+        <div className="space-y-6">
+          {FAMILY_ORDER.map((key) => (
+            <div key={key} className="space-y-3">
+              <div className="flex items-center gap-2 py-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-6" />
+              </div>
+              <div className="space-y-3 pl-5">
+                <Card className="space-y-3 p-4">
+                  <div className="flex items-start gap-4">
+                    <Skeleton className="h-12 w-12 rounded-full" />
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-4 w-1/2" />
+                      <Skeleton className="h-3 w-1/3" />
+                      <Skeleton className="h-3 w-2/3" />
+                    </div>
+                  </div>
+                </Card>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {FAMILY_ORDER.map((key) => (
+            <DisclosureSection
+              key={key}
+              legend={FAMILY_LABELS[key]}
+              count={grouped[key].length}
+              emptyHint="No relationships in this category."
+            >
+              {grouped[key].map((rel) => (
+                <RelationshipCard
+                  key={rel.id}
+                  otherCharacter={rel.otherCharacter}
+                  relationshipType={rel.relationshipType}
+                  relationshipRole={rel.relationshipRole}
+                  startTemporal={rel.startTemporal}
+                  endTemporal={rel.endTemporal}
+                  description={rel.description}
+                  directionLabel={rel.directionLabel}
+                  isReciprocal={rel.isReciprocal}
+                  contradiction={rel.contradiction}
+                  onEdit={() => {}}
+                  onDuplicate={() => {}}
+                  onDelete={() => {}}
+                />
+              ))}
+            </DisclosureSection>
+          ))}
+        </div>
+      )}
+
+      <AddRelationshipSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        initial={initialSheetForm ?? EMPTY_FORM}
+      />
+    </div>
+  );
+}
+
+// ─── Meta ────────────────────────────────────────────────────────────────────
+
+const meta: Meta = {
+  title: "Pages/Relationships Editor",
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+type Story = StoryObj;
+
+const breadcrumbs = [
+  { label: "Characters", href: "/characters" },
+  { label: "Marie Curie", href: "/characters/marie-curie" },
+  { label: "Relationships" },
+];
+
+function ShellWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <Shell
+      nav={NAV}
+      currentPath="/characters/marie-curie/relationships"
+      user={SHELL_USER}
+      quickCreateItems={QUICK_CREATE}
+      breadcrumbs={breadcrumbs}
+    >
+      {children}
+    </Shell>
+  );
+}
+
+// ─── Stories ─────────────────────────────────────────────────────────────────
+
+export const Default: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <ShellWrapper>
+      <RelationshipsEditorPage relationships={MARIE_RELATIONSHIPS} />
+    </ShellWrapper>
+  ),
+};
+
+export const WithContradiction: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <ShellWrapper>
+      <RelationshipsEditorPage
+        relationships={[...MARIE_RELATIONSHIPS, PIERRE_AS_PARENT_CONTRADICTION]}
+      />
+    </ShellWrapper>
+  ),
+};
+
+export const Empty: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <ShellWrapper>
+      <RelationshipsEditorPage relationships={[]} />
+    </ShellWrapper>
+  ),
+};
+
+export const AddSheetOpen: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <ShellWrapper>
+      <RelationshipsEditorPage
+        relationships={MARIE_RELATIONSHIPS}
+        initialSheetOpen
+        initialSheetForm={{
+          otherCharacterId: "",
+          type: "family",
+          role: "spouse",
+          start: null,
+          end: null,
+          description: "",
+        }}
+      />
+    </ShellWrapper>
+  ),
+};
+
+export const Loading: Story = {
+  loaders: shellLoaders,
+  render: () => (
+    <ShellWrapper>
+      <RelationshipsEditorPage relationships={[]} loading />
+    </ShellWrapper>
+  ),
+};

--- a/packages/ui/src/components/shell.test.tsx
+++ b/packages/ui/src/components/shell.test.tsx
@@ -1,0 +1,112 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import { useUiStore } from "@repo/ui/stores";
+
+import { Shell, type ShellNavItem, type ShellQuickCreateItem } from "./shell";
+
+const NAV: ShellNavItem[] = [
+  {
+    label: "Dashboard",
+    href: "/dashboard",
+    icon: ({ className }) => <svg className={className} />,
+  },
+  {
+    label: "Characters",
+    href: "/characters",
+    icon: ({ className }) => <svg className={className} />,
+  },
+  {
+    label: "Events",
+    href: "/events",
+    icon: ({ className }) => <svg className={className} />,
+  },
+];
+
+const QUICK_CREATE: ShellQuickCreateItem[] = [
+  { label: "Character", href: "/characters/new" },
+  { label: "Event", href: "/events/new" },
+];
+
+const USER = { name: "Admin User", email: "admin@example.com" };
+
+function renderShell(
+  overrides: Partial<React.ComponentProps<typeof Shell>> = {},
+) {
+  return render(
+    <Shell
+      nav={NAV}
+      currentPath="/characters/marie-curie"
+      user={USER}
+      quickCreateItems={QUICK_CREATE}
+      breadcrumbs={[
+        { label: "Characters", href: "/characters" },
+        { label: "Marie Curie" },
+      ]}
+      {...overrides}
+    >
+      <div>Content</div>
+    </Shell>,
+  );
+}
+
+describe("Shell", () => {
+  beforeEach(() => {
+    useUiStore.setState({
+      sidebarOpen: true,
+      sidebarWidth: 280,
+      activeModal: null,
+      modalData: {},
+      toasts: [],
+    });
+  });
+
+  it("renders breadcrumbs and marks the active nav item", () => {
+    renderShell();
+
+    expect(screen.getAllByRole("link", { name: "Characters" })[0]).toHaveClass(
+      "bg-surface-2",
+    );
+    expect(screen.getByText("Marie Curie")).toBeInTheDocument();
+    expect(screen.getByText("Content")).toBeInTheDocument();
+  });
+
+  it("collapses and expands the sidebar from the footer action", async () => {
+    const user = userEvent.setup();
+    renderShell();
+
+    const toggle = screen.getByRole("button", { name: /collapse sidebar/i });
+    await user.click(toggle);
+
+    expect(useUiStore.getState().sidebarOpen).toBe(false);
+    expect(
+      screen.getByRole("button", { name: /expand sidebar/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the user menu and calls sign-out", async () => {
+    const user = userEvent.setup();
+    const onSignOut = vi.fn();
+    renderShell({ onSignOut });
+
+    await user.click(screen.getByRole("button", { name: /open user menu/i }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /sign out/i }),
+    );
+
+    expect(onSignOut).toHaveBeenCalledOnce();
+  });
+
+  it("opens the quick create menu and exposes entity links", async () => {
+    const user = userEvent.setup();
+    renderShell();
+
+    await user.click(screen.getByRole("button", { name: /quick create/i }));
+
+    expect(
+      await screen.findByRole("menuitem", { name: /character/i }),
+    ).toHaveAttribute("href", "/characters/new");
+  });
+});

--- a/packages/ui/src/components/shell.tsx
+++ b/packages/ui/src/components/shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ComponentType, type ReactNode } from "react";
+import { Fragment, type ComponentType, type ReactNode } from "react";
 import {
   ChevronsLeft,
   ChevronsRight,
@@ -213,18 +213,18 @@ export const ShellBreadcrumb = ({
         {items.map((item, index) => {
           const last = index === items.length - 1;
           return (
-            <BreadcrumbItem key={`${item.label}-${index}`}>
-              {last || !item.href ? (
-                <BreadcrumbPage>{item.label}</BreadcrumbPage>
-              ) : (
-                <>
+            <Fragment key={`${item.label}-${index}`}>
+              <BreadcrumbItem>
+                {last || !item.href ? (
+                  <BreadcrumbPage>{item.label}</BreadcrumbPage>
+                ) : (
                   <BreadcrumbLink asChild>
                     <LinkComponent href={item.href}>{item.label}</LinkComponent>
                   </BreadcrumbLink>
-                  <BreadcrumbSeparator />
-                </>
-              )}
-            </BreadcrumbItem>
+                )}
+              </BreadcrumbItem>
+              {!last && item.href && <BreadcrumbSeparator />}
+            </Fragment>
           );
         })}
       </BreadcrumbList>

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -15,8 +15,13 @@ export default defineConfig({
       // Scope to files that have tests. Expand this list as test coverage grows.
       include: [
         "src/components/autosave-indicator.tsx",
+        "src/components/data-table.tsx",
+        "src/components/filter-rail.tsx",
+        "src/components/shell.tsx",
         "src/components/chip-input.tsx",
         "src/components/button.tsx",
+        "src/components/relationship-card.tsx",
+        "src/components/relationship-type-selector.tsx",
         "src/components/save-dropdown.tsx",
         "src/components/slug-field.tsx",
         "src/components/temporal-display.tsx",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.10
         version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1561,6 +1564,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5242,6 +5258,24 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.15)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:


### PR DESCRIPTION
## Summary

- New primitives: `RelationshipCard`, `RelationshipTypeSelector`, and `RadioGroup` (shadcn).
- Composite story `Pages > Relationships Editor` with 5 variants (Default / WithContradiction / Empty / AddSheetOpen / Loading). Wireframe: [`02-wireframes/06-relationships-editor.md`](../tree/feat/batch-h-relationship-editor/docs/design/admin/02-wireframes/06-relationships-editor.md).
- Card stream grouped into 5 type-family sections (Family / Professional / Social-Personal / Antagonistic / Asymmetric); sub-role taxonomy from [#119](https://github.com/shaes-farm/time-traveler/issues/119) drives the inline role selector on the three sub-roled types.
- Soft contradiction warning surface on the card; visual-only (service-layer detection is out of scope, follow-up worth filing).
- Parallel Batch F coverage work carried on this branch: `DataTable`, `FilterRail`, `Shell` test files; `Shell` breadcrumb separator fix (wrap each row in `<Fragment>`).
- Marks Batches G and H as `done` in `fidelity-2-plan.md`.

## Test plan

- [x] `pnpm run check-types` — passes
- [x] `pnpm run lint` — zero warnings
- [x] `pnpm run build` — passes
- [x] `pnpm run test:coverage` — 22 test files, 210 tests pass; overall coverage 89/82/88/90 (stmts/branch/fns/lines) above the 80% threshold. New primitives: `relationship-card.tsx` 100/86 (stmts/branch), `relationship-type-selector.tsx` 94/100.
- [ ] Storybook visual check (`pnpm storybook` in `packages/ui`):
  - `Components > Radio Group` renders all 3 stories.
  - `Components > Relationship Card` renders all 8 stories (Contradiction surfaces the Alert; Reciprocal shows the Synced badge).
  - `Components > Relationship Type Selector` renders all 3 stories; the role Select appears/disappears with the chosen type.
  - `Pages > Relationships Editor > Default` shows Marie Curie's full card stream grouped into 5 sections.
  - `Pages > Relationships Editor > AddSheetOpen` shows the right-side sheet pre-filled with family/spouse.
  - `Pages > Relationships Editor > Empty` shows the 5 group headers with empty-state hints.
  - `Pages > Relationships Editor > WithContradiction` surfaces the Alert on the Pierre-as-parent card.
  - `Pages > Relationships Editor > Loading` shows skeleton cards.

## Out of scope (worth follow-up issues)

- Service-layer contradiction detection (`detectContradictions`) — needs precise definition first.
- Production `/characters/[slug]/relationships` route in `apps/admin`.
- Table view + network graph alternatives (deferred per [`feedback_relationship_editor_pattern`](../tree/feat/batch-h-relationship-editor/.claude/projects/-home-tbyrd-Projects-time-traveler/memory/feedback_relationship_editor_pattern.md)).

After this PR, every fidelity-1 wireframe has a visual realization in Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)