### PR TITLE
feat(ui): RelationshipTypeSelector — asymmetric direction + inline sub-role radios

### DIFF
--- a/docs/design/admin/01-user-flows.md
+++ b/docs/design/admin/01-user-flows.md
@@ -54,7 +54,7 @@ Edge cases:
 
 - **Duplicate type.** If the user picks a type that already exists for this pair, the DB rejects via the unique index. Editor catches the constraint violation and surfaces "Marie already has a `family` relationship with Pierre — edit the existing one?" with a link.
 - **Self-relationship.** DB rejects (`CHECK (character_id != related_character_id)`). Editor disables the "self" option in the picker before submit.
-- **Asymmetric types.** `mentor_student`, `creator_creation`, `owner_pet`, `trainer_trainee`, `worship` are directional. The selector renders these as **paired radios** under the Asymmetric fieldset ("Marie mentors Pierre" / "Pierre mentors Marie") so direction is picked explicitly. No reciprocal row is created for asymmetric types — the chosen direction is the only row stored.
+- **Asymmetric types.** `mentor_student`, `creator_creation`, `owner_pet`, `trainer_trainee`, `worship` are directional. The selector renders one radio per asymmetric type and stores the row with the focal character as `character_id` and the other character as `related_character_id` (the focal-is-subject convention). No reciprocal row is created — direction lives in column position. To record the reverse direction (e.g., "Pierre mentored Marie"), the author switches to Pierre's editor and creates the relationship from there.
 
 ## Flow D — Edit a character that owns published events (permission edge)
 

--- a/docs/design/admin/01-user-flows.md
+++ b/docs/design/admin/01-user-flows.md
@@ -43,18 +43,18 @@ Persona: Biographer adding the Marie/Pierre marriage relationship.
 1. From **Character detail** ("Marie Curie"), click into the **Relationships** section.
 2. **Relationships editor** opens scoped to Marie. User clicks **Add relationship**.
 3. Picker: pick the other character ("Pierre Curie"). User searches by name.
