### PR TITLE
docs(admin): timeline & event management UI design (milestone 5)

### DIFF
--- a/docs/design/admin/00-screen-inventory.md
+++ b/docs/design/admin/00-screen-inventory.md
@@ -3,31 +3,81 @@
 Status: draft 1 — markdown wireframes phase
 Scope: characters + events CRUD, character relationships, the junctions that touch those entities
 
+> **Milestone 5 extension (Phase 4 — Timeline & Event management).** A second wireframe batch (screens 11–16) was added to cover the timeline, media, collaborator, and publish surfaces that were deliberately deferred in the original pass. See [Milestone 5 additions](#milestone-5-additions) below for the screen table, the resolved **fractal containment-vs-decomposition model**, and the upstream issues filed during the design.
+
 ## What's in scope
 
-| #   | Screen                         | Purpose                                                                                                                                               | Wireframe                                                                            |
-| --- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| 0   | App shell                      | Persistent chrome: sidebar nav, topbar (user menu, global search stub), content area, breadcrumb                                                      | [02-wireframes/00-app-shell.md](02-wireframes/00-app-shell.md)                       |
-| 1   | Sign in                        | Email + magic-link entry. Out-of-band concern but listed for completeness — minimal annotation only                                                   | [02-wireframes/01-sign-in.md](02-wireframes/01-sign-in.md)                           |
-| 2   | Dashboard                      | Entity counts (powered by `get_user_metrics` RPC) + recent activity + quick-create buttons                                                            | [02-wireframes/02-dashboard.md](02-wireframes/02-dashboard.md)                       |
-| 3   | Characters list                | Paginated table of the user's characters, filterable by `character_type` and significance, searchable by name/alias                                   | [02-wireframes/03-characters-list.md](02-wireframes/03-characters-list.md)           |
-| 4   | Character detail               | Read view: identity, biography, temporal scope (birth/death), aliases, profile media, event participation summary, relationship summary               | [02-wireframes/04-character-detail.md](02-wireframes/04-character-detail.md)         |
-| 5   | Character editor               | Create/edit form. Adapts visible fields by `character_type` (species/breed for animal, domain for divine, etc.)                                       | [02-wireframes/05-character-editor.md](02-wireframes/05-character-editor.md)         |
-| 6   | Character relationships editor | The hardest screen. Manages temporally-scoped many-to-many edges with 11 type values and directionality semantics. Three alternatives sketched        | [02-wireframes/06-relationships-editor.md](02-wireframes/06-relationships-editor.md) |
-| 7   | Events list                    | Paginated table sorted by `sort_order_years`, filterable by `event_type`, importance, timeline, era, character participant                            | [02-wireframes/07-events-list.md](02-wireframes/07-events-list.md)                   |
-| 8   | Event detail                   | Read view: title, temporal range, location, type, importance, parent/child events, participating characters, attached media, categories               | [02-wireframes/08-event-detail.md](02-wireframes/08-event-detail.md)                 |
-| 9   | Event editor                   | Create/edit form including the participant sub-editor (event_characters with role + significance), category multi-select, media attachments           | [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md)                 |
-| 10  | Temporal input control         | Reusable primitive used by character editor, event editor, and relationship editor. Adapts fields per era (CE/BCE/KYA/MYA/BYA) per system-design §7.4 | [02-wireframes/10-temporal-input.md](02-wireframes/10-temporal-input.md)             |
+| #   | Screen                         | Purpose                                                                                                                                                                       | Wireframe                                                                            |
+| --- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| 0   | App shell                      | Persistent chrome: sidebar nav, topbar (user menu, global search stub), content area, breadcrumb                                                                              | [02-wireframes/00-app-shell.md](02-wireframes/00-app-shell.md)                       |
+| 1   | Sign in                        | Email + magic-link entry. Out-of-band concern but listed for completeness — minimal annotation only                                                                           | [02-wireframes/01-sign-in.md](02-wireframes/01-sign-in.md)                           |
+| 2   | Dashboard                      | Entity counts (powered by `get_user_metrics` RPC) + recent activity + quick-create buttons                                                                                    | [02-wireframes/02-dashboard.md](02-wireframes/02-dashboard.md)                       |
+| 3   | Characters list                | Paginated table of the user's characters, filterable by `character_type` and significance, searchable by name/alias                                                           | [02-wireframes/03-characters-list.md](02-wireframes/03-characters-list.md)           |
+| 4   | Character detail               | Read view: identity, biography, temporal scope (birth/death), aliases, profile media, event participation summary, relationship summary                                       | [02-wireframes/04-character-detail.md](02-wireframes/04-character-detail.md)         |
+| 5   | Character editor               | Create/edit form. Adapts visible fields by `character_type` (species/breed for animal, domain for divine, etc.)                                                               | [02-wireframes/05-character-editor.md](02-wireframes/05-character-editor.md)         |
+| 6   | Character relationships editor | The hardest screen. Manages temporally-scoped many-to-many edges with 11 type values and directionality semantics. Three alternatives sketched                                | [02-wireframes/06-relationships-editor.md](02-wireframes/06-relationships-editor.md) |
+| 7   | Events list                    | Paginated table sorted by `sort_order_years`, filterable by `event_type`, importance, timeline, era, character participant                                                    | [02-wireframes/07-events-list.md](02-wireframes/07-events-list.md)                   |
+| 8   | Event detail                   | Read view: title, temporal range, location, type, importance, containing/sub-timelines (forward fractal), nearby events, participating characters, attached media, categories | [02-wireframes/08-event-detail.md](02-wireframes/08-event-detail.md)                 |
+| 9   | Event editor                   | Create/edit form including the participant sub-editor (event_characters with role + significance), category multi-select, media attachments                                   | [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md)                 |
+| 10  | Temporal input control         | Reusable primitive used by character editor, event editor, and relationship editor. Adapts fields per era (CE/BCE/KYA/MYA/BYA) per system-design §7.4                         | [02-wireframes/10-temporal-input.md](02-wireframes/10-temporal-input.md)             |
+
+## Milestone 5 additions
+
+Phase 4 (GitHub milestone 5, issues #42–#50) is the timeline & event management build. The **event** surfaces (list/detail/editor + temporal input, screens 7–10) were already specified in the original pass, so this batch adds the **timeline**, **media**, **collaborator**, and **publish** surfaces around them.
+
+| #   | Screen                   | Purpose                                                                                               | Issue | Wireframe                                                                    |
+| --- | ------------------------ | ----------------------------------------------------------------------------------------------------- | ----- | ---------------------------------------------------------------------------- |
+| 11  | Timelines list           | Paginated table, filter by visibility / type / publication, sort, search                              | #42   | [02-wireframes/11-timeline-list.md](02-wireframes/11-timeline-list.md)       |
+| 12  | Timeline editor          | Create/edit form: span (TemporalInput), type, visibility, biographical subject, publish toggle        | #43   | [02-wireframes/12-timeline-editor.md](02-wireframes/12-timeline-editor.md)   |
+| 13  | Timeline detail          | Header + publish; tabs: Events (link/unlink), Periods (read-only stub), Collaborators, Media          | #44   | [02-wireframes/13-timeline-detail.md](02-wireframes/13-timeline-detail.md)   |
+| 14  | Collaborators (timeline) | Add by username, role (`viewer/editor/admin`), remove, owner safeguards                               | #50   | [02-wireframes/14-collaborators.md](02-wireframes/14-collaborators.md)       |
+| 15  | Media management         | Cross-cutting: upload + external-URL attach dialog, list/grid, ordering, detach vs. delete            | #49   | [02-wireframes/15-media-management.md](02-wireframes/15-media-management.md) |
+| 16  | Publish / unpublish      | Cross-cutting pattern: badges, confirm dialogs, owner gating, list filters, visibility-vs-publication | #48   | [02-wireframes/16-publish-workflow.md](02-wireframes/16-publish-workflow.md) |
+
+### The fractal timeline model (resolved)
+
+The schema exposes several ways an event relates to a timeline, and they were previously undocumented and ambiguous (the event editor used `events.timeline_id` as "membership"; issue #44 built on the `timeline_events` junction; `parent_event_id` offered a second, backward nesting axis). This batch resolved them into a **forward, timeline-as-recursion-unit model** — three live mechanisms plus one retired:
+
+| Mechanism                             | Meaning                                                                                                                                                               | Axis          |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `events.timeline_id`                  | The event's **primary containing timeline**. RLS source of truth — **unchanged**.                                                                                     | containment   |
+| `timeline_events` junction            | **Additional** "also appears in" timelines (e.g. comparative).                                                                                                        | containment   |
+| `events.detail_timeline_id` (**new**) | The fractal **drill-down sub-timeline** an event expands into (zoom in).                                                                                              | decomposition |
+| ~~`parent_event_id`~~ (**retired**)   | Was event-to-event nesting; **deprecated** ([#180](https://github.com/shaes-farm/time-traveler/issues/180)) — decomposition is forward-only via `detail_timeline_id`. | —             |
+
+This preserves the committed event RLS (`read_events` / `update_events` derive collaborator access from `events.timeline_id`) and the `idx_events_timeline_sort` index, while making "an event opens into a whole sub-timeline" a first-class relationship. **Nesting is forward-only:** the hierarchy is `timeline → events → (event expands into) sub-timeline → events`, recursing on the timeline. Event-to-event nesting (`parent_event_id`) is retired ([#180](https://github.com/shaes-farm/time-traveler/issues/180)) — it was a redundant backward reflection of the same hierarchy, permitted cross-timeline integrity holes, and fought the cosmic-scale fetch shape. The model is wired through the event editor ([09](02-wireframes/09-event-editor.md) annotations #5, #15), event detail ([08](02-wireframes/08-event-detail.md) annotations #6, #13), events list ([07](02-wireframes/07-events-list.md) annotations #3, #10), and timeline detail ([13](02-wireframes/13-timeline-detail.md) annotations #3, #5–#8).
+
+### Upstream issues filed during this batch
+
+Per the CLAUDE.md "When you find a spec or upstream bug" rule:
+
+- **[#177](https://github.com/shaes-farm/time-traveler/issues/177)** — add `events.detail_timeline_id` (the new fractal drill-down column). The Expands-into / drill-down affordances across screens 8, 9, and 13 are **blocked** on this migration. _(Confirmed missing against the full migration history 00001–00015.)_
+- **[#179](https://github.com/shaes-farm/time-traveler/issues/179)** — `media.storage_path` is `NOT NULL` with no upload/external discriminator, which blocks #49's external-URL embeds. Recommended fix (nullable `storage_path` + a `source` column) documented in [15](02-wireframes/15-media-management.md) schema-gap callout.
+- **[#180](https://github.com/shaes-farm/time-traveler/issues/180)** — deprecate `events.parent_event_id` in favor of the forward `detail_timeline_id` model. No data migration (nothing populates it); deprecate the Zod field + `getChildEvents`/`setEventParent` service methods, tombstone the column, drop later. Gated behind #177.
+- **[#178](https://github.com/shaes-farm/time-traveler/issues/178) — closed invalid.** Filed in error off a stale read of the initial migrations; `timeline_events.sort_order` **already exists** (migration `00012`, issue #122). Issue #44's "sort_order support" / "deterministic order" wording is therefore correct.
+
+### M5 design decisions (resolved)
+
+- **Event ↔ timeline membership** — forward fractal model above; dedicated `detail_timeline_id` for drill-down (avoids overloading `timeline_id`, preserves RLS).
+- **Fractal nesting is forward-only** — `detail_timeline_id` → sub-timeline is the sole decomposition mechanism; `parent_event_id` retired ([#180](https://github.com/shaes-farm/time-traveler/issues/180)). Chosen over a dual-axis model because a single recursion unit (the timeline) gives uniform navigation, eliminates cross-timeline parent-link integrity holes, and fits per-level bounded fetch. Ceremony is held down by the "Expands into → ✚ create sub-timeline with inherited defaults" shortcut; the timelines list defaults to top-level (root) timelines so sub-timelines don't clutter it.
+- **Timeline event ordering** — editorial `timeline_events.sort_order` (exists since migration `00012`) with a chronological (`events.sort_order_start`) fallback when unset. Drag-to-reorder supported; default-`0` timelines read chronologically.
+- **Many-to-many membership kept** — `events.timeline_id` is the event's home timeline (RLS root); `timeline_events` adds appearances in other (e.g. comparative) timelines. Confirmed intentional in the service layer + PRD comparative view.
+- **Periods tab on timeline detail** — read-only stub now; full period linking arrives in Phase 6.
+- **Visibility vs. publication** — kept strictly orthogonal across all surfaces; never merged into one control. See [16](02-wireframes/16-publish-workflow.md).
+- **Collaborator lookup** — by `profiles.username` (no client-queryable email); email-invite delivery is a non-goal this pass.
+- **Media scope** — hybrid upload + external embed with association/ordering; no standalone library browser.
 
 ## What's deliberately not in scope this pass
 
-- Timelines, periods, stories CRUD — adjacent but excluded to keep this pass focused
-- Media library — referenced from character/event editors but the library UX itself is deferred
-- Categories management — same reason
+> Three items below moved **into scope** in the [Milestone 5 additions](#milestone-5-additions) batch (screens 11–16): timelines CRUD, media management, and collaborator management. They remain listed here, struck, for historical continuity.
+
+- ~~Timelines~~, periods, stories CRUD — timelines now covered (screens 11–13); periods + stories still excluded
+- ~~Media library~~ — media management now covered as a cross-cutting surface (screen 15); a standalone reusable library browser is still deferred
+- Categories management — still deferred
 - Bulk import / export — these are Edge Function flows that need their own design pass
 - Admin moderation queue (`content_reports`) — admin-role-only surface, separate audience
 - Notifications inbox — needs a separate IA pass
-- Collaborator management — needs a separate IA pass (RLS surface, invite flow)
+- ~~Collaborator management~~ — now covered for timelines (screen 14); email-invite delivery + org/team model still deferred
 - Public reader / explorer views — different audience and aesthetic genre entirely
 
 ## Entities and tables this covers
@@ -59,7 +109,7 @@ Workflow polish — the final batch in the design review. Closes out the 29 in-s
 
 - **Publish vs. draft ratio on dashboard** — not surfaced. The Drafts panel covers the actionable "what needs finishing" question; a ratio adds judgment without action. See [02-wireframes/02-dashboard.md](02-wireframes/02-dashboard.md) Open Questions.
 - **Activity-feed entries for deleted entities** — omitted. Without soft-delete (`deleted_at` columns; not in the current schema), a tombstone has no nav target. Soft-delete is a separate architectural question, out of scope for this design pass. See [02-wireframes/02-dashboard.md](02-wireframes/02-dashboard.md) Open Questions.
-- **"Save and add another" field persistence** — curated set persists between consecutive creates. Character editor: `character_type`, `significance`, `cultural_context`. Event editor: `event_type`, `timeline_id`, `parent_event_id`, `categories`. Inline note after save reports what was cleared vs. persisted. See [02-wireframes/05-character-editor.md](02-wireframes/05-character-editor.md) annotation #9 and [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md) annotation #13.
+- **"Save and add another" field persistence** — curated set persists between consecutive creates. Character editor: `character_type`, `significance`, `cultural_context`. Event editor: `event_type`, `timeline_id`, `parent_event_id`, `categories`. _(`parent_event_id` later dropped from the set when the field was removed — [#180](https://github.com/shaes-farm/time-traveler/issues/180); current set is `event_type`, `timeline_id`, `categories`.)_ Inline note after save reports what was cleared vs. persisted. See [02-wireframes/05-character-editor.md](02-wireframes/05-character-editor.md) annotation #9 and [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md) annotation #13.
 - **Duplicate event affordance** — deferred until users request it. The persistence-based "Save and add another" handles the bulk-create case. See [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md) annotation #13.
 - **Temporal-scope inline timeline on character detail** — formally deferred to fidelity-2 (Tier 4). Needs visual design language for the timeline visual to land first. See [02-wireframes/04-character-detail.md](02-wireframes/04-character-detail.md) Open Questions.
 
@@ -80,7 +130,7 @@ List-view refinements. All single-screen decisions; lower stakes than Batches 1�
 
 - **Character per-row primary media thumbnail** — hover-card on the name row; no dedicated column. See [02-wireframes/03-characters-list.md](02-wireframes/03-characters-list.md) annotation #10.
 - **`has_media` filter on characters list** — kept. Real recurring use case for content authors auditing portrait coverage.
-- **Parent-event filter (Show)** — 3-state radio in events-list filter rail: `All` / `Root only` / `Nested only`. See [02-wireframes/07-events-list.md](02-wireframes/07-events-list.md) annotation #10.
+- **Parent-event filter (Show)** — 3-state radio in events-list filter rail: `All` / `Root only` / `Nested only`. _(Superseded by the forward fractal model — replaced with an `All`/`Expandable`/`Leaf` drill-down filter, [#180](https://github.com/shaes-farm/time-traveler/issues/180).)_ See [02-wireframes/07-events-list.md](02-wireframes/07-events-list.md) annotation #10.
 - **Categories on events list** — stay on row line 3 (rendered only when present); not promoted to a column. The events table is the densest in the admin; a column claimed by a frequently-empty field isn't a good trade. See [02-wireframes/07-events-list.md](02-wireframes/07-events-list.md) annotation #11.
 - **Filter-by-participating-character on events list** — deferred to character-detail Events tab; not added to events-list filter rail.
 - **Drafts panel vs. filter on Recent activity** — kept as a separate panel. Distinct intents: "what needs finishing" vs. "where did I leave off."
@@ -92,7 +142,7 @@ Editor-level decisions resolved during the second design-review batch. These mos
 - **Reciprocal sync depth** — dates and type sync between paired rows; description stays per-side so each character's card can carry perspective-specific text. See [02-wireframes/06-relationships-editor.md](02-wireframes/06-relationships-editor.md).
 - **Logical contradiction detection** — warn but never block on save when a contradictory relationship is detected (mutual parent_of, mutual mentor_of, etc.). Authors can override. See [02-wireframes/06-relationships-editor.md](02-wireframes/06-relationships-editor.md).
 - **`relationship_role` sub-role design** ([#119](https://github.com/shaes-farm/time-traveler/issues/119)) — Option A chosen: nullable `relationship_role` column with type-conditional CHECK. Sub-roles apply to `family`, `professional`, and `collaboration`; the other 8 types must have NULL role. Concrete sub-role taxonomy documented in the relationships-editor wireframe and in #119.
-- **Parent event picker** — searchable combobox with the parent's temporal range shown on selection. A `[ browse hierarchy ]` side-sheet tree view is documented as a future affordance but not built this pass. See [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md) annotation #5.
+- **Parent event picker** — searchable combobox with the parent's temporal range shown on selection. A `[ browse hierarchy ]` side-sheet tree view is documented as a future affordance but not built this pass. _(Superseded — the parent-event field was removed entirely under the forward fractal model; decomposition is the "Expands into" sub-timeline field, [#180](https://github.com/shaes-farm/time-traveler/issues/180).)_ See [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md) annotation #5.
 - **Primary-media single-primary enforcement** — DB-enforced via partial unique index. Tracked in [#125](https://github.com/shaes-farm/time-traveler/issues/125). Admin UI continues to do atomic swap as a UX flow; the DB index guarantees correctness under races. See [02-wireframes/04-character-detail.md](02-wireframes/04-character-detail.md) Open Questions.
 - **Inline-participant editing scalability** — always inline, section scrolls internally when long. No threshold-switch UX. Future "manage in side sheet" affordance documented for 20+-participant events but not built. See [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md) annotation #7.
 
@@ -101,7 +151,7 @@ Editor-level decisions resolved during the second design-review batch. These mos
 > **All initial inventory-level questions resolved:**
 >
 > 1. Relationship reciprocity — resolved per-screen in [02-wireframes/06-relationships-editor.md](02-wireframes/06-relationships-editor.md) (Alternative B card-stream with type-grouping). Further refined in Batch 2: reciprocal-edge creation became implicit in the type/role choice via the [#119](https://github.com/shaes-farm/time-traveler/issues/119) sub-role taxonomy.
-> 2. Parent event picker — resolved in Batch 2: searchable combobox with documented future hierarchy-browse side-sheet affordance. See [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md) annotation #5.
+> 2. Parent event picker — resolved in Batch 2: searchable combobox with documented future hierarchy-browse side-sheet affordance. _(Later superseded — the parent-event field was removed under the forward fractal model, [#180](https://github.com/shaes-farm/time-traveler/issues/180).)_ See [02-wireframes/09-event-editor.md](02-wireframes/09-event-editor.md) annotation #5.
 
 ## Reading order
 

--- a/docs/design/admin/01-user-flows.md
+++ b/docs/design/admin/01-user-flows.md
@@ -17,23 +17,23 @@ Persona: Biographer creating "Marie Curie" before adding events.
 
 Edge cases: slug collision (handled by `resolveCollision` utility — already shipped per recent commits); image upload failure (event saves, media does not — user can retry attachment from detail view).
 
-## Flow B — Create a fractal event with character participants
+## Flow B — Create an event with character participants
 
-Persona: Historian adding "Discovery of polonium (1898)" as a child of "Curies' radium research (1895–1898)".
+Persona: Historian adding "Discovery of polonium (1898)" to the Curie biography timeline. _(Fractal decomposition — making an event open into a sub-timeline — is its own flow; see Flow G. Under the forward model, an event is not created "as a child of" another event.)_
 
 1. From **Events list**, click **New event**.
 2. **Event editor** opens. User enters title "Discovery of polonium".
-3. User opens **Parent event** picker. Searches "radium", picks "Curies' radium research". Picker displays the parent's temporal range so user can sanity-check that the child date fits.
+3. User sets **Primary timeline** = "Curie biography" (the event's home; this is what RLS and the default timeline list key off). Optionally adds an **Also appears in** timeline (e.g. "Women in science") via the junction.
 4. User picks `event_type = discovery`, `importance = 8`.
 5. User enters **Start temporal**: 1898 CE, precision `exact`. Leaves end temporal empty (point event).
 6. User opens **Participants** sub-editor. Searches for "Curie", adds "Marie Curie" (role: `protagonist`, significance: `primary`). Searches "Pierre", adds "Pierre Curie" (role: `protagonist`, significance: `primary`).
 7. User multi-selects categories: "Physics", "Discovery".
-8. User saves. The service-layer `createEventWithRelations` (per system-design §5.3) issues the event insert plus three junction inserts in parallel.
+8. User saves. The service-layer `createEventWithRelations` (per system-design §5.3) issues the event insert plus the junction inserts in parallel.
 
 Edge cases:
 
-- **Cycle prevention.** If user picks a parent that would create a cycle, the editor blocks save with an inline error (cycle detection is service-layer per system-design §3.4 note on self-referential FK cycles).
-- **Temporal mismatch.** If the child's date falls outside the parent's range, show a soft warning but allow save — sometimes the parent has fuzzy bounds.
+- **No parent-event step.** Event-to-event nesting is retired ([#180](https://github.com/shaes-farm/time-traveler/issues/180)); there is no parent picker and no parent-range/cycle check at create time. To place this event inside a larger structure, either it shares a timeline with related events (chronological neighbors) or a larger event **expands into** a sub-timeline that contains it (Flow G).
+- **Sub-timeline span mismatch.** Only relevant when this event is later added to a sub-timeline whose declared span doesn't cover its date — a soft, non-blocking warning (declared span is editorial). See Flow G.
 - **Junction insert partial failure.** Per system-design §5.3, these multi-step ops are not transactional. If a junction insert fails, the event exists without that relation; toast offers a retry.
 
 ## Flow C — Build a character relationship across two characters with temporal scope
@@ -81,9 +81,71 @@ Persona: Investigator deduplicating characters; "John Smith (duplicate)" needs t
 
 Edge case: if the character is referenced by `timelines.subject_character_id` (biographical timeline) or `stories.perspective_character_id`, those FKs are `ON DELETE SET NULL` per the schema. The confirm dialog should call this out separately: "Will also clear the subject character on 1 biographical timeline."
 
+## Milestone 5 flows — Timelines, fractal zoom, collaboration, publishing
+
+Four flows added for the Phase 4 timeline & event build (screens 11–16). They depend on the **fractal model** resolved in this batch — read this primer first.
+
+### The fractal model in one paragraph
+
+A timeline **contains** events; an event can **decompose into** a timeline. These are different axes, and nesting is **forward-only** — the timeline is the recursion unit ([#180](https://github.com/shaes-farm/time-traveler/issues/180)). Containment: an event's primary home is `events.timeline_id`, and it can additionally appear in other timelines via the `timeline_events` junction. Decomposition (the fractal zoom): an event expands into its own sub-timeline via `events.detail_timeline_id` (new column, [#177](https://github.com/shaes-farm/time-traveler/issues/177)). There is **no** event-to-event nesting — `parent_event_id` is retired; you don't make one event a child of another, you make an event open into a sub-timeline that holds the finer events. Concretely: the "Cosmic history" timeline _contains_ the event "Earth forms"; that event _expands into_ a separate "Evolution of life on Earth" timeline, which contains its own events ("first cells", "Cambrian explosion"), one of which might itself expand further. Zooming in follows `detail_timeline_id`; zooming out follows the inverse lookup shown on [timeline detail](02-wireframes/13-timeline-detail.md).
+
+## Flow F — Create a timeline and populate it with events
+
+Persona: Biographer starting a "Curie scientific biography" timeline before arranging events into it.
+
+1. From the **Dashboard** or **Timelines list**, click **New timeline**.
+2. **Timeline editor** opens. User enters title "Curie scientific biography". Slug auto-generates.
+3. User picks `timeline_type = biographical`; the form reveals the required **Subject character** picker. User selects "Marie Curie".
+4. User sets **Visibility = private** (the default) and leaves **Published = Draft** — publication happens later, from the detail page, after the events are arranged.
+5. User opens **Start span** (TemporalInput): 1867 CE; **End span**: 1934 CE. Sets **Scale** = "a single lifetime".
+6. User clicks **Save** (`useCreateTimeline`). Redirects to **Timeline detail**.
+7. On the **Events tab**, the user clicks **+ Link event**, searches "polonium", and links "Discovery of polonium" — it appears as `linked`. Repeats for the other Curie events.
+8. For events that don't exist yet, the user uses the **+ Link event ▾ → Create new event in this timeline** split-button, which opens the [event editor](02-wireframes/09-event-editor.md) with this timeline pre-filled as the **primary** timeline (so the new event lands as `home`).
+
+Edge cases: biographical type with no subject chosen blocks save; events outside the declared span surface a non-blocking advisory on the detail header (not an error — declared span is editorial).
+
+## Flow G — Drill an event down into a sub-timeline (fractal zoom)
+
+Persona: Cosmologist building "Cosmic history" who wants the "Earth forms" event to open into its own detailed timeline.
+
+1. From the **Cosmic history** timeline detail → **Events tab**, the user opens the "Earth forms" **event detail**.
+2. In the event's **Timelines** block, under **Expands into**, the user picks (or, via the `↗` shortcut, creates) the sub-timeline "Evolution of life on Earth". This sets `events.detail_timeline_id`.
+3. A `⤵` marker now appears on the "Earth forms" row in the Cosmic history Events tab and on its event detail. Clicking `⤵` navigates **into** the sub-timeline (zoom in).
+4. On the **"Evolution of life on Earth"** timeline detail, the header shows the inverse: `ⓘ Details the event: ↗ "Earth forms" (in Cosmic history)` — the zoom-out path back up the hierarchy.
+5. The user populates the sub-timeline with its own events ("first cells", "Cambrian explosion"), any of which can itself expand further.
+
+Edge cases:
+
+- **Fractal cycle.** The picker (and a service-layer check) prevents an event from expanding into a timeline that transitively contains the event itself. This is the cycle guard that formerly lived on the parent-event picker, now applied to `detail_timeline_id`.
+- **Blocked on [#177](https://github.com/shaes-farm/time-traveler/issues/177).** The Expands-into field is hidden until the `detail_timeline_id` column ships. There is no `parent_event_id` fallback — event-to-event nesting is retired ([#180](https://github.com/shaes-farm/time-traveler/issues/180)); until #177 lands, decomposition simply isn't available and events are organized by timeline membership alone.
+
+## Flow H — Share a timeline with a collaborator
+
+Persona: Owner inviting a co-author to edit a timeline.
+
+1. From **Timeline detail** → **Collaborators tab**, the owner clicks **+ Add collaborator**.
+2. The owner types `@irenejc`. The dialog resolves it against `profiles` and confirms "✓ Irène Joliot-Curie". (Lookup is by **username** — there's no client-queryable email; see [14-collaborators.md](02-wireframes/14-collaborators.md) annotation #2.)
+3. The owner picks **role = editor** (read + edit events; cannot delete or publish) and confirms. `addCollaborator` writes the `timeline_collaborators` row; Irène gains access immediately under RLS.
+4. To change a role, the owner uses the inline `role ▾` select on the collaborator's row (`updateCollaboratorRole`, applied immediately). To remove, `[×]` with a confirm (`removeCollaborator`).
+5. For the timeline to be reachable by collaborators in listings, its **visibility** should be `shared` (set in the editor) — distinct from publication.
+
+Edge cases: adding the owner or an existing collaborator is blocked at validation; the owner row is rendered locked and can never be removed; there is no email-invite delivery this pass (collaborators are added directly).
+
+## Flow I — Publish a timeline and its events
+
+Persona: Author taking a finished biography live.
+
+1. From **Timeline detail**, the owner clicks **Publish** in the header. A **confirm dialog** explains the consequence; on confirm, `published = true` and `published_at = now()`.
+2. The header badge flips to `✓ Published`; the timelines-list row shows the same badge.
+3. Publication does **not** cascade to the timeline's events — each event publishes independently. The Events tab surfaces a non-blocking note: "3 events in this timeline are still drafts."
+4. The owner opens each draft event and publishes it from the event-detail header (same confirm pattern; `publishEvent` lands in PR #174).
+5. **Visibility is unchanged by publishing.** A `private` timeline that is published is "done" but still owner-only; making it reachable to others is the separate `visibility` axis. See [16-publish-workflow.md](02-wireframes/16-publish-workflow.md).
+
+Edge cases: a collaborator-editor sees no Publish control (publishing is owner-only); unpublishing clears `published_at` to NULL and narrows RLS read access on the next request.
+
 ## What these flows do not cover
 
 - Bulk operations (multi-select delete, bulk publish, bulk export). Reserved for a later pass.
-- Cross-user collaboration. The relationships editor assumes single-user authoring; collaborator edits per timeline are a separate flow.
+- ~~Cross-user collaboration~~ — timeline collaboration is now covered (Flow H). The character relationships editor still assumes single-user authoring; collaborative _editing of the same record_ in real time is separate.
 - Realtime co-presence. Supabase Realtime is in the stack but no co-presence UX is designed yet.
 - Search across all entity types. Global search is in the topbar wireframe but its result view isn't designed.

--- a/docs/design/admin/02-wireframes/07-events-list.md
+++ b/docs/design/admin/02-wireframes/07-events-list.md
@@ -4,7 +4,7 @@
 
 ## Data shown
 
-- Per event: title, temporal range (start–end with era), event_type, importance, participant count, category badges (truncated), parent event indicator, timeline membership, published state
+- Per event: title, temporal range (start–end with era), event_type, importance, participant count, category badges (truncated), drill-down indicator (expands into a sub-timeline), timeline membership, published state
 - Total count + filtered count
 - Active filter state
 - Active sort order
@@ -12,7 +12,7 @@
 ## Primary actions
 
 - Search (by title, summary, detail — backed by `idx_events_search` GIN)
-- Filter by `event_type`, importance range, era, timeline, parent vs. root, has-participants, has-media, published
+- Filter by `event_type`, importance range, era, timeline, drill-down (expands into a sub-timeline vs. leaf), has-participants, has-media, published
 - Sort by `sort_order_years` (default), title, importance, updated_at
 - Create new event
 - Click row → event detail
@@ -71,14 +71,14 @@
 
 1. **Era filter is the most-used filter for this entity.** Pinned to the top of the filter rail.
 2. **Importance filter is a range slider** (1–10), not a multi-select. The schema constrains importance to 1–10; users care about "show me importance 7+", not individual values.
-3. **Nesting indicator in the first column.** `⌒` for root events, `↳` for child events. Indentation of one level only — deeper nesting would require tree expansion which is a different UX. Click into the event for full lineage.
+3. **Drill-down indicator in the first column.** `⤵` marks an event that **expands into a sub-timeline** (`detail_timeline_id` is set); blank otherwise. This is the only fractal signal a flat cross-timeline list can carry under the forward model ([#180](https://github.com/shaes-farm/time-traveler/issues/180)) — there is no root/child event nesting anymore. Clicking `⤵` opens that sub-timeline. _(The ASCII mock above still shows the legacy `⌒`/`↳` root/child glyphs; read the column as the `⤵` drill-down marker. **Blocked on [#177](https://github.com/shaes-farm/time-traveler/issues/177)** until `detail_timeline_id` lands.)_
 4. **Date column shows uncertainty inline.** "66 MYA ±1M" makes the precision visible without a dedicated column.
 5. **Importance shows as a 1–10 number, right-aligned, tabular figures.** Sequential color scale on a single hue (per [03-aesthetic-notes.md](../03-aesthetic-notes.md)). 10 is darkest; 1 is faintest.
 6. **Three-line row layout.** Line 1: title. Line 2: timeline + type + participant count. Line 3 (only when present): category badges. Saves horizontal space at the cost of vertical.
 7. **Sort default is `sort_order_years` ascending.** Chronological is the natural order for events. The cursor pagination strategy from system-design §8.2 applies here when result sets get large.
 8. **No "all eras" parent toggle.** The era filter is checkbox-multi-select. If nothing is checked, all eras are shown. Avoids the "you forgot to filter and got 13 billion years of events" footgun.
 9. **Has-chars filter** is the most common refinement when authors are auditing event participation coverage.
-10. **Show filter — fractal scope** (Batch 3 decision Q3). A 3-state radio in the filter rail between Era and Type controls visibility: `All` (default) / `Root only` (`parent_event_id IS NULL`) / `Nested only` (`parent_event_id IS NOT NULL`). Authors thinking about the fractal hierarchy use this for "show me only top-level events" or "show me only sub-events." The row nesting indicator (annotation #3) remains visible regardless of filter state. The ASCII mockup above predates this decision and does not show the Show group — it lives between Era and Type in the rail.
+10. **Drill-down filter — fractal scope** (Batch 3 decision Q3, reframed for the forward model in [#180](https://github.com/shaes-farm/time-traveler/issues/180)). A 3-state radio in the filter rail between Era and Type: `All` (default) / `Expandable` (`detail_timeline_id IS NOT NULL` — events that open into a sub-timeline) / `Leaf` (`detail_timeline_id IS NULL`). This replaces the former Root-only/Nested-only (`parent_event_id`) control — under forward-only nesting, "is this a top-level event?" is no longer meaningful at the event level (nesting lives on timelines), but "does this event drill down?" is. The `⤵` row indicator (annotation #3) stays visible regardless of filter state. **Blocked on [#177](https://github.com/shaes-farm/time-traveler/issues/177).**
 11. **Categories stay on row line 3, not promoted to a column** (Batch 3 decision Q4). Line 3 only renders when categories exist; rows without categories remain 2 lines tall. The events table is the densest in the admin and cannot afford a column claimed by a frequently-empty field.
 12. **Status column** shows three states (per PRD §7.11.5; #127 reconciliation): `✓ Published`, `─ draft` for Draft, and `⇄ shared` for events reachable to the user via `timeline_collaborators` (the event belongs to another user's timeline but is visible because the current user collaborates on that timeline). The Shared state is a permission-context marker. Specific colors (green / gray / blue per PRD §7.11.5) and icons applied at fidelity-2 visual design.
 
@@ -97,6 +97,6 @@
 
 > **Resolved (Batch 3):**
 >
-> - Parent-event filtering as a user control — added as a 3-state Show radio (`All` / `Root only` / `Nested only`) in the filter rail between Era and Type. See annotation #10.
+> - ~~Parent-event filtering (Root/Nested)~~ — **superseded by [#180](https://github.com/shaes-farm/time-traveler/issues/180).** Replaced by the Drill-down filter (`All` / `Expandable` / `Leaf`) keyed on `detail_timeline_id` under the forward fractal model. See annotation #10.
 > - Categories column vs. row line 3 — line 3 stays. See annotation #11.
 > - Filter-by-participating-character — deferred to the character-detail Events tab; not added to the events-list filter rail. If filter state is URL-encoded for the rail filters that exist, a `?character=<id>` query parameter could carry character filtering as a low-cost side-effect, documented as future polish.

--- a/docs/design/admin/02-wireframes/08-event-detail.md
+++ b/docs/design/admin/02-wireframes/08-event-detail.md
@@ -9,8 +9,8 @@
 - Temporal: temporal_data, end_temporal_data (range), computed durations
 - Location: location string, spatial_data (lat/lng — defer visualization)
 - Importance (1–10)
-- Fractal: parent_event_id (breadcrumb), child events (count + list)
-- Timeline membership (timeline_id + timeline title)
+- Timelines (the fractal axis): containing timelines — home (`timeline_id`) + guest appearances (`timeline_events`); the drill-down sub-timeline this event **expands into** (`detail_timeline_id` — see [#177](https://github.com/shaes-farm/time-traveler/issues/177)); and chronological neighbors within the home timeline
+- ~~Fractal: parent_event_id (breadcrumb), child events~~ — **removed.** Event-to-event nesting is retired; the fractal hierarchy is expressed forward via `detail_timeline_id` → sub-timeline → events (see [#180](https://github.com/shaes-farm/time-traveler/issues/180))
 - Participating characters (`event_characters` joined)
 - Categories (`event_categories` joined)
 - Attached media (`event_media` joined, ordered by `sort_order`)
@@ -23,13 +23,13 @@
 - Delete (danger zone)
 - Add participant
 - Attach media
-- Navigate to parent / child / timeline / participating character
+- Navigate to a containing timeline / the sub-timeline it expands into / a nearby event / participating character
 
 ## Layout
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│  Events ▸ Curies' radium research ▸ Discovery of polonium                    │
+│  Curie biography ▸ Discovery of polonium                                     │
 │                                                          [Edit] [Publish ✓]  │
 │                                                                              │
 │  Discovery of polonium                                                       │
@@ -46,22 +46,19 @@
 │  │  ───────────────────────────────    │  Paris, France                   │  │
 │  │  [ full long-form detail … ]        │  48.86° N · 2.35° E              │  │
 │  │                                     │                                  │  │
-│  │                                     │  Lineage                         │  │
+│  │                                     │  Timelines                       │  │
 │  │                                     │  ───────────────────────────     │  │
-│  │                                     │  Parent                          │  │
-│  │                                     │  ⌒ Curies' radium research       │  │
-│  │                                     │     1895–1898 CE                 │  │
+│  │                                     │  Contained in                    │  │
+│  │                                     │  • Curie biography      (home)   │  │
+│  │                                     │  • Women in science     (guest)  │  │
 │  │                                     │                                  │  │
-│  │                                     │  Sibling events (2)              │  │
-│  │                                     │  ↳ Discovery of radium · 1898    │  │
-│  │                                     │  ↳ Radium isolation · 1902       │  │
+│  │                                     │  Expands into ⤵                  │  │
+│  │                                     │  Marie's lab years               │  │
+│  │                                     │    sub-timeline · 6 events       │  │
 │  │                                     │                                  │  │
-│  │                                     │  Child events                    │  │
-│  │                                     │  — none —                        │  │
-│  │                                     │                                  │  │
-│  │                                     │  Timeline                        │  │
-│  │                                     │  ───────────────────────────     │  │
-│  │                                     │  Curie scientific biography      │  │
+│  │                                     │  Nearby in Curie biography       │  │
+│  │                                     │  ↞ Marriage to Pierre · 1895     │  │
+│  │                                     │  ↠ Curies share Nobel  · 1903    │  │
 │  └─────────────────────────────────────┴──────────────────────────────────┘  │
 │                                                                              │
 │  ┌── Participants (2) ──┬── Categories (2) ──┬── Media (1) ──┐               │
@@ -79,18 +76,22 @@
 
 ## Annotations
 
-1. **Breadcrumb shows fractal lineage**, not just `Events ▸ This event`. The parent appears as a real segment so the user can navigate up.
-2. **Two-column overview.** Left: narrative content (summary, detail). Right: structured metadata (temporal, location, lineage, timeline). Right column is fixed-width and doesn't scroll.
+1. **Breadcrumb is timeline-rooted**, not event-lineage-rooted: `[containing timeline] ▸ [this event]`. Under the forward fractal model ([#180](https://github.com/shaes-farm/time-traveler/issues/180)) "up" from an event is its containing timeline, not a parent event. When the event is reached from the flat events list, the breadcrumb falls back to `Events ▸ [this event]`. Navigating further up the fractal (timeline → the event that expands into it) happens from the [timeline detail](13-timeline-detail.md) header, not here.
+2. **Two-column overview.** Left: narrative content (summary, detail). Right: structured metadata (temporal, location, timelines/fractal). Right column is fixed-width and doesn't scroll.
 3. **Importance is in the header, near the type.** Both are categorical identifiers of the event.
 4. **Temporal block shows the era explicitly.** "July 1898 CE (exact)" not "July 1898". For MYA/KYA events, era + precision dominate.
 5. **Range vs. point.** If `end_temporal_data` is null, render "point event". If present, render "1895–1898 CE" with the inferred duration. **Duration is always shown** with era-aware formatting (Batch 4 decision Q3): CE/BCE renders "lived 66 years" or "spans 300 years"; KYA renders "spans 4,000 years"; MYA renders "spans 79 million years"; BYA rounds to significant digits. **A visual range bar renders only when** uncertainty > 100 years OR the range spans > 1000 years OR the range crosses an era boundary (Batch 4 decision Q2) — trivial CE ranges get no bar; "66 MYA ±1M" or "12 KYA – 8 KYA" get one. Exact thresholds and visual treatment refined at the next fidelity step.
-6. **Lineage section** surfaces parent, siblings (other events with same parent), and children. This is the navigation surface for the fractal model — it's how authors traverse the tree.
-7. **Sibling events** is a high-value affordance for fractal browsing — "what else happened in this research arc?" Cap at 5 visible; "see all" if more. **Ordered by chronological proximity** to the current event (Batch 4 decision Q1) — `ABS(this.sort_order_years - sibling.sort_order_years) ASC`. Importance is not used as secondary sort; the importance dimension is served on the events list, not here.
+6. **Timelines section is the fractal navigation surface** (forward model, [#180](https://github.com/shaes-farm/time-traveler/issues/180)). It has three parts: **Contained in** (the timelines this event belongs to — home + guests), **Expands into** (the sub-timeline it decomposes into, the zoom-in direction), and **Nearby in timeline** (chronological neighbors). There is no parent/child-event lineage — event-to-event nesting is retired; you traverse the hierarchy by entering timelines, not by walking a parent_event_id tree.
+7. **"Nearby in timeline"** replaces the old sibling-events affordance and answers the same question — "what else happened around here?" — but grounded in **home-timeline membership + chronological proximity** rather than a shared parent. Show the nearest event on each side (`↞` earlier, `↠` later) by `ABS(this.sort_order_years − neighbor.sort_order_years)`; "see all" opens the home [timeline detail](13-timeline-detail.md). When the event has no home timeline, this section is omitted.
 8. **Tabs below for the junction data.** Participants is the most active tab; Categories and Media are simpler.
 9. **Participant rows show role + significance** as labels, not icons. The 11 roles are too many to encode with glyphs.
 10. **Per-participant edit action** opens the inline participant editor (a sheet) — it edits only that one row.
 11. **Spatial data** has a lat/lng pair shown as text. No map embed in this pass. Out of scope, but the data is there.
 12. **Media per-item actions live in an overflow menu** (`⋯`) — Edit caption, Reorder, Detach (Batch 4 decision Q4). Always-visible inline buttons clutter at scale and none of these actions are frequent enough to claim per-row space. Standard admin-tool pattern.
+13. **The three timeline relationships in the Timelines section** (forward fractal model; see [09-event-editor.md](09-event-editor.md) annotation #15, [13-timeline-detail.md](13-timeline-detail.md), and [#177](https://github.com/shaes-farm/time-traveler/issues/177)):
+    - **Contained in → home** (`timeline_id`) — the event's home/containing timeline; the RLS source. Links to that [timeline detail](13-timeline-detail.md).
+    - **Contained in → guest** (`timeline_events`) — additional timelines the event appears in (e.g. comparative); each links out.
+    - **Expands into `⤵`** (`detail_timeline_id`) — the fractal drill-down sub-timeline; the `⤵` affordance is the "zoom in" navigation into that sub-timeline (the inverse of [13-timeline-detail.md](13-timeline-detail.md)'s "Details the event" header line). This is the **only** decomposition mechanism — event-to-event nesting (`parent_event_id`) is retired ([#180](https://github.com/shaes-farm/time-traveler/issues/180)). **Blocked on [#177](https://github.com/shaes-farm/time-traveler/issues/177)** — the Expands-into row is hidden until the column lands.
 
 ## Tab variations
 
@@ -121,9 +122,9 @@ Media in `event_media` has `sort_order` for explicit ordering. Drag to reorder.
 ## Edge cases
 
 - **No participants / no media / no categories.** Each tab shows an empty state with the add CTA.
-- **Event at root of fractal tree (no parent).** Lineage section omits the Parent subsection; sibling list shows "other root events" or omits entirely depending on UX testing.
-- **Event with many children.** Show first 5; "see all 23 child events" link opens the events list pre-filtered.
-- **Event with no timeline.** Timeline section shows "Not in any timeline" with a link to add.
+- **Event that expands into nothing (leaf).** The Timelines section omits the "Expands into" subsection; no `⤵`. The event is a leaf of the fractal hierarchy.
+- **Sub-timeline with many events.** "Expands into" shows the sub-timeline name + event count ("6 events"); the count links into that [timeline detail](13-timeline-detail.md) rather than listing events inline.
+- **Event with no home timeline.** "Contained in" shows "Not in any timeline" with a link to add; "Nearby in timeline" is omitted (no home to be nearby within).
 - **Permissions: collaborator viewing a shared event** (per PRD §7.11.5; #127 reconciliation). Header status badge shows `⇄ Shared`. Edit appears only if the user is a collaborator-editor on the parent timeline (per system-design §9.2.1 RLS). Delete is hidden for collaborators (only owner + admin can delete).
 - **Computed start/end date out of CE range.** The `computed_start_date` column is NULL for non-CE events. UI uses `temporal_data` directly for display in those cases.
 
@@ -131,7 +132,7 @@ Media in `event_media` has `sort_order` for explicit ordering. Drag to reorder.
 
 > **Resolved (Batch 4):**
 >
-> - Sibling-event ordering — chronological proximity. See annotation #7.
+> - Nearby-event ordering (formerly "sibling events") — chronological proximity within the home timeline. See annotation #7. _(Reframed from parent_event_id siblings to timeline-membership neighbors under the forward fractal model, [#180](https://github.com/shaes-farm/time-traveler/issues/180).)_
 > - Range-bar visualization — triggered rendering (uncertainty > 100 yr OR range > 1000 yr OR spans era boundary). See annotation #5.
 > - Duration display — always shown with era-aware formatting. See annotation #5.
 > - Media per-item affordances — overflow menu (`⋯`). See annotation #12.

--- a/docs/design/admin/02-wireframes/09-event-editor.md
+++ b/docs/design/admin/02-wireframes/09-event-editor.md
@@ -1,6 +1,6 @@
 # 09 — Event Editor
 
-**Purpose.** Create or edit an event. Includes the inline participant sub-editor — the second-hardest UX in the admin (after the relationships editor). Many concerns share one form: temporal range, fractal parent, participants, categories, media.
+**Purpose.** Create or edit an event. Includes the inline participant sub-editor — the second-hardest UX in the admin (after the relationships editor). Many concerns share one form: temporal range, fractal decomposition (the sub-timeline an event expands into), timeline membership, participants, categories, media.
 
 ## Data captured
 
@@ -16,10 +16,15 @@ All event row columns except generated ones (`sort_order_years`, `computed_start
 - location
 - spatial_data (JSONB — lat/lng)
 - importance (1–10)
-- parent_event_id (optional)
-- timeline_id (optional)
+- ~~parent_event_id~~ — **removed from the form.** Event-to-event nesting is retired ([#180](https://github.com/shaes-farm/time-traveler/issues/180)); decomposition is expressed forward via `detail_timeline_id`.
+- timeline_id (optional — the event's **primary containing timeline**; RLS source)
+- detail_timeline_id (optional — the fractal **drill-down sub-timeline** this event expands into; **blocked on [#177](https://github.com/shaes-farm/time-traveler/issues/177)** until the column lands)
 - metadata
 - published
+
+Plus secondary timeline membership managed inline:
+
+- `timeline_events` (per-row: timeline_id) — **additional** "also appears in" timelines beyond the primary one
 
 Plus junction data managed inline:
 
@@ -69,12 +74,14 @@ Plus junction data managed inline:
 │  │  Location      [ Paris, France   ]  │                                  │  │
 │  │  Coordinates   [ 48.8566 ] [ 2.3522]│                                  │  │
 │  │                                     │                                  │  │
-│  │  Lineage                            │                                  │  │
+│  │  Timelines                          │                                  │  │
 │  │  ───────────────────────────────    │                                  │  │
-│  │  Parent event  [ Curies' radium … ▾]│                                  │  │
-│  │                Range: 1895–1898 CE  │                                  │  │
-│  │                                     │                                  │  │
-│  │  Timeline      [ Curie biography ▾] │                                  │  │
+│  │  Primary timeline                   │                                  │  │
+│  │     [ Curie biography           ▾]  │                                  │  │
+│  │  Also appears in                    │                                  │  │
+│  │     [ Women in science ×] [ + Add ] │                                  │  │
+│  │  Expands into (sub-timeline)        │                                  │  │
+│  │     [ — none —             ▾] [ ↗ ] │                                  │  │
 │  │                                     │                                  │  │
 │  │  Participants (2)                   │                                  │  │
 │  │  ───────────────────────────────    │                                  │  │
@@ -108,10 +115,10 @@ Plus junction data managed inline:
 
 1. **Same two-column shell** as the character editor. Left: narrative + relationships. Right: identity-adjacent metadata. Slug behavior matches the character editor (live 300ms debounced regeneration on create; locked-by-default with `[edit slug]` unlock affordance on update) — see [05-character-editor.md](05-character-editor.md) annotation #3.
 2. **Importance is a slider** on the right rail. 1–10 with integer steps. Live numeric label.
-3. **When/Where/Lineage sectioning.** Three named sections in the left column structure the form so it doesn't feel like an unbroken wall of inputs.
+3. **When/Where/Timelines sectioning.** Three named sections in the left column structure the form so it doesn't feel like an unbroken wall of inputs. The Timelines section holds the timeline-relationship fields (annotation #15). _(Formerly "Lineage & timelines" — the parent-event field was removed; see annotation #5.)_
 4. **End date defaults to "point event"** — the schema makes end_temporal optional. Most events are point events; range events are the exception. Affordance shows the current state as an empty button so the user knows it's settable.
-5. **Parent event picker** is a combobox / command-palette pattern. Search by title; result rows show the parent's temporal range so the user can sanity-check. After selection, the parent's range renders below the field — context for child placement. A `[ browse hierarchy ]` link on the right of the picker is documented as a future affordance that would open a side-sheet tree view; not built in this pass (Batch 2 decision Q4 — most authors know parent titles, so the combobox is sufficient).
-6. **Cycle prevention** (per system-design §3.4 note on self-referential FK cycles): the picker excludes this event itself and any descendants. If editing an existing event with descendants, the picker pre-filters them out.
+5. **No parent-event picker** ([#180](https://github.com/shaes-farm/time-traveler/issues/180)). Event-to-event nesting is retired in favor of the forward fractal model: to make an event part of a larger structure you either put it in the same timeline (it becomes a chronological neighbor) or you make the larger event **expand into** a sub-timeline (annotation #15) and add this event to that sub-timeline. There is no `parent_event_id` field on this form anymore. The cycle-prevention concern that the old parent picker carried now applies to the **Expands into** field instead (annotation #15).
+6. **Cycle prevention applies to "Expands into"** (annotation #15), not to a parent field. The sub-timeline picker excludes any timeline that (transitively) contains this event, so an event can't expand into a timeline it already lives in. Service-layer, consistent with the descendant-exclusion logic that previously guarded the parent picker.
 7. **Participants sub-editor is inline**, not a modal — always inline regardless of count (Batch 2 decision Q6). The section header shows the count ("Participants (47)") and is collapsible; the section scrolls internally when it grows long. For events with 20+ participants, a future "manage participants in side sheet" affordance is documented but deferred — the inline editor stays the default, with a `[ open in side sheet ]` link when the count crosses a future threshold. Each participant is a card with editable role + significance + description. The "add" CTA opens a character picker (searchable combobox).
 8. **Per-participant role + significance** are inline selects, not labels. Editing a role doesn't require a sub-modal. The `×` removes the participant from the event.
 9. **Per-participant `description`** is the column on `event_characters` that lets the author note context for _this character's role in this event_ ("led the isolation"). It's optional and shown inline.
@@ -119,8 +126,13 @@ Plus junction data managed inline:
 11. **Media is a thumbnail grid + add affordance.** Reordering and detaching happen in the event detail view, not in the editor (avoids a second drag-reorder surface).
 12. **Coordinates** are split into two number inputs. No map widget in this pass.
 
-13. **Save dropdown for events** (Batch 5 decisions Q3, Q4). Primary action: "Save". Dropdown: "Save and add another" (create flow only). **"Save and add another" persists a curated set**: `event_type`, `timeline_id`, `parent_event_id`, `categories` carry forward to the next blank form. Cleared: title, slug, summary, detail, temporal data, location, coordinates, participants, media. An inline note after save reports what was cleared vs. persisted. **No "Duplicate" option** in the dropdown — deferred until real user demand surfaces (Q4); the persistence-based pattern handles the bulk-create case without an explicit duplicate.
+13. **Save dropdown for events** (Batch 5 decisions Q3, Q4). Primary action: "Save". Dropdown: "Save and add another" (create flow only). **"Save and add another" persists a curated set**: `event_type`, `timeline_id` (primary timeline), `categories` carry forward to the next blank form. Cleared: title, slug, summary, detail, temporal data, location, coordinates, participants, media, "also appears in", "expands into". _(`parent_event_id` is no longer in the set — the field is removed, [#180](https://github.com/shaes-farm/time-traveler/issues/180).)_ An inline note after save reports what was cleared vs. persisted. **No "Duplicate" option** in the dropdown — deferred until real user demand surfaces (Q4); the persistence-based pattern handles the bulk-create case without an explicit duplicate.
 14. **Auto-save to draft state every 30 seconds** (per PRD §7.11.3; #127 reconciliation). Same pattern as the character editor — see [05-character-editor.md](05-character-editor.md) annotation #11. The top-right of the editor toolbar shows `Draft saved at H:MM PM` after each successful auto-save. Auto-save never publishes; the explicit Save button is still required for Draft → Published.
+
+15. **Three distinct timeline relationships — do not conflate them** (fractal model; resolved during M5 design, see [#177](https://github.com/shaes-farm/time-traveler/issues/177) and [13-timeline-detail.md](13-timeline-detail.md)):
+    - **Primary timeline** (`timeline_id`, single combobox) — the timeline this event _belongs to_. This is the RLS source: collaborator read/edit access derives from it (system-design §9). Optional, but an event with no primary timeline is owner-only.
+    - **Also appears in** (`timeline_events` junction, multi chip-add) — _additional_ timelines the event surfaces in (e.g. a comparative timeline), without changing its home. This is the same containment the [timeline detail Events tab](13-timeline-detail.md) edits from the other side; managing it here is a convenience. Optional.
+    - **Expands into** (`detail_timeline_id`, single combobox + `[ ↗ ]` create-new) — the fractal **drill-down**: the sub-timeline this event decomposes into (the "Earth forms" event opening into an "evolution of life" timeline). The `[ ↗ ]` shortcut mints a new timeline with inherited defaults (title seeded from the event, span clamped to the event's range) and links it as this event's drill-down in one step — this is what keeps forward-only nesting low-ceremony. **This is the sole decomposition mechanism** now that `parent_event_id` is retired ([#180](https://github.com/shaes-farm/time-traveler/issues/180)). **Blocked on [#177](https://github.com/shaes-farm/time-traveler/issues/177)** — hidden until the column lands; cycle prevention (an event can't expand into a timeline that contains it) is service-layer (annotation #6).
 
 ## Save flow
 
@@ -134,7 +146,7 @@ Per system-design §5.3, `createEventWithRelations` issues the event insert and 
 
 ## Edge cases
 
-- **Parent event date mismatch.** If `start_temporal` falls outside the parent's `[temporal_data, end_temporal_data]` range, show a soft warning beneath the parent field: "Parent event's range is 1895–1898 CE; this event's date is 1899 CE." Save not blocked.
+- **Sub-timeline span mismatch ("Expands into").** If this event's date falls outside the chosen sub-timeline's declared span, show a soft warning beneath the field: "The sub-timeline spans 1895–1898 CE; this event's date is 1899 CE." Save not blocked (declared span is editorial). _(Replaces the former parent-event date-mismatch warning.)_
 - **End date before start date.** Hard validation error; save blocked.
 - **Removing a participant who has an inline description.** Confirm dialog: "Remove Marie Curie? The note 'led the isolation' will be deleted."
 - **Switching event_type mid-edit.** No fields change; type is purely categorical. No warning needed.
@@ -150,10 +162,10 @@ Per system-design §5.3, `createEventWithRelations` issues the event insert and 
 
 > **Resolved (Batch 2):**
 >
-> - Parent event picker UX — combobox with documented future hierarchy-browse side-sheet affordance. See annotation #5.
+> - ~~Parent event picker UX~~ — **superseded.** The parent-event field was removed entirely under the forward fractal model ([#180](https://github.com/shaes-farm/time-traveler/issues/180)); decomposition is the "Expands into" sub-timeline field (annotation #15). See annotation #5.
 > - Inline-participant editing scalability — always inline with internal scroll; no threshold-switch. See annotation #7.
 >
 > **Resolved (Batch 5):**
 >
 > - Duplicate event affordance — deferred until users request it. The persistence-based "Save and add another" handles the bulk-create case. See annotation #13.
-> - "Save and add another" field persistence — curated set: `event_type`, `timeline_id`, `parent_event_id`, `categories`. See annotation #13.
+> - "Save and add another" field persistence — curated set: `event_type`, `timeline_id`, `categories`. (`parent_event_id` dropped from the set with the field's removal, [#180](https://github.com/shaes-farm/time-traveler/issues/180).) See annotation #13.

--- a/docs/design/admin/02-wireframes/11-timeline-list.md
+++ b/docs/design/admin/02-wireframes/11-timeline-list.md
@@ -1,0 +1,82 @@
+# 11 — Timelines List
+
+**Purpose.** Find, scan, and triage timelines. A timeline is the primary container authors organize their work around — the entry point into the fractal hierarchy. Optimized for an author who owns a handful to a few dozen timelines and needs to jump to the one they're working in, or spot which ones are still drafts.
+
+## Data shown
+
+- Per timeline: title, `timeline_type` (badge), `visibility` (badge), published state, `updated_at`, event count, collaborator count, temporal span (start–end with era, when set)
+- Total count + filtered count
+- Sort + filter state
+
+> **Event count and collaborator count are deferred-tolerant** (issue #42 Data Contract). The list renders without them if the count query contract isn't wired yet; when present they show as `· 24 events · 2 collaborators` on row line 2. Treat both as progressive enhancement, not a blocking dependency.
+
+## Primary actions
+
+- Search (by title, summary, detail — backed by `timelines.search_vector` GIN)
+- Filter by `visibility` (`private|public|shared`), `timeline_type` (`general|biographical|comparative`), published state
+- Sort by `title`, `updated_at` (default), `created_at`
+- Create new timeline (top-right + shortcut)
+- Click row → timeline detail
+- Bulk multi-select for publish/unpublish/delete (mirrors characters/events lists)
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Timelines                                             [ + New timeline ]    │
+│  14 total · 9 shown                                                          │
+│                                                                              │
+│  ┌─────────────────┐  ┌────────────────────────────────────────────────────┐  │
+│  │ Filter          │  │ ⌕ Search title, summary, detail…                   │  │
+│  │                 │  │                                                    │  │
+│  │ Type            │  │ ┌──┬──────────────────────┬──────────┬──────┬────┐ │  │
+│  │ ☐ General    8 │  │ │  │ Title                │ Type     │ Vis. │Pub │ │  │
+│  │ ☐ Biographical 4│  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
+│  │ ☐ Comparative 2 │  │ │  │ Curie scientific…    │ Biograph.│ 🌐pub│ ✓  │ │  │
+│  │                 │  │ │  │ 1867–1934 CE · 24 ev…│          │      │    │ │  │
+│  │ Visibility      │  │ │  │ · 2 collaborators    │          │      │    │ │  │
+│  │ ☐ Private    9 │  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
+│  │ ☐ Public     3 │  │ │  │ Cosmic history       │ General  │ 🌐pub│ ✓  │ │  │
+│  │ ☐ Shared     2 │  │ │  │ 14 BYA–now · 312 ev… │          │      │    │ │  │
+│  │                 │  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
+│  │ Status          │  │ │  │ Origin of life       │ General  │ 🔒prv│ ─  │ │  │
+│  │ ☐ Published 11 │  │ │  │ 3.8–3.5 BYA · 9 ev…  │          │      │draft│ │  │
+│  │ ☐ Draft      3 │  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
+│  │                │  │ │  │ Mesozoic era         │ General  │ 🔒prv│ ─  │ │  │
+│  │ Clear filters  │  │ │  │ 252–66 MYA · 41 ev…  │          │      │draft│ │  │
+│  └────────────────┘  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
+│                      │ │  │ Greek mythology      │ General  │ 👥shr│ ✓  │ │  │
+│                      │ │  │ cosmos–1200 BCE      │          │      │    │ │  │
+│                      │ └──┴──────────────────────┴──────────┴──────┴────┘ │  │
+│                      │                                                    │  │
+│                      │ ⟨ 1  2  ⟩                       Sort: Updated ▾    │  │
+│                      └────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Same left-rail filter pattern** as the characters and events lists ([03](03-characters-list.md), [07](07-events-list.md)) — grouped checkbox sets with per-option counts; OR within a group, AND across groups. Discoverability over novelty: a third list screen is not the place to invent a new filter idiom.
+2. **`timeline_type` badge** — `general` / `biographical` / `comparative`. Color + label, not color alone (per [03-aesthetic-notes.md](../03-aesthetic-notes.md)). Biographical timelines carry a subject character (see annotation #6).
+3. **`visibility` and published are two independent axes — and the list shows both** (issue #42, #48). `visibility` (`private`/`public`/`shared`) controls _who can reach_ the timeline via RLS; `published` controls _whether it is live_. A timeline can be `public` + draft, or `private` + published. The Visibility column uses an icon+label (`🔒 private`, `🌐 public`, `👥 shared`); the Pub column uses the shared publish badge from [16-publish-workflow.md](16-publish-workflow.md). Do **not** collapse these into one column — conflating them is the single most common timeline-model mistake and the schema deliberately separates them.
+4. **Two-line row** (the established list pattern). Line 1: title. Line 2: temporal span + event count + collaborator count. Temporal span renders era explicitly for non-CE (`252–66 MYA`, `14 BYA–now`); CE spans render bare years.
+5. **Temporal span is derived from `temporal_data` / `end_temporal_data`** on the timeline row, not computed from member events. A timeline's declared span and the range of events it contains can differ; the declared span is what's shown here. (Mismatch surfacing is a timeline-detail concern — see [13-timeline-detail.md](13-timeline-detail.md).)
+6. **Biographical timelines** show their `subject_character_id` subject as a chip on line 2 when present (`· about Marie Curie`). Comparative timelines get no special row treatment in this pass.
+7. **Sort default is `updated_at` descending** — unlike events (which default to chronological `sort_order_years`), timelines are work surfaces, so "what did I touch last" is the dominant ordering. Title and `created_at` are the alternates.
+8. **No "Shared" status conflation.** A timeline reachable via `timeline_collaborators` shows `visibility = shared` (👥) — but that is the visibility axis, distinct from the `⇄ shared` _permission-context_ badge used on the events/characters lists. For timelines, collaborator-reachable rows simply appear in the list with their real visibility; ownership is implied by the presence of owner-only actions (Edit/Delete) on hover/detail. See [14-collaborators.md](14-collaborators.md).
+9. **Pagination is offset-based**, page size 20 (issue #42). Filter + sort state is URL-encoded so a refresh preserves the view (acceptance criterion: "URL/query state survives refresh").
+10. **List defaults to top-level timelines** (forward fractal model, [#180](https://github.com/shaes-farm/time-traveler/issues/180)). Under forward-only nesting, every event's drill-down mints a sub-timeline — so without this default the master list would fill with nested sub-timelines. The default view shows only **root** timelines: those **not** referenced by any event's `detail_timeline_id`. A filter-rail toggle **"Include sub-timelines"** (off by default) reveals the rest; sub-timeline rows, when shown, carry a `↳ details: [event]` hint linking to the event they expand. The natural way to reach a sub-timeline is by drilling into its event (`⤵`), not by scrolling this list. **Depends on [#177](https://github.com/shaes-farm/time-traveler/issues/177)** (the `detail_timeline_id` column the root/sub partition is computed from); until it lands, all timelines are "root."
+
+## Edge cases
+
+- **Empty list (zero timelines).** Replace the whole panel with an empty state: "No timelines yet. A timeline is the canvas you arrange events on — from a single lifetime to the whole of cosmic history." Single CTA: **New timeline**.
+- **Filtered to zero results.** Inline empty state above the table: "No timelines match these filters." + Clear filters link.
+- **Timeline with no temporal span set.** `temporal_data` defaults to `'{}'`. Render `—` in the span position rather than a bogus `0`.
+- **Very long titles** (`title VARCHAR(2000)`). Truncate with ellipsis at row width; hover reveals full title.
+- **Bulk multi-select.** Selecting any row reveals the sticky action bar: `3 selected · [Publish] [Unpublish] [Delete] [Cancel]`. Consistent with the other lists.
+- **Loading.** Skeleton rows; filter rail renders immediately.
+
+## Open questions
+
+- **Card/grid view** is explicitly a non-goal for #42 (table only this pass). A gallery view keyed on a timeline cover image becomes worthwhile once `timeline_media` is populated and visual design lands — defer to fidelity-2 / a later pass.
+- **Event-count query contract.** Whether the count is a denormalized column, a view, or an N+1 per-row query is a services decision (#42 leaves it deferred). The list must degrade gracefully when the count is absent — designed for above (annotation, row line 2 is optional).

--- a/docs/design/admin/02-wireframes/12-timeline-editor.md
+++ b/docs/design/admin/02-wireframes/12-timeline-editor.md
@@ -1,0 +1,101 @@
+# 12 — Timeline Editor
+
+**Purpose.** Create or edit a timeline. Simpler than the event editor — no inline junction sub-editors — but it owns two model subtleties: the **visibility vs. publication** split, and the **biographical-subject** conditional field. Event linking, collaborators, and media all happen on the [timeline detail](13-timeline-detail.md) page after the timeline exists, not here.
+
+## Data captured
+
+All `timelines` row columns except generated ones (`sort_order_start`, `sort_order_end`, `search_vector`) and timestamps:
+
+- `title` (required)
+- `slug` (auto-generated)
+- `summary`
+- `detail`
+- `scale` (free-form label for the timeline's intended zoom granularity, e.g. "geological", "decades", "days")
+- `timeline_type` (`general|biographical|comparative`)
+- `subject_character_id` (conditional — biographical only)
+- `temporal_data` (start of span)
+- `end_temporal_data` (end of span)
+- `visibility` (`private|public|shared`)
+- `fractal_depth` (integer, default 5 — advanced)
+- `metadata` (advanced)
+- `published` (toggle; see [16-publish-workflow.md](16-publish-workflow.md))
+
+## Primary actions
+
+- Save (create → `useCreateTimeline`; edit → `useUpdateTimeline`)
+- Cancel / discard (with unsaved-changes guard)
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Timelines ▸ New timeline                            [ Cancel ] [ Save ]     │
+│                                                          Draft saved 4:12 PM │
+│  ┌─────────────────────────────────────┬──────────────────────────────────┐  │
+│  │  Identity                           │  Slug                            │  │
+│  │  ───────────────────────────────    │  ───────────────────────────     │  │
+│  │  Title *                            │  curie-scientific-biography      │  │
+│  │  [ Curie scientific biography  ]    │  [ edit slug ]                   │  │
+│  │                                     │                                  │  │
+│  │  Type *                             │  Visibility                      │  │
+│  │  [ Biographical              ▾]     │  ───────────────────────────     │  │
+│  │                                     │  ◯ 🔒 Private  (only you)         │  │
+│  │  Subject character *                │  ◉ 🌐 Public   (anyone, once     │  │
+│  │  [ Marie Curie              ▾]      │       published)                 │  │
+│  │   ⓘ shown for biographical type     │  ◯ 👥 Shared   (collaborators)   │  │
+│  │                                     │                                  │  │
+│  │  Summary                            │  ⓘ Visibility ≠ publication.     │  │
+│  │  ┌─────────────────────────────┐    │     Publish from the detail page │  │
+│  │  │ One-paragraph summary…      │    │     to make a public/shared      │  │
+│  │  └─────────────────────────────┘    │     timeline actually live.      │  │
+│  │                                     │                                  │  │
+│  │  Detail                             │  Published                       │  │
+│  │  ┌─────────────────────────────┐    │  ◯ Draft (publish from detail)   │  │
+│  │  │ Long-form description…      │    │                                  │  │
+│  │  │                             │    │                                  │  │
+│  │  └─────────────────────────────┘    │                                  │  │
+│  │                                     │                                  │  │
+│  │  Span                               │                                  │  │
+│  │  ───────────────────────────────    │                                  │  │
+│  │  Start  [ 1867 CE (exact)      ▾]   │                                  │  │
+│  │  End    [ 1934 CE (exact)      ▾]   │                                  │  │
+│  │  Scale  [ a single lifetime    ]    │                                  │  │
+│  │                                     │                                  │  │
+│  │  ▸ Advanced (fractal depth, metadata)│                                 │  │
+│  └─────────────────────────────────────┴──────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Same two-column editor shell** as the character ([05](05-character-editor.md)) and event ([09](09-event-editor.md)) editors. Left: narrative + structured input. Right: identity-adjacent metadata (slug, visibility, publish). Reuse, don't reinvent.
+2. **Slug behavior matches the other editors** ([05](05-character-editor.md) annotation #3): live 300ms-debounced regeneration from the title on the create form; locked-by-default with an `[ edit slug ]` unlock (and a "this breaks existing links" warning) on the edit form. Uniqueness is `(user_id, slug)` per `timelines_slug_idx` — collision resolution reuses the shared `resolveCollision` utility.
+3. **Type drives one conditional field.** Selecting `timeline_type = biographical` reveals a required **Subject character** picker (`subject_character_id`, a searchable combobox over the user's characters). Switching away from biographical hides it and clears the value (with a confirm if one was set). `general` and `comparative` show no extra fields this pass.
+4. **Visibility is a three-way radio with plain-language helper text**, not a bare dropdown. The model subtlety that trips authors is that **visibility and publication are orthogonal** (see [11-timeline-list.md](11-timeline-list.md) annotation #3 and [16-publish-workflow.md](16-publish-workflow.md)). The inline ⓘ note states it explicitly and points publication to the detail page. `shared` visibility is what makes the timeline reachable by the people added in [14-collaborators.md](14-collaborators.md).
+5. **Publish stays a Draft toggle here, and publishing is owned by the detail page.** The editor can leave a new timeline as Draft (the default) but the canonical publish/unpublish action — with its confirmation dialog — lives in the [timeline detail header](13-timeline-detail.md) and [16-publish-workflow.md](16-publish-workflow.md). Rationale: you usually publish a timeline _after_ arranging its events, which happens on the detail page. The toggle here is a convenience for "create-and-publish in one shot."
+6. **Span uses the shared [TemporalInput control](10-temporal-input.md)** for both start (`temporal_data`) and end (`end_temporal_data`), era-aware (CE/BCE/KYA/MYA/BYA). Both are optional at the schema level (`temporal_data` defaults to `'{}'`), but a timeline with no span shows `—` everywhere downstream, so the form nudges (not blocks) the author to set at least a start. **End-before-start is a hard validation error**, consistent with the event editor.
+7. **`scale` is a free-form text label**, not an enum — the schema is `VARCHAR(2000)`. It's a human note about intended granularity ("geological", "a single lifetime", "decades"), surfaced on the detail header. No controlled vocabulary in this pass; flagged as a future enum candidate.
+8. **`fractal_depth` and `metadata` live behind the Advanced disclosure.** `fractal_depth` (default 5) is a rendering hint for the eventual visualization (Phase 7) — most authors never touch it, so it does not deserve top-level real estate. Same escape-hatch pattern as the character editor's JSON fields ([05](05-character-editor.md) annotation, Batch 4).
+9. **Auto-save to draft every 30 seconds** (per PRD §7.11.3; #127 reconciliation), identical to the character/event editors. The toolbar shows `Draft saved at H:MM PM`. Auto-save never publishes.
+10. **Unsaved-changes guard** (issue #43): navigating away with a dirty form prompts to discard. Standard pattern; reuse the editor-shell guard already specified for [05](05-character-editor.md)/[09](09-event-editor.md).
+11. **No event/collaborator/media management in this editor.** Those are post-creation, detail-page concerns (issue #43 explicitly scopes this form to timeline row fields). On a successful create the user is redirected to the timeline detail, where linking events is the natural next step.
+
+## Save flow
+
+1. Validate client-side (Zod, including `temporalDataSchema` for both span endpoints, and `subject_character_id` required-when-biographical).
+2. `useCreateTimeline` / `useUpdateTimeline` (optimistic via TanStack Query).
+3. On success, redirect to **timeline detail** (`/timelines/[slug]`).
+
+## Edge cases
+
+- **Biographical type with no subject chosen.** Hard validation error: "Biographical timelines need a subject character." Save blocked until set or type changed.
+- **Subject character deleted later.** FK is `ON DELETE SET NULL` (schema). The detail page handles the now-null subject gracefully; the editor just shows an empty picker on next edit.
+- **Switching type from biographical to general with a subject set.** Confirm: "Remove Marie Curie as the subject of this timeline?" Clearing is non-destructive to the character.
+- **End span before start span.** Hard error on the End field; save blocked.
+- **Visibility = shared but no collaborators yet.** Allowed — `shared` just opens the door; collaborators are added on the detail page. No warning needed.
+- **Slug collision on save.** Caught via `timelines_slug_idx`; `resolveCollision` appends a suffix and the form surfaces the resolved slug inline.
+
+## Open questions
+
+- **`scale` as an enum vs. free text** — kept free text this pass (matches schema). If a visualization in Phase 7 needs to key zoom behavior off scale, an enum migration becomes worthwhile. Tier 4 — defer until the visualization surfaces real demand.
+- **Should the timeline span auto-suggest from member events?** A "set span to fit contained events" convenience action is appealing but belongs on the detail page (where the events are), not the create form (where there are none yet). Documented as a future detail-page affordance — see [13-timeline-detail.md](13-timeline-detail.md) Open Questions.

--- a/docs/design/admin/02-wireframes/13-timeline-detail.md
+++ b/docs/design/admin/02-wireframes/13-timeline-detail.md
@@ -1,0 +1,123 @@
+# 13 — Timeline Detail
+
+**Purpose.** Read + manage view of a single timeline. This is the author's primary workspace: it shows the timeline's metadata and publication state, lists and lets you arrange the events it contains, and hosts collaborator and media management. It is also the surface where the **fractal model** becomes visible — both "this timeline contains these events" and "this timeline details that event."
+
+## Data shown
+
+- Identity: title, slug, `timeline_type`, `scale`
+- Narrative: summary, detail
+- Temporal: declared span (`temporal_data` / `end_temporal_data`)
+- `visibility` + published state (two independent axes — see [16-publish-workflow.md](16-publish-workflow.md))
+- Subject character (biographical timelines)
+- **Fractal context:** the event this timeline details, if any (inverse of `events.detail_timeline_id` — see [#177](https://github.com/shaes-farm/time-traveler/issues/177))
+- Tabbed junction data: Events, Periods (read-only stub), Collaborators, Media
+
+## Primary actions
+
+- Edit timeline (→ [12-timeline-editor.md](12-timeline-editor.md))
+- Publish / unpublish (header; see [16-publish-workflow.md](16-publish-workflow.md))
+- Delete (danger zone)
+- Link / unlink events (Events tab)
+- Add / remove / re-role collaborators (Collaborators tab → [14-collaborators.md](14-collaborators.md))
+- Attach / detach / reorder media (Media tab → [15-media-management.md](15-media-management.md))
+- Navigate to a contained event, the subject character, or the detailed event
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Timelines ▸ Curie scientific biography              [Edit] [Publish ✓] [⋯]  │
+│                                                                              │
+│  Curie scientific biography                                                  │
+│  Biographical · about Marie Curie · 🌐 Public · scale: a single lifetime     │
+│  1867 CE — 1934 CE                                                           │
+│                                                                              │
+│  ⓘ Details the event:  ↗ "Marie Curie's life" (in Cosmic history)            │
+│                                                                              │
+│  Summary                                                                     │
+│  ────────────────────────────────────────────────────────────────────────  │
+│  The scientific life of Marie Curie, from her arrival in Paris through her   │
+│  two Nobel Prizes to her death from aplastic anemia.                         │
+│                                                                              │
+│  ┌── Events (24) ──┬── Periods (0) ──┬── Collaborators (2) ──┬── Media (3) ─┐ │
+│  ╞═════════════════╧═════════════════╧═══════════════════════╧═════════════╡ │
+│  │                                       [ ⌕ filter ] [ + Link event ▾ ]   │ │
+│  │  ───────────────────────────────────────────────────────────────────   │ │
+│  │  1891 CE  Sklodowska arrives in Paris      milestone   ★7   home    [×] │ │
+│  │  1895 CE  Marriage to Pierre Curie         ceremony    ★6   home    [×] │ │
+│  │  1898 CE  Discovery of polonium            discovery   ★8   home  ⤵ [×] │ │
+│  │  1898 CE  Discovery of radium              discovery   ★8   home    [×] │ │
+│  │  1903 CE  Curies share Nobel in Physics    ceremony    ★9   home    [×] │ │
+│  │  1906 CE  Pierre Curie killed              incident    ★10  linked  [×] │ │
+│  │  1911 CE  Solo Nobel in Chemistry          ceremony    ★9   home    [×] │ │
+│  │  …                                                                      │ │
+│  │  ───────────────────────────────────────────────────────────────────   │ │
+│  │  Showing 24 events · chronological order (no manual sort set) · ⠿ drag  │ │
+│  └────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ▸ Danger zone                                                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Header mirrors the character/event detail headers** ([04](04-character-detail.md), [08](08-event-detail.md)): breadcrumb, title, a type/visibility/scale metadata line, and the action cluster `[Edit] [Publish] [⋯]`. The `[⋯]` overflow carries secondary actions (copy ID, view raw JSON, duplicate-deferred).
+2. **Two independent state badges in the header**, never merged: `visibility` (🔒/🌐/👥) and the publish badge. See [11-timeline-list.md](11-timeline-list.md) annotation #3 — the orthogonality of visibility and publication is a recurring source of confusion and the detail page is where authors act on both.
+3. **Fractal context line (`ⓘ Details the event:`)** is the inverse lookup of `events.detail_timeline_id` ([#177](https://github.com/shaes-farm/time-traveler/issues/177)). When some event drills down _into_ this timeline, the header shows which event (and the timeline that event lives in), with a jump link. This is how an author navigates _up_ the fractal hierarchy — from a sub-timeline back to the event it expands. When no event details this timeline (it's a top-level timeline), the line is omitted. **Blocked on [#177](https://github.com/shaes-farm/time-traveler/issues/177)** — until the column lands, this line is hidden.
+4. **Tabs:** Events | Periods | Collaborators | Media — the structure from issue #44. Counts in the labels (the established detail-tab convention). Tabs lazy-load on activation.
+5. **Events tab is the heart of the page.** It lists every event contained by this timeline and lets the author link existing events in and unlink them.
+   - **Containment is the union of two sources** (resolved fractal model, [#177](https://github.com/shaes-farm/time-traveler/issues/177)): events whose **primary** `timeline_id` is this timeline (badge: `home`) **plus** events linked via the `timeline_events` junction (badge: `linked`). The `home`/`linked` chip tells the author whether this is the event's primary home or a secondary appearance.
+   - **Ordering is editorial `timeline_events.sort_order` ascending, with a chronological fallback.** The junction carries a `sort_order` column (migration `00012`, issue #122); the service layer's convention is: when every row shares the default `0`, fall back to the joined `events.sort_order_start` (chronological). So a timeline that hasn't been hand-arranged reads chronologically, and dragging a row to reorder writes a non-zero `sort_order` (e.g. for a comparative or thematic timeline where narrative beats matter more than dates). A short note under the list states the active ordering. Drag handle (`⠿`) per row enables manual arrangement.
+6. **`[ + Link event ▾ ]`** opens a searchable combobox over the user's events (the same command-palette pattern as the event editor's timeline pickers, [09](09-event-editor.md) annotation #15). Selecting an event inserts a `timeline_events` junction row → it appears as `linked`. The split-button `▾` offers **Create new event in this timeline**, which deep-links to the [event editor](09-event-editor.md) with this timeline pre-filled as the primary `timeline_id` (so the new event lands as `home`).
+7. **Unlink (`[×]`) semantics depend on home vs. linked:**
+   - `linked` event → `[×]` deletes only the `timeline_events` junction row. The event is untouched and keeps its own home timeline.
+   - `home` event → `[×]` is a heavier action: it would orphan the event's primary timeline. Confirm: "Remove this event's home timeline? It will have no primary timeline until you set a new one." (Sets `events.timeline_id = NULL`, per the FK's `ON DELETE SET NULL` spirit, done explicitly.) This guard prevents accidental orphaning.
+8. **Per-row fractal drill-down marker (`⤵`)** appears on events that themselves have a `detail_timeline_id` — i.e. events you can zoom _into_ from here. Clicking `⤵` navigates to that sub-timeline's detail page. This is the "zoom in" direction; annotation #3's header line is the "zoom out" direction. **Blocked on [#177](https://github.com/shaes-farm/time-traveler/issues/177).**
+9. **Periods tab is a read-only stub this pass** (resolved decision). Period CRUD arrives in Phase 6 (milestone 7). The tab renders linked periods (`period_timelines` junction) read-only if any exist, otherwise an empty state: "Period management arrives in a later release." Keeping the tab preserves issue #44's IA without designing period-linking prematurely.
+10. **Collaborators tab** hosts the full collaborator panel — add by username, role select, remove, with owner safeguards. Fully specified in [14-collaborators.md](14-collaborators.md). The tab count excludes the owner (the owner is `timelines.user_id`, not a `timeline_collaborators` row).
+11. **Media tab** uses the shared media management surface — attach (upload or external URL), reorder via `timeline_media.sort_order`, detach. Fully specified in [15-media-management.md](15-media-management.md).
+12. **Edit/Delete are owner-gated; collaborator capability follows role.** Per system-design §9 RLS: the owner and admins see Edit/Delete; a collaborator-editor sees Edit (and event link/unlink) but not Delete; a collaborator-viewer gets a read-only page. The publish control is owner-only (see [16-publish-workflow.md](16-publish-workflow.md)). Action visibility is computed from the viewer's role, mirroring [08-event-detail.md](08-event-detail.md) Edge Cases.
+
+## Tab variations
+
+### Collaborators tab (summary — full spec in [14](14-collaborators.md))
+
+```
+  Collaborators (2)                                  [ + Add collaborator ]
+  ───────────────────────────────────────────────────────────────────────
+  @irenejc       Irène Joliot-Curie   editor ▾   [ remove ]
+  @ebranly       Édouard Branly       viewer ▾   [ remove ]
+  ─────────────────────────────────────────────────────────────
+  Owner: you (Philipe Banglarian)  — owners can't be removed
+```
+
+### Media tab (summary — full spec in [15](15-media-management.md))
+
+```
+  Media (3)                            [ + Attach media ]
+  ───────────────────────────────────────────────────────
+  [cover] [thumb] [thumb]      drag ⠿ to reorder (timeline_media.sort_order)
+```
+
+### Periods tab (read-only stub)
+
+```
+  Periods (0)
+  ───────────────────────────────────────────────────────
+  — Period management arrives in a later release (Phase 6) —
+```
+
+## Edge cases
+
+- **404 / not found.** Timeline lookup is by `(user_id, slug)` uniqueness; a slug that doesn't resolve for the current viewer (accounting for RLS) renders a 404 with a link back to the timelines list.
+- **Empty Events tab.** "No events linked yet. Link existing events, or create one in this timeline." Two CTAs (Link / Create).
+- **Span mismatch.** When contained events fall outside the timeline's declared span, surface a non-blocking advisory in the header span line: "3 events fall outside this timeline's span (1867–1934 CE)." Links to the offending rows. Never blocks — declared span is editorial, not a constraint.
+- **Biographical timeline with a deleted subject.** `subject_character_id` is now NULL (FK `ON DELETE SET NULL`); the metadata line drops the "about X" chip rather than rendering a broken link.
+- **Collaborator-viewer.** Whole page is read-only; tabs render but their add/remove affordances are hidden.
+- **Loading.** Skeleton header; tabs lazy-load with per-tab skeletons (acceptance criterion: tab-level loading/error states).
+
+## Open questions
+
+- **Manual event ordering within a timeline.** Supported — `timeline_events.sort_order` exists (migration `00012`, issue #122). Default `0` everywhere reads as chronological; dragging assigns explicit ordering. Open sub-question: whether dragging rewrites a single row's `sort_order` or renumbers the whole set (sparse vs. dense ordering) — a fidelity-2 interaction detail, not a schema question.
+- **"Fit span to events" convenience action.** A header action that sets `temporal_data`/`end_temporal_data` to the min/max `sort_order_years` of contained events. Useful, lives here (not the editor) because the events exist here. Deferred to a polish pass.
+- **Bulk link.** Multi-select on the Link-event combobox (link several events at once). Deferred — single-link covers the common case; bulk operations are a cross-cutting later pass (see [01-user-flows.md](../01-user-flows.md) "What these flows do not cover").

--- a/docs/design/admin/02-wireframes/14-collaborators.md
+++ b/docs/design/admin/02-wireframes/14-collaborators.md
@@ -1,0 +1,89 @@
+# 14 — Collaborator Management (Timeline)
+
+**Purpose.** Manage who else can see and edit a timeline, and at what role. Lives as the **Collaborators** tab on [timeline detail](13-timeline-detail.md). Collaboration is the one place the admin stops being single-user, so this surface is small but permission-sensitive: every action here changes what another person can do under RLS.
+
+Scoped to **timelines only** this pass (issue #50). Characters, events, periods, and stories inherit collaborator access _derived from_ the timelines that reference them (system-design §9.2.1), so there is no separate collaborator UI for those entities.
+
+## Data shown
+
+- Owner (from `timelines.user_id`) — always shown, never editable, never removable
+- Each collaborator (`timeline_collaborators`): profile identity (username, display name, avatar), `role` (`viewer|editor|admin`), added date
+- Collaborator count (excludes owner)
+
+## Primary actions
+
+- Add collaborator by username + role (`addCollaborator`)
+- Change a collaborator's role (`updateCollaboratorRole`)
+- Remove a collaborator (`removeCollaborator`)
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Collaborators (2)                                   [ + Add collaborator ]   │
+│  ──────────────────────────────────────────────────────────────────────────  │
+│                                                                              │
+│  Owner                                                                       │
+│  ──────────────────────────────────────────────────────────────────────────  │
+│  ◑ you  ·  @Philipe Banglarian                          owner   (full control) │
+│                                                                              │
+│  Collaborators                                                               │
+│  ──────────────────────────────────────────────────────────────────────────  │
+│  ◑ Irène Joliot-Curie  ·  @irenejc        editor ▾    added 2026-05-02  [×]  │
+│  ◑ Édouard Branly      ·  @ebranly        viewer ▾    added 2026-05-11  [×]  │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+  ── Add collaborator (dialog) ──────────────────────────────────────────┐
+  │  Add collaborator                                                     │
+  │  ──────────────────────────────────────────────────────────────────  │
+  │  Username                                                             │
+  │  [ @irenejc                          ]  ✓ Irène Joliot-Curie         │
+  │                                                                      │
+  │  Role                                                                │
+  │  ◯ Viewer   — can read this timeline and its events                  │
+  │  ◉ Editor   — can read and edit events; cannot delete or publish     │
+  │  ◯ Admin    — can edit, and manage collaborators; cannot delete the  │
+  │              timeline or change the owner                            │
+  │                                                                      │
+  │                                        [ Cancel ]  [ Add collaborator]│
+  └──────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Owner is rendered as a distinct, locked top section** — not a row in the collaborator list. The owner is `timelines.user_id`, which is _not_ a `timeline_collaborators` row, so it can never be removed or re-roled here (acceptance criterion: "owner-removal is blocked in UI"). Showing it explicitly answers "who's in charge?" without implying it's editable.
+2. **Lookup is by `username`, not email** (schema reality). `profiles` exposes `username` (unique-ish, client-queryable); there is **no** client-readable email — email lives in `auth.users`, behind the service role. So "validate target user" (issue #50) means: resolve the typed `@username` against `profiles`, show the matched display name as confirmation (✓), and only enable **Add** once a real profile resolves. A non-matching username shows "No user found with that username."
+   - **Resolved — profiles are globally readable.** The `read_profiles` policy is `USING (true)` (migration `00007_rls_policies.sql`), so any authenticated user can resolve a `@username` to a profile. Add-by-username works without further RLS work. (`profiles.username` has a length CHECK but is nullable, so a username search must tolerate users who never set one — they simply aren't findable this way.)
+3. **Three roles map exactly to the schema CHECK** (`viewer|editor|admin`) and to the RLS helper functions (`is_timeline_collaborator`, `is_timeline_collab_editor`). The role descriptions in the dialog are the plain-language contract:
+   - **Viewer** — read the timeline and its events (RLS read access).
+   - **Editor** — read + update events on the timeline (`is_timeline_collab_editor`); **cannot delete** events or **publish** the timeline.
+   - **Admin** — editor capabilities **plus** manage collaborators on this timeline; still **cannot delete the timeline** or change ownership (owner + global admin only).
+     Spelling out the negatives ("cannot delete / publish") is deliberate — role names alone under-communicate the ceiling.
+4. **Role change is an inline select per row** (`editor ▾`), applied immediately via `updateCollaboratorRole` (acceptance criterion: "role changes take effect immediately in UI"). Optimistic update with rollback on failure. No separate save step.
+5. **Remove (`[×]`) requires confirmation** (issue #50): "Remove @irenejc as a collaborator? They will lose access to this timeline and its events." On confirm, `removeCollaborator` deletes the junction row.
+6. **Who can manage collaborators:** the owner always; a collaborator-**admin** can add/remove/re-role _other_ collaborators but cannot remove the owner, cannot promote anyone above their own ceiling in a way that grants delete/ownership, and cannot remove themselves to orphan the timeline's management (they can leave only if the owner remains — which is always true since the owner isn't a collaborator row). Viewers and editors see the list read-only (no add/remove/role controls).
+7. **No self-add, no duplicate, no adding the owner.** The add dialog disables **Add** when the resolved username is the current owner ("That user already owns this timeline") or already a collaborator ("Already a collaborator — change their role below instead"). The PK `(timeline_id, user_id)` would reject a duplicate anyway; the UI catches it first.
+8. **Collaborator count surfaces in two places** (issue #50 acceptance: "count is visible where required"): the tab label here (`Collaborators (2)`) and, optionally, row line 2 on the [timelines list](11-timeline-list.md). Both exclude the owner.
+9. **Avatars** come from `profiles.avatar_url`; fall back to initials when null. Display name is `first_name last_name` from `profiles`.
+
+## Edge cases
+
+- **Username not found.** Inline under the field: "No user found with that username." Add stays disabled.
+- **Adding a user who already collaborates.** Blocked at validation with a pointer to change their role inline.
+- **Adding the owner.** Blocked: "That user already owns this timeline."
+- **Removing yourself (as a collaborator-admin).** Allowed — confirm "Leave this timeline? You'll lose access." After leaving, redirect to the timelines list (the page is no longer reachable for them).
+- **Role downgrade mid-session for another connected user.** Out of scope for realtime sync this pass; their access updates on their next RLS-checked request. (Supabase Realtime co-presence is explicitly not designed yet — see [01-user-flows.md](../01-user-flows.md).)
+- **Loading / error.** Tab-level skeleton on the collaborator list; failed add/remove/role-change rolls back the optimistic update and toasts the error.
+
+## Non-goals (issue #50)
+
+- **Email-invite delivery.** No "send an invitation email" flow — collaborators are added directly by username and gain access immediately under RLS. The `notifications` table (system-design §3) could later carry an in-app "you were added to a timeline" notice; that's a separate notifications-IA pass, not this ticket.
+- **Organization / team-wide permissions.** No group roles; collaboration is per-timeline, per-user only.
+- **Pending/invited state.** Because add is immediate, there is no "invited but not accepted" state to model in this pass.
+
+## Open questions
+
+- **In-app notification on add.** Worth wiring once the notifications inbox is designed — surfaces "@you were added to _Curie scientific biography_ as editor." Deferred to the notifications IA pass.
+- **Username vs. email lookup.** If product wants email-based invites (the more familiar pattern), it needs a service-role lookup or an invite-token flow — a meaningfully larger feature than #50's scope. Flagged for product; username lookup is the schema-honest choice for now.
+- **Profiles directory privacy.** Add-by-username assumes usernames are discoverable. If that's undesirable (privacy), an invite-token model replaces directory lookup. Tied to the annotation #2 RLS prerequisite.

--- a/docs/design/admin/02-wireframes/15-media-management.md
+++ b/docs/design/admin/02-wireframes/15-media-management.md
@@ -1,0 +1,105 @@
+# 15 — Media Management (cross-cutting)
+
+**Purpose.** A reusable media surface for attaching, ordering, previewing, and detaching media on the three entities that carry it: **events** (`event_media`), **characters** (`character_media`), and **timelines** (`timeline_media`). Like the [TemporalInput control](10-temporal-input.md), this is a primitive, not a screen — it's embedded in the editors and detail tabs already designed, so its behavior must be defined once and reused.
+
+Issue #49 deliberately scopes this to **hybrid media** (uploaded files + external URL embeds) with **association + ordering** — _not_ a full digital-asset-manager. There is no standalone media library browser in this pass.
+
+## The two media kinds
+
+`media` rows are one of two kinds, distinguished by how the bytes are sourced:
+
+| Kind         | Where bytes live                                         | `storage_path`     | `url`                          |
+| ------------ | -------------------------------------------------------- | ------------------ | ------------------------------ |
+| **Uploaded** | Supabase Storage bucket                                  | the object path    | the resolved public/signed URL |
+| **External** | a third-party host (YouTube, archive.org, a museum CDN…) | — (see schema gap) | the external URL               |
+
+> **Schema gap — must resolve before build.** `media.storage_path` is `NOT NULL` in the current schema, but an _external_ embed has no stored object. There is also **no column distinguishing uploaded vs external** (no `source`/`is_external` flag) and no `media_type`-independent kind marker. #49 cannot ship external embeds cleanly until this is addressed. Recommended fix: make `storage_path` nullable **and** add `source VARCHAR CHECK (source IN ('upload','external'))` (or infer kind from `storage_path IS NULL`). `// BLOCKED: storage_path NOT NULL + no upload/external discriminator — needs a migration before external embeds work.` File as an upstream schema issue (mirrors the [#177](https://github.com/shaes-farm/time-traveler/issues/177) treatment for the fractal column).
+
+## Data captured
+
+Per `media` row: `slug`, `alt_text`, `caption`, `storage_path`, `url`, `media_type` (`image|video|audio|document`), `width`, `height`, `file_size_bytes`, `mime_type`, `metadata`.
+
+Per association (junction):
+
+- `event_media` — `(event_id, media_id, sort_order)`
+- `timeline_media` — `(timeline_id, media_id, sort_order)`
+- `character_media` — `(character_id, media_id, is_primary)` — **no `sort_order`; has a single-primary invariant** (partial unique index, [#125](https://github.com/shaes-farm/time-traveler/issues/125) / [#133](https://github.com/shaes-farm/time-traveler/pull/133))
+
+## The Attach dialog
+
+Invoked from every `[ + Attach media ]` / `[ + Add media ]` affordance (event detail, character detail/editor, timeline detail).
+
+```
+  ── Attach media ───────────────────────────────────────────────────────┐
+  │  ( Upload )   ( External URL )                                        │
+  │  ──────────────────────────────────────────────────────────────────  │
+  │  Upload tab:                                                          │
+  │  ┌────────────────────────────────────────────────────────────────┐ │
+  │  │   ⬆  Drop a file here, or click to browse                       │ │
+  │  │      images · video · audio · documents                        │ │
+  │  └────────────────────────────────────────────────────────────────┘ │
+  │  [filename.jpg ▓▓▓▓▓▓▓░░░ 68%]                                        │
+  │                                                                      │
+  │  Alt text   [ Marie Curie in her laboratory, 1898         ]          │
+  │  Caption    [ Source: Curie Museum archive               ]          │
+  │                                                                      │
+  │                                          [ Cancel ]  [ Attach ]       │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  ── External URL tab ───────────────────────────────────────────────────┐
+  │  URL       [ https://archive.org/details/…           ]  ✓ recognized │
+  │  ┌──────────────┐                                                    │
+  │  │ [preview]    │  detected: image · 1200×800                        │
+  │  └──────────────┘                                                    │
+  │  Alt text   [ … ]      Caption  [ … ]                                │
+  │                                          [ Cancel ]  [ Attach ]       │
+  └──────────────────────────────────────────────────────────────────────┘
+```
+
+## Display: list / grid with per-item actions
+
+The attached-media render is shared across the three detail surfaces. It matches the media tab already sketched in [08-event-detail.md](08-event-detail.md) (thumbnail + caption + `⋯` overflow):
+
+```
+  Media (3)                                           [ + Attach media ]
+  ───────────────────────────────────────────────────────────────────
+  ⠿ ╔════════════╗  Marie Curie in her laboratory, 1898
+    ║ [thumb]    ║  uploaded · image · sort_order 0          [⋯]
+    ╚════════════╝
+  ⠿ ╔════════════╗  Newsreel: Curie receives 1911 Nobel
+    ║ [▶ thumb]  ║  external (archive.org) · video · sort 1   [⋯]
+    ╚════════════╝
+  ⠿ ╔════════════╗  Polonium discovery paper, first page
+    ║ [doc icon] ║  uploaded · document · sort 2             [⋯]
+    ╚════════════╝
+```
+
+## Annotations
+
+1. **One dialog, two tabs: Upload / External URL** — the "hybrid" of #49. Upload streams to Supabase Storage then creates the `media` row + the junction row; External validates/recognizes the URL then creates an external `media` row + junction row. Both end by attaching to the current entity.
+2. **`media_type` is inferred, not asked.** Upload derives it from MIME (`image`/`video`/`audio`/`document`); External derives it from the recognized URL / content-type. The four-value CHECK (`image|video|audio|document`) is the closed set — anything unrecognized falls back to `document` with a notice.
+3. **Per-item actions live in the `⋯` overflow** (consistent with [08-event-detail.md](08-event-detail.md) annotation #12): **Edit caption / alt text**, **Reorder** (or drag the `⠿` handle), **Set as primary** (character only), **Detach**, **Delete original**. Keeping these in the overflow keeps dense media lists clean.
+4. **Reorder applies only where the junction has `sort_order`** — events and timelines. Drag the `⠿` handle to rewrite `event_media.sort_order` / `timeline_media.sort_order`. **Character media has no `sort_order`** (schema) — so the character media list has no drag handle; its only ordering concept is **primary vs. the rest** (annotation #5).
+5. **`is_primary` is character-only** and single-valued, enforced by the partial unique index ([#125](https://github.com/shaes-farm/time-traveler/issues/125)/[#133](https://github.com/shaes-farm/time-traveler/pull/133)). "Set as primary" does the atomic swap (unset old, set new) as a UX flow; the DB index is the correctness backstop. The primary item renders with a `primary` badge. This matches [04-character-detail.md](04-character-detail.md).
+6. **Detach vs. Delete are different, and the difference matters for shared media** (issue #49 acceptance: "delete behavior is explicit for uploaded vs external"):
+   - **Detach** removes only the _junction row_ — the `media` record survives and may still be attached elsewhere. Always safe.
+   - **Delete original** removes the `media` row itself (and, for uploaded media, the Storage object). Confirm with blast radius: "This image is attached to 2 other entities. Deleting it removes it everywhere and deletes the stored file." For external media, no Storage object is removed — only the row.
+     The `⋯` menu offers Detach by default; Delete original is the heavier, separately-confirmed action.
+7. **Upload progress + partial failure** follow the editor pattern already established ([05](05-character-editor.md)/[09](09-event-editor.md)): uploads complete in the background; if the entity saves but the upload fails, a toast offers retry from the detail view. Media never blocks the parent entity save.
+8. **Previews degrade by type.** Image → thumbnail; video → poster frame with a ▶ overlay; audio → waveform/clip icon; document → file-type icon + filename. External embeds show the host's thumbnail when available, otherwise the type icon. No inline players in the admin this pass — preview is a still; playback opens the source.
+9. **No standalone library browser this pass.** Attachment always starts from an entity ("attach to _this_ event"). A cross-entity "pick from existing media" picker (browse everything you've uploaded and reuse it) is a natural #49 follow-up but is **not** required by the acceptance criteria — documented under Open Questions.
+
+## Edge cases
+
+- **External URL not recognized.** Allow attach anyway as a generic link with a `document` fallback and a "couldn't generate a preview" note. Never block on preview failure.
+- **Oversized upload.** #49 scopes uploads to "small files." Enforce a client-side size cap (value is a services/config decision); over-cap files are rejected with the limit stated. `// NEEDS: max upload size config`.
+- **Detaching the character's primary media.** Confirm and, if other media exist, prompt "Make another image primary?" so the character isn't left with no primary. Non-blocking.
+- **Reordering during an in-flight attach.** New item lands at the end (`max(sort_order)+1`); reorder is enabled once the attach settles.
+- **Empty state.** Per entity: "No media attached yet." + the Attach CTA.
+- **Loading / error.** Grid skeleton; failed attach rolls back optimistic insert and toasts.
+
+## Open questions
+
+- **Reusable media picker** (browse + reattach existing media across entities) — the biggest deferred piece. Becomes worthwhile once authors accumulate a library; out of scope for #49's association-focused acceptance criteria.
+- **External-embed schema discriminator** — see the schema-gap callout above. Must be resolved (nullable `storage_path` + a `source` discriminator) before external embeds ship. Treat as a hard prerequisite for the External URL tab.
+- **Transcoding / responsive variants** — explicit non-goal (#49). Originals are stored and served as-is this pass.

--- a/docs/design/admin/02-wireframes/16-publish-workflow.md
+++ b/docs/design/admin/02-wireframes/16-publish-workflow.md
@@ -1,0 +1,101 @@
+# 16 — Publish / Unpublish Workflow (cross-cutting)
+
+**Purpose.** Define the one consistent publish/unpublish pattern used by **timelines** and **events** across their list, detail, and editor surfaces. Like media ([15](15-media-management.md)) and TemporalInput ([10](10-temporal-input.md)), this is a cross-cutting behavior, not a screen — the badges and the confirm dialog appear on screens designed elsewhere, so the rules live here once.
+
+Scope is **timelines + events only** (issue #48). Characters carry a `published` column and already show a publish badge on their list/detail (the schema is uniform), but a _characters/stories/periods_ publish workflow is an explicit #48 non-goal — this pass formalizes the pattern for the two entities #48 names, and the same pattern extends to the others later without change.
+
+## The model: `published` + `published_at`
+
+Both `timelines` and `events` have:
+
+- `published BOOLEAN DEFAULT false`
+- `published_at TIMESTAMPTZ` (nullable)
+
+The invariant (issue #48 acceptance):
+
+- **Publish** → `published = true`, `published_at = now()`.
+- **Unpublish** → `published = false`, `published_at = NULL` (cleared, not retained).
+
+> **Publication is not visibility.** This is the single most important distinction in the timeline/event model and the reason the two axes get separate badges everywhere:
+>
+> - **`visibility`** (timelines: `private|public|shared`) = _who is allowed to reach this_ under RLS.
+> - **`published`** = _whether it is live_ (vs. a work-in-progress draft).
+>
+> They are orthogonal: a `public` timeline that is still a draft is reachable by RLS rules but presents as not-yet-live; a `private` published timeline is "done" but only the owner sees it. Never collapse them into one control. (Events have no `visibility` column — an event's reach is derived from its containing timeline via RLS — so for events `published` is the only state axis.)
+
+## Status badges (the shared vocabulary)
+
+Three states, used identically on every list row and detail header (already referenced by [03](03-characters-list.md) #7, [07](07-events-list.md) #12, [08](08-event-detail.md), [11](11-timeline-list.md) #3):
+
+| Badge         | Meaning                                                                              | Color (PRD §7.11.5) |
+| ------------- | ------------------------------------------------------------------------------------ | ------------------- |
+| `✓ Published` | `published = true`                                                                   | green               |
+| `─ Draft`     | `published = false`                                                                  | gray                |
+| `⇄ Shared`    | reachable via `timeline_collaborators` (permission-context, **not** a content state) | blue                |
+
+`⇄ Shared` is orthogonal to Published/Draft — it marks _why you can see someone else's row_, and the underlying row may itself be Published or Draft from its owner's perspective. Exact colors/icons land at fidelity-2 visual design; the states and their semantics are fixed here.
+
+## The publish/unpublish control
+
+```
+  Detail header (owner):              Detail header (after publish):
+  ┌──────────────────────────┐        ┌──────────────────────────┐
+  │  [Edit]  [ Publish ]     │        │  [Edit]  [ ✓ Published ▾ ]│
+  └──────────────────────────┘        └──────────────────────────┘
+                                         └ dropdown: Unpublish
+
+  ── Confirm publish (dialog) ───────────────────────────────────────────┐
+  │  Publish “Discovery of polonium”?                                     │
+  │  ──────────────────────────────────────────────────────────────────  │
+  │  This event becomes live. People with access to its timeline will     │
+  │  see it as published. You can unpublish at any time.                  │
+  │                                                                      │
+  │                                          [ Cancel ]  [ Publish ]      │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  ── Confirm unpublish (dialog) ─────────────────────────────────────────┐
+  │  Unpublish “Discovery of polonium”?                                   │
+  │  ──────────────────────────────────────────────────────────────────  │
+  │  This returns the event to draft. published_at is cleared. It stays   │
+  │  reachable to you and editors but reads as not-yet-live.              │
+  │                                                                      │
+  │                                          [ Cancel ]  [ Unpublish ]    │
+  └──────────────────────────────────────────────────────────────────────┘
+```
+
+## Surfaces and behavior
+
+1. **Detail header (canonical).** The publish/unpublish action lives in the detail header for both entities — [08-event-detail.md](08-event-detail.md) and [13-timeline-detail.md](13-timeline-detail.md). A draft shows `[ Publish ]`; a published row shows `[ ✓ Published ▾ ]` whose dropdown holds **Unpublish**. Both transitions go through the confirmation dialog above (issue #48 acceptance: "confirmation dialog exists for both actions").
+2. **Editor (convenience).** The timeline ([12](12-timeline-editor.md)) and event ([09](09-event-editor.md)) editors carry a Draft/publish toggle on the right rail as a _create-and-publish-in-one-shot_ convenience. The toggle still routes through the confirm dialog on the publish transition. **Auto-save never publishes** — it only writes draft state (per PRD §7.11.3). Draft→Published is always an explicit, confirmed action.
+3. **List rows (badge + bulk).** Every list row shows the status badge ([07](07-events-list.md), [11](11-timeline-list.md)). The bulk multi-select action bar offers **Publish** / **Unpublish** across selected rows; bulk transitions show a single batched confirm ("Publish 4 events?") rather than one dialog per row.
+4. **List filters.** Both the [events list](07-events-list.md) and [timelines list](11-timeline-list.md) carry a Status filter group (`Published` / `Draft`) with counts — issue #48 acceptance: "publication-state filtering works on relevant list pages."
+
+## Ownership & permission gating
+
+Publish is a **higher-privilege action than edit** (issue #48 acceptance: "owner-only action gating enforced in UI and service paths"):
+
+- **Owner** and **global admin** — can publish/unpublish.
+- **Collaborator-editor** — can edit events but **cannot publish/unpublish** (the control is hidden, not just disabled). Publishing is an editorial go-live decision reserved to ownership. This matches the RLS posture in system-design §9 where editors get update but go-live stays with the owner.
+- **Collaborator-viewer / non-collaborator** — read-only; no control.
+
+UI gating mirrors the service/RLS check — the control's _visibility_ is computed from role, and the service path re-checks (defense in depth; the UI never assumes it's the only gate).
+
+## Services & hooks (issue #48 contract work)
+
+- **Timelines** already have publish/unpublish service methods.
+- **Events** gain parity — `publishEvent(id)` / `unpublishEvent(id)` plus the publish/unpublish mutations on the events hook — landing in **PR #174** (`feat(services,ui): add event publish/unpublish parity for #48`).
+- Both set/clear `published_at` server-side on transition. RLS visibility behavior stays aligned with existing policies (no policy changes required — `published = true` already widens read access in `read_events` / the timeline read policy).
+
+## Edge cases
+
+- **Publishing a timeline with draft events (or vice versa).** No cascade — publication is per-row. A timeline can be published while some of its events are drafts. Surface a non-blocking note on the timeline detail Events tab when this happens ("3 events in this timeline are still drafts"), mirroring [04-character-detail.md](04-character-detail.md) Edge Cases ("2 events not yet published"). Never auto-publish children.
+- **Unpublishing something others can currently see.** The confirm dialog states the consequence; on unpublish, `published = false` narrows RLS read access back to owner/editors. Anyone relying on public reach loses it immediately on their next request.
+- **Publish on an unsaved new entity.** The editor's publish toggle applies on save; you cannot publish a row that doesn't exist yet. The confirm fires as part of the save when the toggle is on.
+- **Optimistic transition failure.** Badge flips optimistically; on service error it rolls back and toasts ("Couldn't publish — try again").
+- **`published_at` retention.** Unpublish clears `published_at` to NULL (issue #48). If a future analytics need wants "first published at" history, that's a separate audit-column decision — flagged, not built.
+
+## Open questions
+
+- **Scheduled publish** ("go live on a date") — not in #48. `published_at` is a transition timestamp, not a schedule. A scheduled-publish feature would need a separate `publish_at_scheduled` column + a job; deferred.
+- **Extending the pattern to characters/stories/periods.** The badge + control + confirm pattern is entity-agnostic by design; rolling it out to the other `published`-bearing entities is a later, mechanical pass once those entities' detail pages exist.
+- **Re-publish timestamp semantics.** On unpublish→republish, `published_at` is set fresh to the new `now()`. If "original publish date" must persist across cycles, that's the audit-column decision above.

--- a/docs/design/admin/03-aesthetic-notes.md
+++ b/docs/design/admin/03-aesthetic-notes.md
@@ -70,10 +70,10 @@ When this graduates to in-tree React in `apps/admin`, expected primitives — mo
 - Sheet (right-slide for relationship editor, event participant editor)
 - Dialog (destructive confirms, quick-create)
 - Popover (temporal input control)
-- Combobox / Command palette (parent event picker, character picker, global search)
+- Combobox / Command palette (timeline & sub-timeline pickers, link-event picker, character picker, global search)
 - TagInput / chip-style multi-text for `TEXT[]` fields
-- Tabs (character detail, event detail)
-- Tree (parent event lineage, category hierarchy) — _no shadcn primitive for this; custom build_
+- Tabs (character detail, event detail, timeline detail)
+- Tree (category hierarchy; timeline fractal hierarchy) — _no shadcn primitive for this; custom build_
 - Toast + optimistic-state feedback (TanStack Query pairs well)
 
 ## What I deliberately defer

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -42,7 +42,7 @@ The system provides a fractal approach to time visualization, allowing users to 
 
 ### 1.2 Key Innovations
 
-**Fractal Time Navigation.** Events can contain nested sub-events, creating a multi-dimensional temporal hierarchy where users zoom seamlessly from billion-year geological scales to individual seconds.
+**Fractal Time Navigation.** The recursion unit is the **timeline**: a timeline contains events, and any event can _expand into_ its own sub-timeline (`events.detail_timeline_id`), which in turn contains finer events that may expand further. Users zoom seamlessly from billion-year geological scales to individual seconds by following this forward `timeline → event → sub-timeline` chain. (Nesting is forward-only; the earlier event-to-event `parent_event_id` mechanism is deprecated — see §3.2 and the fractal-model callout.)
 
 **Hybrid Temporal System.** Structured JSONB date representation that extends beyond SQL date type limitations to support prehistoric, geological, and cosmological dates with precision metadata, uncertainty ranges, and scientific dating context.
 
@@ -316,8 +316,9 @@ CREATE TABLE events (
   location VARCHAR(2000),
   spatial_data JSONB,
   importance INTEGER DEFAULT 5 CHECK (importance BETWEEN 1 AND 10),
-  parent_event_id UUID REFERENCES events(id) ON DELETE CASCADE,
-  timeline_id UUID REFERENCES timelines(id) ON DELETE SET NULL,
+  parent_event_id UUID REFERENCES events(id) ON DELETE CASCADE,  -- DEPRECATED (#180): event-to-event nesting; superseded by detail_timeline_id
+  timeline_id UUID REFERENCES timelines(id) ON DELETE SET NULL,  -- primary containing timeline (RLS source)
+  detail_timeline_id UUID REFERENCES timelines(id) ON DELETE SET NULL,  -- PENDING (#177): the sub-timeline this event expands into (forward fractal drill-down)
   metadata JSONB DEFAULT '{}',
   search_vector TSVECTOR GENERATED ALWAYS AS (
     to_tsvector('english'::regconfig,
@@ -337,13 +338,24 @@ CREATE UNIQUE INDEX events_slug_idx ON events (user_id, slug);
 > **Key changes from prior schema:**
 >
 > - Renamed from `historical_events` to `events`. The table name `historical_events` created awkward FK names (`historical_event_id`) throughout the entire schema. In a greenfield build, brevity wins.
-> - Added `parent_event_id` self-reference for fractal nesting.
+> - ~~Added `parent_event_id` self-reference for fractal nesting.~~ **Deprecated (#180).** Fractal nesting is now forward-only via `detail_timeline_id` → sub-timeline (#177); see the fractal-model callout below. `parent_event_id` is being tombstoned (no data uses it) and dropped in a later migration.
 > - Added `event_type` with CHECK constraint.
 > - Added `spatial_data JSONB` alongside the free-form `location` string.
 > - Added `search_vector` as a generated column.
 > - `importance` is now a 1–10 integer with CHECK constraint rather than unconstrained.
 > - Temporal data is JSONB from day one — no VARCHAR date columns.
 > - Both start and end dates have their own `temporal_data`/`sort_order` pair, rather than embedding end dates inside the start temporal JSONB. This is cleaner for range queries.
+
+**The event ↔ timeline model (canonical).** An event relates to timelines along two axes — _containment_ ("which timeline shows this event") and _decomposition_ ("what does this event expand into"). These are distinct and must not be conflated:
+
+| Mechanism                    | Axis              | Meaning                                                                                                                                                                                                                      |
+| ---------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `events.timeline_id`         | containment       | The event's **primary / home** timeline. **This is the RLS source** — `read_events` / `update_events` derive collaborator access from it (§9), and `idx_events_timeline_sort` is built on it. One event → one home timeline. |
+| `timeline_events` junction   | containment       | **Additional** "also appears in" timelines (e.g. an event surfaced in a comparative timeline). Many-to-many; carries `sort_order` for editorial arrangement (§3.4). Does **not** affect RLS.                                 |
+| `events.detail_timeline_id`  | decomposition     | The **sub-timeline this event expands into** — the forward fractal drill-down. One event → one sub-timeline. `ON DELETE SET NULL`. Pending migration #177.                                                                   |
+| ~~`events.parent_event_id`~~ | ~~decomposition~~ | **Deprecated (#180).** Event-to-event nesting — redundant with, and weaker than, `detail_timeline_id`. Being tombstoned and dropped.                                                                                         |
+
+**Nesting is forward-only.** The hierarchy is `timeline → events → (event expands into) sub-timeline → events`, recursing on the timeline — not a backward `parent_event_id` tree. This preserves the committed event RLS untouched (access is keyed on the _containing_ `timeline_id`, never on the _child_ `detail_timeline_id`), eliminates the cross-timeline parent-link integrity holes `parent_event_id` permits, and keeps reads to one bounded query per zoom level. The forward model is the IA spec across the admin wireframes (`docs/design/admin/`).
 
 #### stories
 
@@ -527,7 +539,9 @@ All junction tables use composite primary keys, no surrogate `id`, no `user_id`.
 > Applied to `character_media` via migration `00012` (issue #125). If `event_media` or `timeline_media`
 > later grow a primary flag, apply the same pattern.
 
-> **Self-referential FK cycles:** `parent_event_id`, `parent_period_id`, and `parent_category_id` are unconstrained at the database level — cycles (A → B → A) are accepted by PostgreSQL. Cycle prevention is enforced in the service layer during create/update operations (#29, #31, #59, #60); the database intentionally does not attempt to detect cycles via constraints.
+> **Self-referential FK cycles:** `parent_period_id` and `parent_category_id` are unconstrained at the database level — cycles (A → B → A) are accepted by PostgreSQL. Cycle prevention is enforced in the service layer during create/update operations (#31, #59, #60); the database intentionally does not attempt to detect cycles via constraints. (`parent_event_id` formerly belonged to this set but is deprecated — #180.)
+>
+> **Fractal-decomposition cycles:** the forward fractal mechanism `events.detail_timeline_id` → timeline can also form a cycle (an event expands into a timeline that, transitively, contains the event itself). Like the self-FK cases, this is **not** DB-constrained — the service layer rejects an `detail_timeline_id` assignment that would close such a loop (#177). The `detail_timeline_id` FK is `ON DELETE SET NULL`, so deleting a sub-timeline detaches the drill-down rather than cascading into the parent event.
 
 ```sql
 -- Events ↔ Categories
@@ -561,10 +575,13 @@ CREATE TABLE event_characters (
   PRIMARY KEY (event_id, character_id)
 );
 
--- Timelines ↔ Events
+-- Timelines ↔ Events — ADDITIONAL ("also appears in") membership, distinct from
+-- the primary events.timeline_id home (see the event ↔ timeline model in §3.2).
+-- Does not affect RLS. sort_order added in migration 00012 (#122).
 CREATE TABLE timeline_events (
   timeline_id UUID REFERENCES timelines(id) ON DELETE CASCADE,
   event_id UUID REFERENCES events(id) ON DELETE CASCADE,
+  sort_order INTEGER DEFAULT 0,  -- editorial ordering; default 0 ⇒ fall back to events.sort_order_start (chronological)
   PRIMARY KEY (timeline_id, event_id)
 );
 
@@ -1347,10 +1364,13 @@ CREATE INDEX idx_char_rels_char ON character_relationships (character_id);
 CREATE INDEX idx_char_rels_related ON character_relationships (related_character_id);
 CREATE INDEX idx_timeline_events_event ON timeline_events (event_id);
 
--- Parent lookups (fractal nesting)
-CREATE INDEX idx_events_parent ON events (parent_event_id);
+-- Parent lookups (hierarchy)
+CREATE INDEX idx_events_parent ON events (parent_event_id);  -- DEPRECATED (#180): dropped with the column
 CREATE INDEX idx_periods_parent ON periods (parent_period_id);
 CREATE INDEX idx_categories_parent ON categories (parent_category_id);
+
+-- Forward fractal drill-down reverse lookup ("which event details this timeline?") — PENDING (#177)
+CREATE INDEX idx_events_detail_timeline ON events (detail_timeline_id) WHERE detail_timeline_id IS NOT NULL;
 ```
 
 ### 8.2 Performance Strategies
@@ -1487,6 +1507,8 @@ Policies in §9.2.1, §9.2.2, and §9.2.4 call the SECURITY DEFINER helpers intr
 **Global-read carve-out for organizational tables.** Three tables intentionally use `USING (true)` on SELECT and are reachable by `anon`: `categories` and `media` (organizational metadata — access control is enforced on the parent entity that references them), and `profiles` (public-display data such as username, avatar, bio). These carve-outs are deliberate exceptions to the "anonymous users read only published content" rule and are documented per-table below.
 
 #### 9.2.1 Content Tables with Timeline Association (events)
+
+Event collaborator access derives from the **containing** timeline (`events.timeline_id`) — never from the drill-down `events.detail_timeline_id` or the `timeline_events` guest junction. A sub-timeline's collaborators do not gain access to the parent event through the fractal link; access flows the other way (from the home timeline down to its events). See the event ↔ timeline model in §3.2.
 
 ```sql
 ALTER TABLE events ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## What this is

The design pass for **Phase 4 / milestone 5** (timeline & event management, issues #42–#50). This is **docs only** — fidelity-1 wireframes + spec updates, no app code. It locks the IA and the data model before implementation begins.

## New wireframes (`docs/design/admin/02-wireframes/`)

| # | Screen | Issue |
|---|---|---|
| 11 | Timelines list | #42 |
| 12 | Timeline editor | #43 |
| 13 | Timeline detail (events / periods / collaborators / media tabs) | #44 |
| 14 | Collaborator management | #50 |
| 15 | Media management (upload + external embed, cross-cutting) | #49 |
| 16 | Publish/unpublish workflow (cross-cutting) | #48 |

Event surfaces (#45/#46/#47) were already designed (07/08/09) and are **reframed** here, not rebuilt.

## The headline decision: a forward fractal model

The schema exposed several event↔timeline relationships that were undocumented and ambiguous. This pass resolves them into a **forward, timeline-as-recursion-unit** model:

- `events.timeline_id` — the event's **home** timeline (RLS source) · containment
- `timeline_events` — **guest** appearances in other/comparative timelines (has `sort_order`) · containment
- `events.detail_timeline_id` *(new, #177)* — the **sub-timeline an event expands into** · decomposition
- ~~`events.parent_event_id`~~ — **retired (#180)**; event-to-event nesting was a redundant backward reflection

Nesting is forward-only: `timeline → events → (event expands into) sub-timeline → events`. This preserves the committed event RLS untouched, eliminates cross-timeline parent-link integrity holes, and fits per-level bounded fetch at cosmic scale. Full rationale in the commit and in `00-screen-inventory.md` → Milestone 5 additions.

## Other resolved decisions

- Many-to-many membership kept (home + guest); chronological + editorial event ordering; periods tab as a read-only stub (Phase 6); visibility vs. publication kept strictly orthogonal; collaborator lookup by `profiles.username`; media = hybrid upload + external embed, no standalone library.

## Spec sync

`docs/system-design.md` §1.2 / §3.2 / §3.4 / §8 / §9 now documents the canonical event↔timeline model, brings the `events` and `timeline_events` DDL current (`detail_timeline_id`, `timeline_events.sort_order`), and records the `parent_event_id` deprecation.

## Tracking issues filed during the pass

- **#177** — add `events.detail_timeline_id` (forward drill-down). Blocks the fractal affordances.
- **#179** — `media.storage_path NOT NULL` + no upload/external discriminator; blocks #49 external embeds.
- **#180** — deprecate `events.parent_event_id` (no data migration; gated on #177).
- ~~#178~~ — closed invalid (`timeline_events.sort_order` already exists, migration 00012).

## Scope / non-goals

Docs only; no implementation. `package.json` / lockfiles were intentionally left out of this commit (unrelated working-tree changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)