-4. Pick `relationship_type`. User picks `family`. (Note: "spouse" is not in the enum — `family` is the closest. This is a spec friction point worth flagging.)
+4. Pick `relationship_type`. User picks `family`, then picks `spouse` from the inline sub-role radios that appear (the family / professional / collaboration types reveal a sub-role chooser per issue #119; `spouse` is one of 16 family sub-roles).
 5. Enter description: "Married 1895; collaborated on radioactivity research until Pierre's death in 1906."
 6. Enter **Start temporal**: 1895 CE.
 7. Enter **End temporal**: 1906 CE (Pierre's death). System-design treats end-of-relationship as optional — leaving it empty means "ongoing or unknown."
-8. **Reciprocity check.** `family` is treated as symmetric. The editor offers a checkbox: **Also create the reverse edge (Pierre → Marie, family, same dates)**. Default: checked. On save, two inserts go out.
-9. User adds a second relationship for the same pair: `relationship_type = collaboration`, same dates. The unique index `(character_id, related_character_id, relationship_type)` permits this because the type differs.
+8. **Reciprocity is implicit.** There is no longer a "create the reverse edge" checkbox — the wireframe's Batch 2 Q1 decision made reciprocal-edge creation automatic based on the type/role choice. `family/spouse` is symmetric, so on save the service writes two rows: `(Marie, Pierre, family, spouse)` and `(Pierre, Marie, family, spouse)`. Paired sub-roles like `parent`/`child` write the inverted role on the reverse row; symmetric flat types like `friendship` write a same-type reverse. See `02-wireframes/06-relationships-editor.md` for the full taxonomy.
+9. User adds a second relationship for the same pair: `relationship_type = collaboration`, same dates. The unique index `(character_id, related_character_id, relationship_type, relationship_role)` permits this because the type/role tuple differs.
 
 Edge cases:
 
 - **Duplicate type.** If the user picks a type that already exists for this pair, the DB rejects via the unique index. Editor catches the constraint violation and surfaces "Marie already has a `family` relationship with Pierre — edit the existing one?" with a link.
 - **Self-relationship.** DB rejects (`CHECK (character_id != related_character_id)`). Editor disables the "self" option in the picker before submit.
-- **Asymmetric types.** `mentor_student`, `creator_creation`, `owner_pet`, `trainer_trainee`, `worship` are directional. Reciprocity checkbox is hidden for these; the role label in the editor shows direction explicitly ("Marie _mentors_ Pierre" not "Marie ↔ Pierre, mentor_student").
+- **Asymmetric types.** `mentor_student`, `creator_creation`, `owner_pet`, `trainer_trainee`, `worship` are directional. The selector renders these as **paired radios** under the Asymmetric fieldset ("Marie mentors Pierre" / "Pierre mentors Marie") so direction is picked explicitly. No reciprocal row is created for asymmetric types — the chosen direction is the only row stored.
 
 ## Flow D — Edit a character that owns published events (permission edge)
 

--- a/docs/design/admin/02-wireframes/06-relationships-editor.md
+++ b/docs/design/admin/02-wireframes/06-relationships-editor.md
@@ -36,7 +36,7 @@ Per system-design §3.3, relationships are stored as **directed pairs** in the d
 | `worship`          | **Asymmetric**                                        | No                                                          |
 | `mentor_student`   | **Asymmetric**                                        | No                                                          |
 
-This means the editor must distinguish symmetric and asymmetric types and behave differently for each — most critically, asymmetric types must surface direction explicitly in the UI ("Marie _mentors_ Pierre" not "Marie ↔ Pierre").
+This means the editor must distinguish symmetric and asymmetric types and behave differently for each. For asymmetric types the convention is "focal character is the subject of the verb" — the row is always stored from the perspective of whichever character's editor is being used. Cards then surface direction via narrative text ("Marie _mentors_ Pierre" instead of "Marie ↔ Pierre"). Symmetric types create a reciprocal row automatically (paired sub-roles get the inverted role; symmetric sub-roles and symmetric flat types keep the same role).
 
 ## Sub-role taxonomy (Batch 2 decision)
 
@@ -147,12 +147,12 @@ Each relationship is a card with full temporal scope visible. Edits happen inlin
 │   ( ) friendship          ( ) rivalry                            │
 │  Antagonistic                                                    │
 │   ( ) enemy                                                      │
-│  Asymmetric (direction matters)                                  │
-│   ( ) Marie mentors Pierre  ( ) Pierre mentors Marie             │
-│   ( ) Marie created Pierre  ( ) Pierre created Marie             │
-│   ( ) Marie trains Pierre   ( ) Pierre trains Marie              │
-│   ( ) Marie owns Pierre     ( ) Pierre owns Marie                │
-│   ( ) Marie worships Pierre ( ) Pierre worships Marie            │
+│  Asymmetric (focal character is subject of the verb)             │
+│   ( ) mentor / student                                           │
+│   ( ) creator / creation                                         │
+│   ( ) trainer / trainee                                          │
+│   ( ) owner / pet                                                │
+│   ( ) worship                                                    │
 │                                                                  │
 │  Date range                                                      │
 │  Start  [ 1895 CE (exact)  ▾]                                    │
@@ -177,7 +177,7 @@ Each relationship is a card with full temporal scope visible. Edits happen inlin
 2. **Card layout reads the temporal range visually.** A horizontal range bar between start and end dates makes "1895–1906 CE" legible at a glance. "Ongoing" renders as an open right edge. For pre-CE dates, the era is in the labels.
 3. **Direction is rendered as narrative text on the card.** "Marie is mother of Irène" instead of an arrow. The grammar makes asymmetric types unambiguous.
 4. **Add sheet is a right-side slide-out**, not a modal. This makes it easier to reference the current relationships while adding a new one.
-5. **Type picker groups by family** (same groups used in the list). For `family`, `professional`, and `collaboration`, picking a type reveals an inline sub-role chooser ([#119](https://github.com/shaes-farm/time-traveler/issues/119); Batch 2 decision Q3). Asymmetric types render as paired radios — picking "Marie mentors Pierre" stores `(Marie, Pierre, mentor_student)`; picking "Pierre mentors Marie" stores `(Pierre, Marie, mentor_student)`. The user never sees the column names; they see the semantic relationship.
+5. **Type picker groups by family** (same groups used in the list). For `family`, `professional`, and `collaboration`, picking a type reveals an inline sub-role chooser ([#119](https://github.com/shaes-farm/time-traveler/issues/119); Batch 2 decision Q3). Asymmetric types render as a single radio per type. The implementation convention is **focal character is the subject of the verb** — picking `mentor_student` from Marie's editor stores `(Marie, Pierre, mentor_student)` ("Marie mentors Pierre"). To record the reverse direction ("Pierre mentored Marie"), the author switches to Pierre's editor and creates the relationship from there; direction lives implicitly in column ordering. An earlier iteration of this wireframe specified paired radios per asymmetric type with name interpolation; that approach was implemented (PR #164) and reverted because the 10 paired rows added visual weight disproportionate to their value — narrative direction is already carried by the description field, and the focal-is-subject convention covers the common case.
 6. **Reciprocal-edge creation is implicit** in the type/role choice — there is no longer a "reciprocal" checkbox (Batch 2 decision Q1). For paired sub-roles (`parent`/`child`, `grandparent`/`grandchild`, `employer`/`employee`, etc.) the system stores both rows with inverted roles. For symmetric sub-roles and symmetric flat types (`friendship`, `rivalry`, `enemy`, `collaboration` with a symmetric role), both rows are stored with the same type+role. **Description does not sync** between the two rows — each character's card carries its own perspective text. Dates and type/role sync between paired rows; future edits to dates propagate, edits to description do not.
 7. **Type picker uses radio rather than select** because the user benefits from seeing all 11 types at once when choosing — the wrong type is a common error and selects hide that.
 8. **Other-character search** is a combobox that excludes the focal character (`Marie`) and any character already linked by the currently-chosen type (to avoid the unique-index violation before save).

--- a/docs/design/admin/fidelity-2-plan.md
+++ b/docs/design/admin/fidelity-2-plan.md
@@ -266,7 +266,7 @@ This batch tracks the refreshed scope from [#40](https://github.com/shaes-farm/t
 - Composite stories: `Pages > Character Editor`, `Pages > Event Editor`
 - Supporting stories added for newly landed primitives consumed by editor/list surfaces: `Textarea`, `Checkbox`, `Slider`, `Table`, `DataTable`, `FilterRail`
 
-### Batch H — Relationship editor
+### Batch H — Relationship editor ✅ landed in [#162](https://github.com/shaes-farm/time-traveler/pull/162)
 
 Originally Batch F.
 

--- a/packages/ui/src/components/relationship-type-selector.test.tsx
+++ b/packages/ui/src/components/relationship-type-selector.test.tsx
@@ -141,6 +141,31 @@ describe("RelationshipTypeSelector", () => {
     });
   });
 
+  it("renders the sub-role group inline inside the selected type's fieldset", () => {
+    // Family selected → sub-role group lives inside the Family fieldset.
+    render(<Harness initialType="family" initialRole="spouse" />);
+    const familyFieldset = screen.getByTestId(
+      "relationship-type-family-family",
+    );
+    expect(
+      within(familyFieldset).getByTestId("relationship-type-role-select"),
+    ).toBeInTheDocument();
+  });
+
+  it("places the sub-role group inside the Professional fieldset when collaboration is selected", () => {
+    // collaboration and professional share a fieldset; selecting collaboration
+    // should still scope the sub-role group to that fieldset.
+    render(
+      <Harness initialType="collaboration" initialRole="research_partner" />,
+    );
+    const professionalFieldset = screen.getByTestId(
+      "relationship-type-family-professional",
+    );
+    expect(
+      within(professionalFieldset).getByTestId("relationship-type-role-select"),
+    ).toBeInTheDocument();
+  });
+
   // ─── Role carry/clear logic (existing behaviour, updated for isReversed) ───
 
   it("clears role when switching from a sub-roled type to a non-sub-roled type", async () => {

--- a/packages/ui/src/components/relationship-type-selector.test.tsx
+++ b/packages/ui/src/components/relationship-type-selector.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -8,24 +8,41 @@ import {
   type RelationshipType,
 } from "./relationship-type-selector";
 
+type SelectorChange = {
+  type: RelationshipType;
+  role: string | null;
+  isReversed: boolean;
+};
+
 function Harness({
   initialType = "friendship" as RelationshipType,
   initialRole = null as string | null,
+  initialIsReversed = false,
+  focalCharacterName,
+  otherCharacterName,
   onChange,
 }: {
   initialType?: RelationshipType;
   initialRole?: string | null;
-  onChange?: (next: { type: RelationshipType; role: string | null }) => void;
+  initialIsReversed?: boolean;
+  focalCharacterName?: string;
+  otherCharacterName?: string;
+  onChange?: (next: SelectorChange) => void;
 }) {
   const [type, setType] = useState<RelationshipType>(initialType);
   const [role, setRole] = useState<string | null>(initialRole);
+  const [isReversed, setIsReversed] = useState<boolean>(initialIsReversed);
   return (
     <RelationshipTypeSelector
       type={type}
       role={role}
+      isReversed={isReversed}
+      focalCharacterName={focalCharacterName}
+      otherCharacterName={otherCharacterName}
       onChange={(next) => {
         setType(next.type);
         setRole(next.role);
+        setIsReversed(next.isReversed);
         onChange?.(next);
       }}
     />
@@ -33,26 +50,37 @@ function Harness({
 }
 
 describe("RelationshipTypeSelector", () => {
-  it("renders all 11 relationship types under their family legends", () => {
+  // ─── Type radios ────────────────────────────────────────────────────────────
+
+  it("renders 16 type radios total (6 symmetric + 10 paired asymmetric)", () => {
     render(<Harness />);
 
-    // Each fieldset legend visible
+    // 5 fieldset legends
     expect(screen.getByText("Family")).toBeInTheDocument();
     expect(screen.getByText("Professional")).toBeInTheDocument();
     expect(screen.getByText("Social / Personal")).toBeInTheDocument();
     expect(screen.getByText("Antagonistic")).toBeInTheDocument();
     expect(screen.getByText("Asymmetric")).toBeInTheDocument();
 
-    // 11 radio items
+    // 6 symmetric radios (family + professional + collaboration +
+    // friendship + rivalry + enemy) + 10 paired asymmetric radios = 16.
     const radios = screen.getAllByRole("radio");
-    expect(radios).toHaveLength(11);
+    expect(radios).toHaveLength(16);
   });
 
-  it("reveals the role Select when a sub-roled type is selected", async () => {
+  it("renders paired radios per asymmetric type (10 rows in the Asymmetric fieldset)", () => {
+    render(<Harness />);
+    const fieldset = screen.getByTestId("relationship-type-family-asymmetric");
+    const radios = within(fieldset).getAllByRole("radio");
+    expect(radios).toHaveLength(10);
+  });
+
+  // ─── Sub-role radio group (replaces the prior combobox interactions) ────────
+
+  it("reveals the role radio group when a sub-roled type is selected", async () => {
     const user = userEvent.setup();
     render(<Harness />);
 
-    // friendship is initial — no role select yet
     expect(
       screen.queryByTestId("relationship-type-role-select"),
     ).not.toBeInTheDocument();
@@ -64,7 +92,7 @@ describe("RelationshipTypeSelector", () => {
     ).toBeInTheDocument();
   });
 
-  it("hides the role Select for non-sub-roled types", async () => {
+  it("hides the role radio group for non-sub-roled types", async () => {
     const user = userEvent.setup();
     render(<Harness initialType="family" initialRole="spouse" />);
 
@@ -79,6 +107,42 @@ describe("RelationshipTypeSelector", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders all family sub-role radios when type is family", () => {
+    render(<Harness initialType="family" />);
+    const group = screen.getByTestId("relationship-type-role-select");
+    const radios = within(group).getAllByRole("radio");
+    expect(radios).toHaveLength(16);
+    expect(within(group).getByLabelText("spouse")).toBeInTheDocument();
+    expect(within(group).getByLabelText("parent")).toBeInTheDocument();
+    expect(within(group).getByLabelText("step parent")).toBeInTheDocument();
+  });
+
+  it("renders all professional sub-role radios when type is professional", () => {
+    render(<Harness initialType="professional" />);
+    const group = screen.getByTestId("relationship-type-role-select");
+    const radios = within(group).getAllByRole("radio");
+    expect(radios).toHaveLength(9);
+    expect(within(group).getByLabelText("employer")).toBeInTheDocument();
+    expect(within(group).getByLabelText("employee")).toBeInTheDocument();
+  });
+
+  it("updates role when selecting a sub-role radio", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness initialType="family" onChange={onChange} />);
+
+    const group = screen.getByTestId("relationship-type-role-select");
+    await user.click(within(group).getByLabelText("spouse"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "family",
+      role: "spouse",
+      isReversed: false,
+    });
+  });
+
+  // ─── Role carry/clear logic (existing behaviour, updated for isReversed) ───
+
   it("clears role when switching from a sub-roled type to a non-sub-roled type", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
@@ -91,14 +155,13 @@ describe("RelationshipTypeSelector", () => {
     expect(onChange).toHaveBeenCalledWith({
       type: "friendship",
       role: null,
+      isReversed: false,
     });
   });
 
   it("preserves role across sub-roled types when the value is valid in both", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    // "other" is a member of every sub-role enum (family, professional,
-    // collaboration), so switching between them should carry it forward.
     render(
       <Harness
         initialType="professional"
@@ -112,14 +175,13 @@ describe("RelationshipTypeSelector", () => {
     expect(onChange).toHaveBeenCalledWith({
       type: "family",
       role: "other",
+      isReversed: false,
     });
   });
 
   it("clears role when the current value is not valid for the next sub-roled type", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    // "spouse" exists in familyRoleEnum but not in professionalRoleEnum, so
-    // switching from family/spouse to professional must drop the role.
     render(
       <Harness initialType="family" initialRole="spouse" onChange={onChange} />,
     );
@@ -129,47 +191,110 @@ describe("RelationshipTypeSelector", () => {
     expect(onChange).toHaveBeenCalledWith({
       type: "professional",
       role: null,
+      isReversed: false,
     });
   });
 
-  it("shows family sub-roles in the Select when type is family", async () => {
-    const user = userEvent.setup();
-    render(<Harness initialType="family" />);
+  // ─── Asymmetric direction support ──────────────────────────────────────────
 
-    await user.click(screen.getByRole("combobox", { name: "Role" }));
-
+  it("interpolates focal + other names into asymmetric paired-radio labels", () => {
+    render(<Harness focalCharacterName="Marie" otherCharacterName="Pierre" />);
+    const fieldset = screen.getByTestId("relationship-type-family-asymmetric");
     expect(
-      await screen.findByRole("option", { name: "spouse" }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "parent" })).toBeInTheDocument();
-  });
-
-  it("shows professional sub-roles in the Select when type is professional", async () => {
-    const user = userEvent.setup();
-    render(<Harness initialType="professional" />);
-
-    await user.click(screen.getByRole("combobox", { name: "Role" }));
-
-    expect(
-      await screen.findByRole("option", { name: "employer" }),
+      within(fieldset).getByLabelText("Marie mentors Pierre"),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "employee" }),
+      within(fieldset).getByLabelText("Pierre mentors Marie"),
+    ).toBeInTheDocument();
+    expect(
+      within(fieldset).getByLabelText("Marie owns Pierre"),
     ).toBeInTheDocument();
   });
 
-  it("updates role when selecting a sub-role option", async () => {
+  it("falls back to generic labels when focal/other names are not provided", () => {
+    render(<Harness />);
+    const fieldset = screen.getByTestId("relationship-type-family-asymmetric");
+    expect(
+      within(fieldset).getByLabelText("This character mentors Other"),
+    ).toBeInTheDocument();
+    expect(
+      within(fieldset).getByLabelText("Other mentors This character"),
+    ).toBeInTheDocument();
+  });
+
+  it("selecting a reversed asymmetric radio emits isReversed: true", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
+    render(
+      <Harness
+        focalCharacterName="Marie"
+        otherCharacterName="Pierre"
+        onChange={onChange}
+      />,
+    );
 
-    render(<Harness initialType="family" onChange={onChange} />);
-
-    await user.click(screen.getByRole("combobox", { name: "Role" }));
-    await user.click(await screen.findByRole("option", { name: "spouse" }));
+    await user.click(screen.getByLabelText("Pierre mentors Marie"));
 
     expect(onChange).toHaveBeenCalledWith({
-      type: "family",
-      role: "spouse",
+      type: "mentor_student",
+      role: null,
+      isReversed: true,
     });
+  });
+
+  it("selecting a forward asymmetric radio emits isReversed: false", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        focalCharacterName="Marie"
+        otherCharacterName="Pierre"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Marie mentors Pierre"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "mentor_student",
+      role: null,
+      isReversed: false,
+    });
+  });
+
+  it("resets isReversed to false when switching from an asymmetric type to a symmetric type", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialType="mentor_student"
+        initialIsReversed
+        focalCharacterName="Marie"
+        otherCharacterName="Pierre"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("friendship"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: "friendship",
+      role: null,
+      isReversed: false,
+    });
+  });
+
+  // ─── Helper text ───────────────────────────────────────────────────────────
+
+  it("shows the symmetric helper text for non-asymmetric types", () => {
+    render(<Harness initialType="friendship" />);
+    expect(
+      screen.getByText(/a reverse entry will be created automatically/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the asymmetric helper text for asymmetric types", () => {
+    render(<Harness initialType="mentor_student" />);
+    expect(screen.getByText(/direction matters/i)).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/relationship-type-selector.test.tsx
+++ b/packages/ui/src/components/relationship-type-selector.test.tsx
@@ -11,38 +11,26 @@ import {
 type SelectorChange = {
   type: RelationshipType;
   role: string | null;
-  isReversed: boolean;
 };
 
 function Harness({
   initialType = "friendship" as RelationshipType,
   initialRole = null as string | null,
-  initialIsReversed = false,
-  focalCharacterName,
-  otherCharacterName,
   onChange,
 }: {
   initialType?: RelationshipType;
   initialRole?: string | null;
-  initialIsReversed?: boolean;
-  focalCharacterName?: string;
-  otherCharacterName?: string;
   onChange?: (next: SelectorChange) => void;
 }) {
   const [type, setType] = useState<RelationshipType>(initialType);
   const [role, setRole] = useState<string | null>(initialRole);
-  const [isReversed, setIsReversed] = useState<boolean>(initialIsReversed);
   return (
     <RelationshipTypeSelector
       type={type}
       role={role}
-      isReversed={isReversed}
-      focalCharacterName={focalCharacterName}
-      otherCharacterName={otherCharacterName}
       onChange={(next) => {
         setType(next.type);
         setRole(next.role);
-        setIsReversed(next.isReversed);
         onChange?.(next);
       }}
     />
@@ -52,30 +40,27 @@ function Harness({
 describe("RelationshipTypeSelector", () => {
   // ─── Type radios ────────────────────────────────────────────────────────────
 
-  it("renders 16 type radios total (6 symmetric + 10 paired asymmetric)", () => {
+  it("renders 11 type radios total (one per relationship_type)", () => {
     render(<Harness />);
 
-    // 5 fieldset legends
     expect(screen.getByText("Family")).toBeInTheDocument();
     expect(screen.getByText("Professional")).toBeInTheDocument();
     expect(screen.getByText("Social / Personal")).toBeInTheDocument();
     expect(screen.getByText("Antagonistic")).toBeInTheDocument();
     expect(screen.getByText("Asymmetric")).toBeInTheDocument();
 
-    // 6 symmetric radios (family + professional + collaboration +
-    // friendship + rivalry + enemy) + 10 paired asymmetric radios = 16.
     const radios = screen.getAllByRole("radio");
-    expect(radios).toHaveLength(16);
+    expect(radios).toHaveLength(11);
   });
 
-  it("renders paired radios per asymmetric type (10 rows in the Asymmetric fieldset)", () => {
+  it("renders one radio per asymmetric type (5 rows in the Asymmetric fieldset)", () => {
     render(<Harness />);
     const fieldset = screen.getByTestId("relationship-type-family-asymmetric");
     const radios = within(fieldset).getAllByRole("radio");
-    expect(radios).toHaveLength(10);
+    expect(radios).toHaveLength(5);
   });
 
-  // ─── Sub-role radio group (replaces the prior combobox interactions) ────────
+  // ─── Sub-role radio group ──────────────────────────────────────────────────
 
   it("reveals the role radio group when a sub-roled type is selected", async () => {
     const user = userEvent.setup();
@@ -137,12 +122,10 @@ describe("RelationshipTypeSelector", () => {
     expect(onChange).toHaveBeenCalledWith({
       type: "family",
       role: "spouse",
-      isReversed: false,
     });
   });
 
   it("renders the sub-role group inline inside the selected type's fieldset", () => {
-    // Family selected → sub-role group lives inside the Family fieldset.
     render(<Harness initialType="family" initialRole="spouse" />);
     const familyFieldset = screen.getByTestId(
       "relationship-type-family-family",
@@ -153,8 +136,6 @@ describe("RelationshipTypeSelector", () => {
   });
 
   it("places the sub-role group inside the Professional fieldset when collaboration is selected", () => {
-    // collaboration and professional share a fieldset; selecting collaboration
-    // should still scope the sub-role group to that fieldset.
     render(
       <Harness initialType="collaboration" initialRole="research_partner" />,
     );
@@ -166,7 +147,7 @@ describe("RelationshipTypeSelector", () => {
     ).toBeInTheDocument();
   });
 
-  // ─── Role carry/clear logic (existing behaviour, updated for isReversed) ───
+  // ─── Role carry/clear logic ────────────────────────────────────────────────
 
   it("clears role when switching from a sub-roled type to a non-sub-roled type", async () => {
     const onChange = vi.fn();
@@ -180,7 +161,6 @@ describe("RelationshipTypeSelector", () => {
     expect(onChange).toHaveBeenCalledWith({
       type: "friendship",
       role: null,
-      isReversed: false,
     });
   });
 
@@ -200,7 +180,6 @@ describe("RelationshipTypeSelector", () => {
     expect(onChange).toHaveBeenCalledWith({
       type: "family",
       role: "other",
-      isReversed: false,
     });
   });
 
@@ -216,96 +195,6 @@ describe("RelationshipTypeSelector", () => {
     expect(onChange).toHaveBeenCalledWith({
       type: "professional",
       role: null,
-      isReversed: false,
-    });
-  });
-
-  // ─── Asymmetric direction support ──────────────────────────────────────────
-
-  it("interpolates focal + other names into asymmetric paired-radio labels", () => {
-    render(<Harness focalCharacterName="Marie" otherCharacterName="Pierre" />);
-    const fieldset = screen.getByTestId("relationship-type-family-asymmetric");
-    expect(
-      within(fieldset).getByLabelText("Marie mentors Pierre"),
-    ).toBeInTheDocument();
-    expect(
-      within(fieldset).getByLabelText("Pierre mentors Marie"),
-    ).toBeInTheDocument();
-    expect(
-      within(fieldset).getByLabelText("Marie owns Pierre"),
-    ).toBeInTheDocument();
-  });
-
-  it("falls back to generic labels when focal/other names are not provided", () => {
-    render(<Harness />);
-    const fieldset = screen.getByTestId("relationship-type-family-asymmetric");
-    expect(
-      within(fieldset).getByLabelText("This character mentors Other"),
-    ).toBeInTheDocument();
-    expect(
-      within(fieldset).getByLabelText("Other mentors This character"),
-    ).toBeInTheDocument();
-  });
-
-  it("selecting a reversed asymmetric radio emits isReversed: true", async () => {
-    const onChange = vi.fn();
-    const user = userEvent.setup();
-    render(
-      <Harness
-        focalCharacterName="Marie"
-        otherCharacterName="Pierre"
-        onChange={onChange}
-      />,
-    );
-
-    await user.click(screen.getByLabelText("Pierre mentors Marie"));
-
-    expect(onChange).toHaveBeenCalledWith({
-      type: "mentor_student",
-      role: null,
-      isReversed: true,
-    });
-  });
-
-  it("selecting a forward asymmetric radio emits isReversed: false", async () => {
-    const onChange = vi.fn();
-    const user = userEvent.setup();
-    render(
-      <Harness
-        focalCharacterName="Marie"
-        otherCharacterName="Pierre"
-        onChange={onChange}
-      />,
-    );
-
-    await user.click(screen.getByLabelText("Marie mentors Pierre"));
-
-    expect(onChange).toHaveBeenCalledWith({
-      type: "mentor_student",
-      role: null,
-      isReversed: false,
-    });
-  });
-
-  it("resets isReversed to false when switching from an asymmetric type to a symmetric type", async () => {
-    const onChange = vi.fn();
-    const user = userEvent.setup();
-    render(
-      <Harness
-        initialType="mentor_student"
-        initialIsReversed
-        focalCharacterName="Marie"
-        otherCharacterName="Pierre"
-        onChange={onChange}
-      />,
-    );
-
-    await user.click(screen.getByLabelText("friendship"));
-
-    expect(onChange).toHaveBeenCalledWith({
-      type: "friendship",
-      role: null,
-      isReversed: false,
     });
   });
 
@@ -320,6 +209,8 @@ describe("RelationshipTypeSelector", () => {
 
   it("shows the asymmetric helper text for asymmetric types", () => {
     render(<Harness initialType="mentor_student" />);
-    expect(screen.getByText(/direction matters/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/no reverse entry is created/i),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/relationship-type-selector.tsx
+++ b/packages/ui/src/components/relationship-type-selector.tsx
@@ -34,8 +34,11 @@ interface FamilyGroup {
 const TYPE_FAMILIES: FamilyGroup[] = [
   { legend: "Family", types: ["family"] },
   { legend: "Professional", types: ["professional", "collaboration"] },
-  { legend: "Social / Personal", types: ["friendship"] },
-  { legend: "Antagonistic", types: ["rivalry", "enemy"] },
+  // Rivalry sits under Social / Personal per the wireframe: it's
+  // antagonistic in tone but still a social-standing relationship between
+  // peers. Only `enemy` belongs in the strictly Antagonistic fieldset.
+  { legend: "Social / Personal", types: ["friendship", "rivalry"] },
+  { legend: "Antagonistic", types: ["enemy"] },
   {
     legend: "Asymmetric",
     types: [

--- a/packages/ui/src/components/relationship-type-selector.tsx
+++ b/packages/ui/src/components/relationship-type-selector.tsx
@@ -90,28 +90,34 @@ export function RelationshipTypeSelector({
   // collide on id/htmlFor pairs.
   const idPrefix = React.useId();
 
+  // Shared by all five per-fieldset RadioGroups. Each fieldset is its own
+  // Radix RadioGroup so the role RadioGroup (rendered as a sibling within
+  // the fieldset of the selected type) never becomes a DOM descendant of a
+  // type RadioGroup. Avoids nested role="radiogroup" semantics.
+  const handleTypeChange = (next: string) => {
+    const nextType = next as RelationshipType;
+    // Carry role forward only when (a) the next type accepts a role
+    // *and* (b) the current role is valid for that type's enum.
+    const nextRoleOptions = ROLE_OPTIONS[nextType];
+    const nextRole =
+      typeAcceptsRole(nextType) &&
+      role != null &&
+      nextRoleOptions?.includes(role)
+        ? role
+        : null;
+
+    onChange({ type: nextType, role: nextRole });
+  };
+
   return (
     <div className={cn("space-y-4", className)}>
-      <RadioGroup
-        value={type}
-        onValueChange={(next) => {
-          const nextType = next as RelationshipType;
-          // Carry role forward only when (a) the next type accepts a role
-          // *and* (b) the current role is valid for that type's enum.
-          const nextRoleOptions = ROLE_OPTIONS[nextType];
-          const nextRole =
-            typeAcceptsRole(nextType) &&
-            role != null &&
-            nextRoleOptions?.includes(role)
-              ? role
-              : null;
-
-          onChange({ type: nextType, role: nextRole });
-        }}
-        disabled={disabled}
-        className="gap-4"
-      >
-        {TYPE_FAMILIES.map((family) => (
+      {TYPE_FAMILIES.map((family) => {
+        const fieldsetOwnsSelectedType = family.types.includes(type);
+        const roleOptionsForSelected =
+          fieldsetOwnsSelectedType && typeAcceptsRole(type)
+            ? ROLE_OPTIONS[type]
+            : undefined;
+        return (
           <fieldset
             key={family.legend}
             className="space-y-2 border-0 p-0"
@@ -120,9 +126,14 @@ export function RelationshipTypeSelector({
             <legend className="mb-1 text-xs font-medium uppercase tracking-wider text-foreground-muted">
               {family.legend}
             </legend>
-            {family.types.map((typeValue) => (
-              <React.Fragment key={typeValue}>
-                <div className="flex items-center gap-2">
+            <RadioGroup
+              value={type}
+              onValueChange={handleTypeChange}
+              disabled={disabled}
+              className="space-y-2"
+            >
+              {family.types.map((typeValue) => (
+                <div key={typeValue} className="flex items-center gap-2">
                   <RadioGroupItem
                     id={`${idPrefix}-type-${typeValue}`}
                     value={typeValue}
@@ -134,28 +145,23 @@ export function RelationshipTypeSelector({
                     {humanize(typeValue)}
                   </Label>
                 </div>
-                {/* Sub-role radios inline beneath the currently-selected
-                    sub-roled type. Renders inside the same fieldset as the
-                    parent type radio so the visual hierarchy matches the
-                    wireframe. */}
-                {type === typeValue &&
-                  typeAcceptsRole(typeValue) &&
-                  ROLE_OPTIONS[typeValue] && (
-                    <SubRoleRadios
-                      role={role}
-                      options={ROLE_OPTIONS[typeValue]!}
-                      idPrefix={idPrefix}
-                      disabled={disabled}
-                      onChange={(nextRole) =>
-                        onChange({ type, role: nextRole })
-                      }
-                    />
-                  )}
-              </React.Fragment>
-            ))}
+              ))}
+            </RadioGroup>
+            {/* Role radios — sibling of the type RadioGroup, still inside
+                the fieldset of the selected type so the visual hierarchy
+                matches the wireframe without creating nested radiogroups. */}
+            {roleOptionsForSelected && (
+              <SubRoleRadios
+                role={role}
+                options={roleOptionsForSelected}
+                idPrefix={idPrefix}
+                disabled={disabled}
+                onChange={(nextRole) => onChange({ type, role: nextRole })}
+              />
+            )}
           </fieldset>
-        ))}
-      </RadioGroup>
+        );
+      })}
 
       {/* Symmetric/asymmetric semantics helper text */}
       <p className="text-xs text-foreground-muted">

--- a/packages/ui/src/components/relationship-type-selector.tsx
+++ b/packages/ui/src/components/relationship-type-selector.tsx
@@ -169,12 +169,9 @@ export function RelationshipTypeSelector({
   disabled,
   className,
 }: RelationshipTypeSelectorProps) {
-  const roleOptions = ROLE_OPTIONS[type];
-  const acceptsRole = typeAcceptsRole(type);
   // Unique per-instance prefix so multiple selectors on the same page don't
   // collide on id/htmlFor pairs.
   const idPrefix = React.useId();
-  const roleGroupLabelId = `${idPrefix}-role-label`;
 
   const focal = focalCharacterName ?? "This character";
   const other = otherCharacterName ?? "Other";
@@ -215,22 +212,41 @@ export function RelationshipTypeSelector({
             <legend className="mb-1 text-xs font-medium uppercase tracking-wider text-foreground-muted">
               {family.legend}
             </legend>
-            {family.types
-              .flatMap((typeValue) => rowsForType(typeValue, focal, other))
-              .map((row) => {
-                const itemId = `${idPrefix}-type-${row.key}`;
-                return (
-                  <div key={row.key} className="flex items-center gap-2">
-                    <RadioGroupItem id={itemId} value={row.value} />
-                    <Label
-                      htmlFor={itemId}
-                      className="font-normal capitalize text-foreground"
-                    >
-                      {row.label}
-                    </Label>
-                  </div>
-                );
-              })}
+            {family.types.map((typeValue) => (
+              <React.Fragment key={typeValue}>
+                {rowsForType(typeValue, focal, other).map((row) => {
+                  const itemId = `${idPrefix}-type-${row.key}`;
+                  return (
+                    <div key={row.key} className="flex items-center gap-2">
+                      <RadioGroupItem id={itemId} value={row.value} />
+                      <Label
+                        htmlFor={itemId}
+                        className="font-normal capitalize text-foreground"
+                      >
+                        {row.label}
+                      </Label>
+                    </div>
+                  );
+                })}
+                {/* Sub-role radios inline beneath the currently-selected
+                    sub-roled type. Renders inside the same fieldset as the
+                    parent type radio so the visual hierarchy matches the
+                    wireframe. */}
+                {type === typeValue &&
+                  typeAcceptsRole(typeValue) &&
+                  ROLE_OPTIONS[typeValue] && (
+                    <SubRoleRadios
+                      role={role}
+                      options={ROLE_OPTIONS[typeValue]!}
+                      idPrefix={idPrefix}
+                      disabled={disabled}
+                      onChange={(nextRole) =>
+                        onChange({ type, role: nextRole, isReversed })
+                      }
+                    />
+                  )}
+              </React.Fragment>
+            ))}
           </fieldset>
         ))}
       </RadioGroup>
@@ -241,39 +257,56 @@ export function RelationshipTypeSelector({
           ? "Direction matters — this relationship is stored from one perspective only."
           : "A reverse entry will be created automatically."}
       </p>
+    </div>
+  );
+}
 
-      {acceptsRole && roleOptions && (
-        <div className="space-y-2" data-testid="relationship-type-role-select">
-          <span
-            id={roleGroupLabelId}
-            className="block text-sm font-medium text-foreground"
-          >
-            Role
-          </span>
-          <RadioGroup
-            value={role ?? ""}
-            onValueChange={(next) => onChange({ type, role: next, isReversed })}
-            disabled={disabled}
-            aria-labelledby={roleGroupLabelId}
-            className="grid grid-cols-2 gap-x-4 gap-y-2"
-          >
-            {roleOptions.map((roleValue) => {
-              const itemId = `${idPrefix}-role-${roleValue}`;
-              return (
-                <div key={roleValue} className="flex items-center gap-2">
-                  <RadioGroupItem id={itemId} value={roleValue} />
-                  <Label
-                    htmlFor={itemId}
-                    className="font-normal capitalize text-foreground"
-                  >
-                    {humanize(roleValue)}
-                  </Label>
-                </div>
-              );
-            })}
-          </RadioGroup>
-        </div>
-      )}
+// ─── Sub-role radios (inline; rendered beneath the selected sub-roled type) ──
+
+function SubRoleRadios({
+  role,
+  options,
+  idPrefix,
+  disabled,
+  onChange,
+}: {
+  role: string | null | undefined;
+  options: readonly string[];
+  idPrefix: string;
+  disabled?: boolean;
+  onChange: (next: string) => void;
+}) {
+  const labelId = `${idPrefix}-role-label`;
+  return (
+    <div
+      className="mt-1 space-y-2 pl-6"
+      data-testid="relationship-type-role-select"
+    >
+      <span id={labelId} className="block text-sm font-medium text-foreground">
+        Role
+      </span>
+      <RadioGroup
+        value={role ?? ""}
+        onValueChange={onChange}
+        disabled={disabled}
+        aria-labelledby={labelId}
+        className="grid grid-cols-2 gap-x-4 gap-y-2"
+      >
+        {options.map((roleValue) => {
+          const itemId = `${idPrefix}-role-${roleValue}`;
+          return (
+            <div key={roleValue} className="flex items-center gap-2">
+              <RadioGroupItem id={itemId} value={roleValue} />
+              <Label
+                htmlFor={itemId}
+                className="font-normal capitalize text-foreground"
+              >
+                {humanize(roleValue)}
+              </Label>
+            </div>
+          );
+        })}
+      </RadioGroup>
     </div>
   );
 }

--- a/packages/ui/src/components/relationship-type-selector.tsx
+++ b/packages/ui/src/components/relationship-type-selector.tsx
@@ -111,29 +111,33 @@ export function RelationshipTypeSelector({
 
   return (
     <div className={cn("space-y-4", className)}>
-      {TYPE_FAMILIES.map((family) => {
-        const fieldsetOwnsSelectedType = family.types.includes(type);
-        const roleOptionsForSelected =
-          fieldsetOwnsSelectedType && typeAcceptsRole(type)
-            ? ROLE_OPTIONS[type]
-            : undefined;
-        return (
-          <fieldset
-            key={family.legend}
-            className="space-y-2 border-0 p-0"
-            data-testid={`relationship-type-family-${family.legend.toLowerCase().replace(/[^a-z]/g, "-")}`}
-          >
-            <legend className="mb-1 text-xs font-medium uppercase tracking-wider text-foreground-muted">
-              {family.legend}
-            </legend>
-            <RadioGroup
-              value={type}
-              onValueChange={handleTypeChange}
-              disabled={disabled}
-              className="space-y-2"
-            >
-              {family.types.map((typeValue) => (
-                <div key={typeValue} className="flex items-center gap-2">
+      {TYPE_FAMILIES.map((family) => (
+        <fieldset
+          key={family.legend}
+          className="space-y-2 border-0 p-0"
+          data-testid={`relationship-type-family-${family.legend.toLowerCase().replace(/[^a-z]/g, "-")}`}
+        >
+          <legend className="mb-1 text-xs font-medium uppercase tracking-wider text-foreground-muted">
+            {family.legend}
+          </legend>
+          {/*
+            One Radix RadioGroup per type, all sharing value + handler.
+            This lets the SubRoleRadios sit as a DOM sibling of just the
+            selected type's RadioGroup — so the role group renders
+            directly beneath the type the user picked, even when a
+            fieldset contains multiple sub-roled types (e.g. Professional
+            holds both `professional` and `collaboration`). Avoids both
+            (a) nested role="radiogroup" elements and (b) the role group
+            being pushed to the bottom of the fieldset.
+          */}
+          {family.types.map((typeValue) => (
+            <React.Fragment key={typeValue}>
+              <RadioGroup
+                value={type}
+                onValueChange={handleTypeChange}
+                disabled={disabled}
+              >
+                <div className="flex items-center gap-2">
                   <RadioGroupItem
                     id={`${idPrefix}-type-${typeValue}`}
                     value={typeValue}
@@ -145,23 +149,22 @@ export function RelationshipTypeSelector({
                     {humanize(typeValue)}
                   </Label>
                 </div>
-              ))}
-            </RadioGroup>
-            {/* Role radios — sibling of the type RadioGroup, still inside
-                the fieldset of the selected type so the visual hierarchy
-                matches the wireframe without creating nested radiogroups. */}
-            {roleOptionsForSelected && (
-              <SubRoleRadios
-                role={role}
-                options={roleOptionsForSelected}
-                idPrefix={idPrefix}
-                disabled={disabled}
-                onChange={(nextRole) => onChange({ type, role: nextRole })}
-              />
-            )}
-          </fieldset>
-        );
-      })}
+              </RadioGroup>
+              {type === typeValue &&
+                typeAcceptsRole(typeValue) &&
+                ROLE_OPTIONS[typeValue] && (
+                  <SubRoleRadios
+                    role={role}
+                    options={ROLE_OPTIONS[typeValue]!}
+                    idPrefix={idPrefix}
+                    disabled={disabled}
+                    onChange={(nextRole) => onChange({ type, role: nextRole })}
+                  />
+                )}
+            </React.Fragment>
+          ))}
+        </fieldset>
+      ))}
 
       {/* Symmetric/asymmetric semantics helper text */}
       <p className="text-xs text-foreground-muted">

--- a/packages/ui/src/components/relationship-type-selector.tsx
+++ b/packages/ui/src/components/relationship-type-selector.tsx
@@ -12,13 +12,6 @@ import { z } from "zod";
 
 import { Label } from "./label";
 import { RadioGroup, RadioGroupItem } from "./radio-group";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "./select";
 import { cn } from "@repo/ui/lib/utils";
 
 export type RelationshipType = z.infer<typeof relationshipTypeEnum>;
@@ -26,7 +19,30 @@ export type RelationshipType = z.infer<typeof relationshipTypeEnum>;
 export interface RelationshipTypeSelectorProps {
   type: RelationshipType;
   role?: string | null;
-  onChange: (next: { type: RelationshipType; role: string | null }) => void;
+  /**
+   * True when the relationship is stored from the OTHER character's
+   * perspective — i.e., the focal character is the object, not the subject.
+   * Only meaningful for the five asymmetric types
+   * (mentor_student / owner_pet / trainer_trainee / creator_creation / worship).
+   */
+  isReversed?: boolean;
+  /**
+   * Focal character's display name. Interpolated into the paired
+   * asymmetric radio labels (e.g., "Marie mentors Pierre"). Falls back to
+   * "This character" when omitted.
+   */
+  focalCharacterName?: string;
+  /**
+   * Other character's display name. Interpolated into the paired
+   * asymmetric radio labels (e.g., "Marie mentors Pierre"). Falls back to
+   * "Other" when omitted.
+   */
+  otherCharacterName?: string;
+  onChange: (next: {
+    type: RelationshipType;
+    role: string | null;
+    isReversed: boolean;
+  }) => void;
   disabled?: boolean;
   className?: string;
 }
@@ -63,13 +79,92 @@ const ROLE_OPTIONS: Partial<Record<RelationshipType, readonly string[]>> = {
   collaboration: collaborationRoleEnum.options,
 };
 
+// ─── Asymmetric verb mapping ─────────────────────────────────────────────────
+
+/**
+ * UI-presentational verb forms for the five asymmetric types. Used to
+ * interpolate paired-radio labels ("Marie mentors Pierre" vs
+ * "Pierre mentors Marie"). Kept here rather than imported from the service
+ * because this is screen copy, not domain logic — the service's
+ * ASYMMETRIC_TYPES set is the authority on *which* types are asymmetric;
+ * the verb form is a presentation concern.
+ */
+const ASYMMETRIC_VERB: Partial<Record<RelationshipType, string>> = {
+  mentor_student: "mentors",
+  owner_pet: "owns",
+  trainer_trainee: "trains",
+  creator_creation: "created",
+  worship: "worships",
+};
+
+const isAsymmetric = (t: RelationshipType): boolean =>
+  ASYMMETRIC_VERB[t] != null;
+
 const humanize = (value: string): string => value.replace(/_/g, " ");
+
+// ─── Composite-value parser/encoder ──────────────────────────────────────────
+
+/**
+ * Asymmetric paired-radio values encode direction by suffix:
+ *   "mentor_student"          → forward (focal mentors other)
+ *   "mentor_student:reverse"  → reversed (other mentors focal)
+ *
+ * Non-asymmetric types use the plain enum string.
+ */
+const REVERSE_SUFFIX = ":reverse";
+
+function parseTypeValue(raw: string): {
+  type: RelationshipType;
+  isReversed: boolean;
+} {
+  if (raw.endsWith(REVERSE_SUFFIX)) {
+    return {
+      type: raw.slice(0, -REVERSE_SUFFIX.length) as RelationshipType,
+      isReversed: true,
+    };
+  }
+  return { type: raw as RelationshipType, isReversed: false };
+}
+
+function encodeTypeValue(t: RelationshipType, isReversed: boolean): string {
+  return isAsymmetric(t) && isReversed ? `${t}${REVERSE_SUFFIX}` : t;
+}
+
+// ─── Radio row generation ────────────────────────────────────────────────────
+
+interface RadioRow {
+  key: string;
+  value: string;
+  label: string;
+}
+
+function rowsForType(
+  t: RelationshipType,
+  focal: string,
+  other: string,
+): RadioRow[] {
+  if (isAsymmetric(t)) {
+    const verb = ASYMMETRIC_VERB[t]!;
+    return [
+      { key: `${t}-fwd`, value: t, label: `${focal} ${verb} ${other}` },
+      {
+        key: `${t}-rev`,
+        value: `${t}${REVERSE_SUFFIX}`,
+        label: `${other} ${verb} ${focal}`,
+      },
+    ];
+  }
+  return [{ key: t, value: t, label: humanize(t) }];
+}
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function RelationshipTypeSelector({
   type,
   role,
+  isReversed = false,
+  focalCharacterName,
+  otherCharacterName,
   onChange,
   disabled,
   className,
@@ -77,25 +172,36 @@ export function RelationshipTypeSelector({
   const roleOptions = ROLE_OPTIONS[type];
   const acceptsRole = typeAcceptsRole(type);
   // Unique per-instance prefix so multiple selectors on the same page don't
-  // collide on id/htmlFor pairs (each fieldset/radio + the role select trigger).
+  // collide on id/htmlFor pairs.
   const idPrefix = React.useId();
-  const roleSelectId = `${idPrefix}-role`;
+  const roleGroupLabelId = `${idPrefix}-role-label`;
+
+  const focal = focalCharacterName ?? "This character";
+  const other = otherCharacterName ?? "Other";
+
+  const typeRadioValue = encodeTypeValue(type, isReversed);
 
   return (
     <div className={cn("space-y-4", className)}>
       <RadioGroup
-        value={type}
+        value={typeRadioValue}
         onValueChange={(next) => {
-          const nextType = next as RelationshipType;
-          const nextRoleOptions = ROLE_OPTIONS[nextType];
+          const parsed = parseTypeValue(next);
+          // Carry role forward only when (a) the next type accepts a role
+          // *and* (b) the current role is valid for that type's enum.
+          const nextRoleOptions = ROLE_OPTIONS[parsed.type];
           const nextRole =
-            typeAcceptsRole(nextType) &&
+            typeAcceptsRole(parsed.type) &&
             role != null &&
             nextRoleOptions?.includes(role)
               ? role
               : null;
 
-          onChange({ type: nextType, role: nextRole });
+          onChange({
+            type: parsed.type,
+            role: nextRole,
+            isReversed: parsed.isReversed,
+          });
         }}
         disabled={disabled}
         className="gap-4"
@@ -109,48 +215,63 @@ export function RelationshipTypeSelector({
             <legend className="mb-1 text-xs font-medium uppercase tracking-wider text-foreground-muted">
               {family.legend}
             </legend>
-            {family.types.map((typeValue) => {
-              const itemId = `${idPrefix}-type-${typeValue}`;
-              return (
-                <div key={typeValue} className="flex items-center gap-2">
-                  <RadioGroupItem id={itemId} value={typeValue} />
-                  <Label
-                    htmlFor={itemId}
-                    className="font-normal capitalize text-foreground"
-                  >
-                    {humanize(typeValue)}
-                  </Label>
-                </div>
-              );
-            })}
+            {family.types
+              .flatMap((typeValue) => rowsForType(typeValue, focal, other))
+              .map((row) => {
+                const itemId = `${idPrefix}-type-${row.key}`;
+                return (
+                  <div key={row.key} className="flex items-center gap-2">
+                    <RadioGroupItem id={itemId} value={row.value} />
+                    <Label
+                      htmlFor={itemId}
+                      className="font-normal capitalize text-foreground"
+                    >
+                      {row.label}
+                    </Label>
+                  </div>
+                );
+              })}
           </fieldset>
         ))}
       </RadioGroup>
 
+      {/* Symmetric/asymmetric semantics helper text */}
+      <p className="text-xs text-foreground-muted">
+        {isAsymmetric(type)
+          ? "Direction matters — this relationship is stored from one perspective only."
+          : "A reverse entry will be created automatically."}
+      </p>
+
       {acceptsRole && roleOptions && (
-        <div
-          className="space-y-1.5"
-          data-testid="relationship-type-role-select"
-        >
-          <Label htmlFor={roleSelectId} className="text-sm">
-            Role
-          </Label>
-          <Select
-            value={role ?? ""}
-            onValueChange={(next) => onChange({ type, role: next })}
-            disabled={disabled}
+        <div className="space-y-2" data-testid="relationship-type-role-select">
+          <span
+            id={roleGroupLabelId}
+            className="block text-sm font-medium text-foreground"
           >
-            <SelectTrigger id={roleSelectId} aria-label="Role">
-              <SelectValue placeholder="Select a role" />
-            </SelectTrigger>
-            <SelectContent>
-              {roleOptions.map((roleValue) => (
-                <SelectItem key={roleValue} value={roleValue}>
-                  <span className="capitalize">{humanize(roleValue)}</span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            Role
+          </span>
+          <RadioGroup
+            value={role ?? ""}
+            onValueChange={(next) => onChange({ type, role: next, isReversed })}
+            disabled={disabled}
+            aria-labelledby={roleGroupLabelId}
+            className="grid grid-cols-2 gap-x-4 gap-y-2"
+          >
+            {roleOptions.map((roleValue) => {
+              const itemId = `${idPrefix}-role-${roleValue}`;
+              return (
+                <div key={roleValue} className="flex items-center gap-2">
+                  <RadioGroupItem id={itemId} value={roleValue} />
+                  <Label
+                    htmlFor={itemId}
+                    className="font-normal capitalize text-foreground"
+                  >
+                    {humanize(roleValue)}
+                  </Label>
+                </div>
+              );
+            })}
+          </RadioGroup>
         </div>
       )}
     </div>

--- a/packages/ui/src/components/relationship-type-selector.tsx
+++ b/packages/ui/src/components/relationship-type-selector.tsx
@@ -19,30 +19,7 @@ export type RelationshipType = z.infer<typeof relationshipTypeEnum>;
 export interface RelationshipTypeSelectorProps {
   type: RelationshipType;
   role?: string | null;
-  /**
-   * True when the relationship is stored from the OTHER character's
-   * perspective — i.e., the focal character is the object, not the subject.
-   * Only meaningful for the five asymmetric types
-   * (mentor_student / owner_pet / trainer_trainee / creator_creation / worship).
-   */
-  isReversed?: boolean;
-  /**
-   * Focal character's display name. Interpolated into the paired
-   * asymmetric radio labels (e.g., "Marie mentors Pierre"). Falls back to
-   * "This character" when omitted.
-   */
-  focalCharacterName?: string;
-  /**
-   * Other character's display name. Interpolated into the paired
-   * asymmetric radio labels (e.g., "Marie mentors Pierre"). Falls back to
-   * "Other" when omitted.
-   */
-  otherCharacterName?: string;
-  onChange: (next: {
-    type: RelationshipType;
-    role: string | null;
-    isReversed: boolean;
-  }) => void;
+  onChange: (next: { type: RelationshipType; role: string | null }) => void;
   disabled?: boolean;
   className?: string;
 }
@@ -79,92 +56,29 @@ const ROLE_OPTIONS: Partial<Record<RelationshipType, readonly string[]>> = {
   collaboration: collaborationRoleEnum.options,
 };
 
-// ─── Asymmetric verb mapping ─────────────────────────────────────────────────
+// ─── Asymmetric type set (UI helper-text branching only) ─────────────────────
+//
+// Mirrors the service's ASYMMETRIC_TYPES set. Kept here rather than imported
+// because the selector's only use for it is rendering helper-text copy — the
+// service is the authority on reciprocal-edge logic, the UI just needs to
+// know which message to show.
 
-/**
- * UI-presentational verb forms for the five asymmetric types. Used to
- * interpolate paired-radio labels ("Marie mentors Pierre" vs
- * "Pierre mentors Marie"). Kept here rather than imported from the service
- * because this is screen copy, not domain logic — the service's
- * ASYMMETRIC_TYPES set is the authority on *which* types are asymmetric;
- * the verb form is a presentation concern.
- */
-const ASYMMETRIC_VERB: Partial<Record<RelationshipType, string>> = {
-  mentor_student: "mentors",
-  owner_pet: "owns",
-  trainer_trainee: "trains",
-  creator_creation: "created",
-  worship: "worships",
-};
-
-const isAsymmetric = (t: RelationshipType): boolean =>
-  ASYMMETRIC_VERB[t] != null;
+const ASYMMETRIC_TYPES: ReadonlySet<RelationshipType> =
+  new Set<RelationshipType>([
+    "mentor_student",
+    "owner_pet",
+    "trainer_trainee",
+    "creator_creation",
+    "worship",
+  ]);
 
 const humanize = (value: string): string => value.replace(/_/g, " ");
-
-// ─── Composite-value parser/encoder ──────────────────────────────────────────
-
-/**
- * Asymmetric paired-radio values encode direction by suffix:
- *   "mentor_student"          → forward (focal mentors other)
- *   "mentor_student:reverse"  → reversed (other mentors focal)
- *
- * Non-asymmetric types use the plain enum string.
- */
-const REVERSE_SUFFIX = ":reverse";
-
-function parseTypeValue(raw: string): {
-  type: RelationshipType;
-  isReversed: boolean;
-} {
-  if (raw.endsWith(REVERSE_SUFFIX)) {
-    return {
-      type: raw.slice(0, -REVERSE_SUFFIX.length) as RelationshipType,
-      isReversed: true,
-    };
-  }
-  return { type: raw as RelationshipType, isReversed: false };
-}
-
-function encodeTypeValue(t: RelationshipType, isReversed: boolean): string {
-  return isAsymmetric(t) && isReversed ? `${t}${REVERSE_SUFFIX}` : t;
-}
-
-// ─── Radio row generation ────────────────────────────────────────────────────
-
-interface RadioRow {
-  key: string;
-  value: string;
-  label: string;
-}
-
-function rowsForType(
-  t: RelationshipType,
-  focal: string,
-  other: string,
-): RadioRow[] {
-  if (isAsymmetric(t)) {
-    const verb = ASYMMETRIC_VERB[t]!;
-    return [
-      { key: `${t}-fwd`, value: t, label: `${focal} ${verb} ${other}` },
-      {
-        key: `${t}-rev`,
-        value: `${t}${REVERSE_SUFFIX}`,
-        label: `${other} ${verb} ${focal}`,
-      },
-    ];
-  }
-  return [{ key: t, value: t, label: humanize(t) }];
-}
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function RelationshipTypeSelector({
   type,
   role,
-  isReversed = false,
-  focalCharacterName,
-  otherCharacterName,
   onChange,
   disabled,
   className,
@@ -173,32 +87,23 @@ export function RelationshipTypeSelector({
   // collide on id/htmlFor pairs.
   const idPrefix = React.useId();
 
-  const focal = focalCharacterName ?? "This character";
-  const other = otherCharacterName ?? "Other";
-
-  const typeRadioValue = encodeTypeValue(type, isReversed);
-
   return (
     <div className={cn("space-y-4", className)}>
       <RadioGroup
-        value={typeRadioValue}
+        value={type}
         onValueChange={(next) => {
-          const parsed = parseTypeValue(next);
+          const nextType = next as RelationshipType;
           // Carry role forward only when (a) the next type accepts a role
           // *and* (b) the current role is valid for that type's enum.
-          const nextRoleOptions = ROLE_OPTIONS[parsed.type];
+          const nextRoleOptions = ROLE_OPTIONS[nextType];
           const nextRole =
-            typeAcceptsRole(parsed.type) &&
+            typeAcceptsRole(nextType) &&
             role != null &&
             nextRoleOptions?.includes(role)
               ? role
               : null;
 
-          onChange({
-            type: parsed.type,
-            role: nextRole,
-            isReversed: parsed.isReversed,
-          });
+          onChange({ type: nextType, role: nextRole });
         }}
         disabled={disabled}
         className="gap-4"
@@ -214,20 +119,18 @@ export function RelationshipTypeSelector({
             </legend>
             {family.types.map((typeValue) => (
               <React.Fragment key={typeValue}>
-                {rowsForType(typeValue, focal, other).map((row) => {
-                  const itemId = `${idPrefix}-type-${row.key}`;
-                  return (
-                    <div key={row.key} className="flex items-center gap-2">
-                      <RadioGroupItem id={itemId} value={row.value} />
-                      <Label
-                        htmlFor={itemId}
-                        className="font-normal capitalize text-foreground"
-                      >
-                        {row.label}
-                      </Label>
-                    </div>
-                  );
-                })}
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem
+                    id={`${idPrefix}-type-${typeValue}`}
+                    value={typeValue}
+                  />
+                  <Label
+                    htmlFor={`${idPrefix}-type-${typeValue}`}
+                    className="font-normal capitalize text-foreground"
+                  >
+                    {humanize(typeValue)}
+                  </Label>
+                </div>
                 {/* Sub-role radios inline beneath the currently-selected
                     sub-roled type. Renders inside the same fieldset as the
                     parent type radio so the visual hierarchy matches the
@@ -241,7 +144,7 @@ export function RelationshipTypeSelector({
                       idPrefix={idPrefix}
                       disabled={disabled}
                       onChange={(nextRole) =>
-                        onChange({ type, role: nextRole, isReversed })
+                        onChange({ type, role: nextRole })
                       }
                     />
                   )}
@@ -253,8 +156,8 @@ export function RelationshipTypeSelector({
 
       {/* Symmetric/asymmetric semantics helper text */}
       <p className="text-xs text-foreground-muted">
-        {isAsymmetric(type)
-          ? "Direction matters — this relationship is stored from one perspective only."
+        {ASYMMETRIC_TYPES.has(type)
+          ? "No reverse entry is created — this relationship is stored as a single row."
           : "A reverse entry will be created automatically."}
       </p>
     </div>

--- a/packages/ui/src/components/relationships-editor.stories.tsx
+++ b/packages/ui/src/components/relationships-editor.stories.tsx
@@ -360,6 +360,12 @@ interface AddRelationshipFormState {
   otherCharacterId: string;
   type: RelationshipType;
   role: string | null;
+  /**
+   * Direction intent — only meaningful for the five asymmetric types.
+   * The selector emits this on each onChange; the consumer maps it to
+   * row ordering when persisting (character_id vs related_character_id).
+   */
+  isReversed: boolean;
   start: TemporalData | null;
   end: TemporalData | null;
   description: string;
@@ -369,6 +375,7 @@ const EMPTY_FORM: AddRelationshipFormState = {
   otherCharacterId: "",
   type: "friendship",
   role: null,
+  isReversed: false,
   start: null,
   end: null,
   description: "",
@@ -401,6 +408,12 @@ function AddRelationshipSheet({
   ) => setForm((prev) => ({ ...prev, [key]: value }));
 
   const canSave = form.otherCharacterId !== "" && form.type !== undefined;
+
+  // The selector needs the other character's display name to interpolate
+  // its paired asymmetric radio labels ("Marie mentors Pierre" etc.).
+  const otherCharacterName = AVAILABLE_CHARACTERS.find(
+    (c) => c.id === form.otherCharacterId,
+  )?.name;
 
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>
@@ -446,9 +459,16 @@ function AddRelationshipSheet({
             <RelationshipTypeSelector
               type={form.type}
               role={form.role}
+              isReversed={form.isReversed}
+              focalCharacterName="Marie Curie"
+              otherCharacterName={otherCharacterName}
               onChange={(next) => {
-                set("type", next.type);
-                set("role", next.role);
+                setForm((prev) => ({
+                  ...prev,
+                  type: next.type,
+                  role: next.role,
+                  isReversed: next.isReversed,
+                }));
               }}
             />
           </div>
@@ -701,6 +721,7 @@ export const AddSheetOpen: Story = {
           otherCharacterId: "",
           type: "family",
           role: "spouse",
+          isReversed: false,
           start: null,
           end: null,
           description: "",

--- a/packages/ui/src/components/relationships-editor.stories.tsx
+++ b/packages/ui/src/components/relationships-editor.stories.tsx
@@ -116,8 +116,10 @@ const familyFor = (type: string): FamilyKey => {
   if (type === "family") return "family";
   if (type === "professional" || type === "collaboration")
     return "professional";
-  if (type === "friendship") return "social";
-  if (type === "rivalry" || type === "enemy") return "antagonistic";
+  // Rivalry sits with Social / Personal per the wireframe — it's
+  // antagonistic in tone but still a social-standing relationship.
+  if (type === "friendship" || type === "rivalry") return "social";
+  if (type === "enemy") return "antagonistic";
   return "asymmetric";
 };
 

--- a/packages/ui/src/components/relationships-editor.stories.tsx
+++ b/packages/ui/src/components/relationships-editor.stories.tsx
@@ -360,12 +360,6 @@ interface AddRelationshipFormState {
   otherCharacterId: string;
   type: RelationshipType;
   role: string | null;
-  /**
-   * Direction intent — only meaningful for the five asymmetric types.
-   * The selector emits this on each onChange; the consumer maps it to
-   * row ordering when persisting (character_id vs related_character_id).
-   */
-  isReversed: boolean;
   start: TemporalData | null;
   end: TemporalData | null;
   description: string;
@@ -375,7 +369,6 @@ const EMPTY_FORM: AddRelationshipFormState = {
   otherCharacterId: "",
   type: "friendship",
   role: null,
-  isReversed: false,
   start: null,
   end: null,
   description: "",
@@ -408,12 +401,6 @@ function AddRelationshipSheet({
   ) => setForm((prev) => ({ ...prev, [key]: value }));
 
   const canSave = form.otherCharacterId !== "" && form.type !== undefined;
-
-  // The selector needs the other character's display name to interpolate
-  // its paired asymmetric radio labels ("Marie mentors Pierre" etc.).
-  const otherCharacterName = AVAILABLE_CHARACTERS.find(
-    (c) => c.id === form.otherCharacterId,
-  )?.name;
 
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>
@@ -459,16 +446,9 @@ function AddRelationshipSheet({
             <RelationshipTypeSelector
               type={form.type}
               role={form.role}
-              isReversed={form.isReversed}
-              focalCharacterName="Marie Curie"
-              otherCharacterName={otherCharacterName}
               onChange={(next) => {
-                setForm((prev) => ({
-                  ...prev,
-                  type: next.type,
-                  role: next.role,
-                  isReversed: next.isReversed,
-                }));
+                set("type", next.type);
+                set("role", next.role);
               }}
             />
           </div>
@@ -721,7 +701,6 @@ export const AddSheetOpen: Story = {
           otherCharacterId: "",
           type: "family",
           role: "spouse",
-          isReversed: false,
           start: null,
           end: null,
           description: "",


### PR DESCRIPTION
## Summary

Closes the design-fidelity gaps in `RelationshipTypeSelector` identified in the post-#162 review. The PR went through a few iterations — paired asymmetric direction radios were tried and reverted as adding visual weight without proportionate value. Final shape:

1. **Sub-role chooser as inline `RadioGroup`.** The family / professional / collaboration sub-role chooser is now a grid of inline radios rather than a `Select` dropdown, matching the wireframe annotation. Family's 16 options get a 2-column grid; intentional tradeoff for the wireframe's per-type-visibility goal.
2. **Sub-role group renders inline beneath the selected type.** When `family` is selected, the 16 family sub-role radios expand directly under the `family` radio inside the Family fieldset (not as a block at the bottom of the component). The Professional fieldset hosts both `professional` and `collaboration` and moves the sub-role group between them depending on which is selected.
3. **Symmetric/asymmetric semantics helper text.** Muted line below the type radios. Symmetric branch: "A reverse entry will be created automatically." Asymmetric branch: "No reverse entry is created — this relationship is stored as a single row."
4. **Rivalry moves under Social / Personal.** The wireframe groups `friendship` + `rivalry` under Social / Personal and reserves Antagonistic for `enemy` alone; the implementation aligns.
5. **Per-fieldset RadioGroup structure.** Each of the 5 fieldsets owns its own Radix `RadioGroup` (sharing `value` and `onValueChange`). The sub-role `RadioGroup` is now a *sibling* of the relevant fieldset's type `RadioGroup` — no nested `role="radiogroup"` semantics. Fixes the a11y concern from the Copilot review.

### Paired-radio direction was tried and reverted

An earlier iteration on this branch implemented paired asymmetric radios (e.g., "Marie mentors Pierre" / "Pierre mentors Marie") with `isReversed`, `focalCharacterName`, and `otherCharacterName` props. The implementation matched the wireframe spec but added 10 paired rows in the Asymmetric fieldset where the other fieldsets each had 1–2 radios. On review, the user and I agreed the visual weight wasn't earning its keep:

- Direction is already implicit in column position (`character_id` vs `related_character_id`) per the schema's design.
- The `description` field carries narrative direction when needed.
- The "focal character is the subject of the verb" convention handles the common case.
- The reverse direction is recorded by authoring from the other character's editor.

Reverted in commit `ad1af7d`. The wireframe doc (`docs/design/admin/02-wireframes/06-relationships-editor.md`) and `docs/design/admin/01-user-flows.md` Flow C have been updated to reflect the focal-is-subject convention.

## Test plan

- [x] `pnpm run check-types` — passes
- [x] `pnpm run lint` — zero warnings
- [x] `pnpm run build` — passes
- [x] `pnpm run test:coverage` — 14 tests pass on `relationship-type-selector`. Overall package coverage well above 80%.
- [ ] Storybook visual + a11y check:
  - `Components > Relationship Type Selector > Default` — friendship + symmetric helper text + no role group.
  - `Components > Relationship Type Selector > Family` — 16 family sub-role radios inline beneath the `family` radio in the Family fieldset; symmetric helper text.
  - `Components > Relationship Type Selector > Professional` — 9 professional sub-role radios inline beneath the `professional` radio in the Professional fieldset. Switching to collaboration slides the role group to appear beneath the `collaboration` radio (7 options).
  - Asymmetric fieldset reads as 5 single radios: `mentor student`, `owner pet`, `trainer trainee`, `creator creation`, `worship`.
  - DOM inspector confirms no `role="radiogroup"` element contains another `role="radiogroup"` element.
  - `Pages > Relationships Editor > AddSheetOpen` — sheet pre-fills `family` + `spouse` with the inline sub-role layout.

## Out of scope (worth follow-up issues)

- **Character-picker combobox refactor** in `AddRelationshipSheet` (wireframe annotation #8).
- **Schema-level `is_reverse` column or relationship-level `importance` field** — the schema's `DECISION NEEDED` comment from #32 invites this conversation. Out of scope here.

References the post-#162 review thread, the wireframe `02-wireframes/06-relationships-editor.md`, the user-flows reconciliation, and the Copilot review comments addressed in commit `<hash>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
