### PR TITLE
docs(admin): stories, periods & categories UI design (milestone 7)

### DIFF
--- a/docs/design/admin/00-screen-inventory.md
+++ b/docs/design/admin/00-screen-inventory.md
@@ -87,13 +87,40 @@ Phase 5 (GitHub milestone 6) is the characters & relationships build. The charac
 - **[#179](https://github.com/shaes-farm/time-traveler/issues/179)** — (already filed in M5) `media.storage_path NOT NULL` + no upload/external discriminator. Screen 17's _Source_ filter and kind badge are **blocked** on it; the wireframe documents a `storage_path IS NULL` stopgap and carries `// BLOCKED` notes.
 - **PRD §7.2.2 era-palette reconciliation (resolved)** — the shipped era tokens (hue-spread for colorblind separation) superseded the PRD's clustered blue/amber/brown/green/purple set. Handled like the [#127](https://github.com/shaes-farm/time-traveler/issues/127) reconciliation, but **fixed directly**: PRD §7.2.2 was rewritten in place to the finalized hue-spread palette and now points at the token files as source of truth. No separate issue filed.
 
+## Milestone 7 additions (Phase 6 — Stories, Categories & Periods)
+
+Phase 6 (GitHub milestone 7, issues #58–#64) is the stories / categories / periods build. **The data layer already exists** — `story-service` / `category-service` / `period-service` (full CRUD + junctions, incl. `getCategoryTree`, `getChildPeriods`, story↔event/character/period linking), the `use-stories|categories|periods` hooks, and the Zustand `ui-store`/`navigation-store`. So #58–#61 are **verify/harden** tickets, not net-new builds; #62/#63/#64 are the UI, designed here for the first time (these three were "not in scope" through M5/M6). The batch references the **finalized M6 visual language** ([03-aesthetic-notes.md](03-aesthetic-notes.md)) rather than deferring it.
+
+| #   | Screen              | Purpose                                                                                              | Issue | Wireframe                                                                          |
+| --- | ------------------- | ---------------------------------------------------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------- |
+| 18  | Stories list        | Narrator/perspective/tag/published filters; perspective character via type identity                  | #62   | [02-wireframes/18-stories-list.md](02-wireframes/18-stories-list.md)               |
+| 19  | Story editor        | Narrative shell: voice (`narrator_type` + perspective character), prose, tags, publish toggle        | #62   | [02-wireframes/19-story-editor.md](02-wireframes/19-story-editor.md)               |
+| 20  | Story detail        | **Narrative event ordering** (drag, `story_events.sort_order`), character roles, period associations | #62   | [02-wireframes/20-story-detail.md](02-wireframes/20-story-detail.md)               |
+| 21  | Periods list        | Chronological + hierarchical (significance ramp, era display, nesting indicator)                     | #64   | [02-wireframes/21-periods-list.md](02-wireframes/21-periods-list.md)               |
+| 22  | Period editor       | Span (TemporalInput), significance, characteristics, parent-period hierarchy                         | #64   | [02-wireframes/22-period-editor.md](02-wireframes/22-period-editor.md)             |
+| 23  | Period detail       | **Span-overlay**: hierarchy + overlaid timelines (`period_timelines`) + computed events-in-range     | #64   | [02-wireframes/23-period-detail.md](02-wireframes/23-period-detail.md)             |
+| 24  | Category management | Taxonomy tree + inspector: create/edit (color/icon/parent), delete with child policy, reparent       | #63   | [02-wireframes/24-category-management.md](02-wireframes/24-category-management.md) |
+
+### Milestone 7 design decisions (resolved)
+
+- **Story event ordering is editorial** — `story_events` gains a `sort_order` ([#183](https://github.com/shaes-farm/time-traveler/issues/183)) so a story can be told out of chronological order (flashbacks, thematic grouping). Story detail (20) gets drag-to-reorder; until #183 lands it falls back to chronological. Mirrors the `timeline_events`/00012 treatment.
+- **Periods are span-overlays, not event containers** — a period overlays timelines (`period_timelines`) and gathers events **by date** (computed events-in-range on screen 23); there is **no `period_events` junction**. This draws the IA line: **timelines contain curated events; periods band timelines and collect events by date; an `event_type='period'` event is a discrete span event** — three distinct things.
+- **Categories tag events only** this pass (`event_categories`); broader attachment (characters/timelines/periods/stories) is deferred. Assignment lives in the event editor; screen 24 owns the taxonomy tree.
+- **Hierarchy axes kept** — `parent_period_id` (periods) and `parent_category_id` (categories) are genuine containment trees (Mesozoic ⊃ Jurassic; Science ⊃ Physics) and are retained, in contrast to the retired event `parent_event_id` ([#180](https://github.com/shaes-farm/time-traveler/issues/180)). Cycle prevention is service-layer for both.
+- **Publish applies to stories + periods** (both have `published`); **categories are not publishable** (taxonomy, no `published` column).
+- **Nav/IA** — Stories and Periods join the sidebar as primary entities; Categories is a lighter management surface (taxonomy tree). No media surfaces in any M7 screen (no `story_media`/`period_media`/`category_media` junctions).
+
+### Upstream issues filed in this batch
+
+- **[#183](https://github.com/shaes-farm/time-traveler/issues/183)** — add `story_events.sort_order` for editorial narrative ordering. Story detail's drag-reorder (screen 20, #62) is **blocked** on it; chronological fallback until then. No other schema changes — periods (span-overlay) and categories (events-only) match the current schema as-is.
+
 ## What's deliberately not in scope this pass
 
-> Three items below moved **into scope** in the [Milestone 5 additions](#milestone-5-additions) batch (screens 11–16): timelines CRUD, media management, and collaborator management. They remain listed here, struck, for historical continuity.
+> Items below moved **into scope** in later batches: timelines/media/collaborators in [Milestone 5](#milestone-5-additions) (screens 11–16), the media library in [Milestone 6](#milestone-6-additions-phase-5--characters--relationships) (screen 17), and stories/periods/categories in [Milestone 7](#milestone-7-additions-phase-6--stories-categories--periods) (screens 18–24). They remain listed here, struck, for historical continuity.
 
-- ~~Timelines~~, periods, stories CRUD — timelines now covered (screens 11–13); periods + stories still excluded
-- ~~Media library~~ — media management covered as a cross-cutting surface (screen 15); the standalone reusable library browser + picker is **now designed** (screen 17, Milestone 6 batch)
-- Categories management — still deferred
+- ~~Timelines, periods, stories CRUD~~ — all now covered (timelines 11–13, periods 21–23, stories 18–20)
+- ~~Media library~~ — media management covered as a cross-cutting surface (screen 15); the standalone reusable library browser + picker is designed (screen 17, Milestone 6 batch)
+- ~~Categories management~~ — now covered (screen 24, Milestone 7 batch)
 - Bulk import / export — these are Edge Function flows that need their own design pass
 - Admin moderation queue (`content_reports`) — admin-role-only surface, separate audience
 - Notifications inbox — needs a separate IA pass

--- a/docs/design/admin/01-user-flows.md
+++ b/docs/design/admin/01-user-flows.md
@@ -143,6 +143,55 @@ Persona: Author taking a finished biography live.
 
 Edge cases: a collaborator-editor sees no Publish control (publishing is owner-only); unpublishing clears `published_at` to NULL and narrows RLS read access on the next request.
 
+## Milestone 7 flows — Stories, periods, categories
+
+Three flows for the Phase 6 build (screens 18–24). The data layer (services/hooks/stores) already exists; these exercise the new UI and the resolved model decisions.
+
+## Flow J — Author a story and order its events narratively
+
+Persona: Storyteller writing "The Curies' Quest," a third-person telling that opens in media res.
+
+1. From the **Stories list**, click **New story**.
+2. **Story editor** opens. User enters title + sub-title, picks `narrator_type = third_person`, sets perspective character "Marie Curie" (rendered with her human type identity). Writes the summary + Markdown narrative; adds tags `tragedy`, `triumph`. Saves → redirect to **story detail**.
+3. On **story detail → Events tab**, user clicks **+ Add event** and links the Curie events. Each lands at the end of the list.
+4. User **drags (`⠿`) to set narrative order** — putting "Leaving Poland (1891)" _after_ "Discovery of polonium (1898)" as a flashback. The row shows order-index 6 but date 1891, so the non-chronological telling stays legible. This writes `story_events.sort_order` ([#183](https://github.com/shaes-farm/time-traveler/issues/183)).
+5. On the **Characters tab**, user assigns roles (`protagonist` for Marie + Pierre, `supporting` for Becquerel). On **Periods**, associates the "Belle Époque" period.
+6. User publishes from the detail header (owner-only; confirm dialog).
+
+Edge cases:
+
+- **Blocked on [#183](https://github.com/shaes-farm/time-traveler/issues/183).** Until `story_events.sort_order` ships, events render chronologically and the drag handle is hidden — the rest of the flow works.
+- **First-person without perspective character** is blocked at save (Flow's voice is third-person here, so N/A).
+- An event linked here is only _referenced_ — it keeps its home timeline and can appear in other stories with a different order/interpretation (PRD §4.6.3).
+
+## Flow K — Build a period hierarchy and overlay it on a timeline
+
+Persona: Paleontologist structuring deep time.
+
+1. From the **Periods list**, create "Mesozoic Era" (252–66 MYA, significance `critical`, characteristics `reptiles`, `warm climate`). Save → period detail.
+2. Create "Jurassic" (201–145 MYA); in the editor, set **Parent period = Mesozoic Era** (the picker shows Mesozoic's range so the child span can be sanity-checked; it excludes Mesozoic's descendants to prevent cycles).
+3. On **Jurassic detail**, the breadcrumb reads `Mesozoic Era ▸ Jurassic`; the Hierarchy panel shows the parent.
+4. On the **Overlaid timelines tab**, user clicks **+ Overlay a timeline** and adds "Evolution of life on Earth" (`period_timelines`).
+5. The **Events in range tab** now lists events whose dates fall within 201–145 MYA — **computed by date, scoped to the overlaid timeline** — without anyone linking events to the period (span-overlay model; no `period_events`).
+
+Edge cases:
+
+- **Child span outside parent range** → soft, non-blocking warning (period bounds are sometimes fuzzy).
+- **Deleting Mesozoic** cascades to its child periods (`ON DELETE CASCADE`); the Danger-zone confirm states the blast radius (events/timelines unaffected — the period only overlaid them).
+
+## Flow L — Organize the category taxonomy
+
+Persona: Archivist tidying tags.
+
+1. From **Categories**, the tree shows roots (Science, War, Art). User expands **Science → Physics** and clicks **+ Add child** under Physics, creating "Quantum Mechanics" with a color + icon.
+2. User realizes "Relativity" is mis-filed under War; selects it and changes **Parent → Physics** in the inspector (the picker excludes Relativity's own descendants — cycle prevention). The subtree moves.
+3. User deletes the redundant "Misc" category. Because it has children and tagged events, the **delete policy dialog** appears: blast radius ("2 child categories, 7 events"), with **Reparent children first** (recommended) vs. **Delete subtree**. User reparents to root, then deletes only "Misc."
+
+Edge cases:
+
+- Categories tag **events only** this pass; assignment happens in the event editor, not here.
+- No publish state — categories are taxonomy, always live for their owner.
+
 ## What these flows do not cover
 
 - Bulk operations (multi-select delete, bulk publish, bulk export). Reserved for a later pass.

--- a/docs/design/admin/02-wireframes/00-app-shell.md
+++ b/docs/design/admin/02-wireframes/00-app-shell.md
@@ -11,7 +11,7 @@
 
 ## Primary actions
 
-- Navigate to any top-level entity list (Characters, Events; later: Timelines, Periods, Stories, Media, Categories)
+- Navigate to any top-level entity list (Characters, Events, Timelines, Periods, Stories, Media, Categories — all now designed across Milestones 5–7)
 - Open user menu (profile, sign out, theme toggle)
 - Open global search (`Cmd+K` / `Ctrl+K`)
 - Open quick-create menu (`C` keyboard shortcut, opens command palette pre-filtered to "create...")
@@ -28,13 +28,13 @@
 │  Content     │                                                               │
 │  ▸ Characters│                                                               │
 │  ▸ Events    │              [ screen content goes here ]                     │
-│  ─ Timelines │                                                               │
-│  ─ Periods   │                                                               │
-│  ─ Stories   │                                                               │
+│  ▸ Timelines │                                                               │
+│  ▸ Periods   │                                                               │
+│  ▸ Stories   │                                                               │
 │              │                                                               │
 │  Library     │                                                               │
-│  ─ Media     │                                                               │
-│  ─ Categories│                                                               │
+│  ▸ Media     │                                                               │
+│  ▸ Categories│                                                               │
 │              │                                                               │
 │  ─ Settings  │                                                               │
 │              │                                                               │
@@ -45,7 +45,7 @@
 
 ## Annotations
 
-1. **Sidebar nav uses two visual states**: active (filled marker `▸`), inactive (dim marker `─`). Out-of-scope entities are dimmed but still present, so the IA reads complete even in this first pass.
+1. **Sidebar nav uses two visual states**: active (filled marker `▸`), inactive (dim marker `─`). All primary entities — Characters, Events, Timelines, Periods, Stories, Media, Categories — are now designed (Milestones 5–7) and render active; only Settings remains a dim placeholder. The two-state convention persists for any future out-of-scope additions.
 2. **Sidebar grouping reflects the data model**, not arbitrary product sections: "Content" for entities the user authors as primary work, "Library" for organizational resources, "Settings" alone at the bottom.
 3. **Topbar global search** opens a command palette ([Cmd+K]) that searches across all four searchable entity types (events, characters, stories, timelines — backed by their `search_vector` columns). Results group by entity type.
 4. **Quick-create button** (⊕) opens the same command palette pre-filtered to "Create…". This is the primary way to start a new entity from anywhere.

--- a/docs/design/admin/02-wireframes/18-stories-list.md
+++ b/docs/design/admin/02-wireframes/18-stories-list.md
@@ -1,0 +1,74 @@
+# 18 — Stories List
+
+**Purpose.** Find and triage stories. A story is a **narrative layer over events** — not a container of data but an interpretation of it, with a perspective and a cast. Authors here are writers managing several tellings; the list optimizes for "which story was I writing" and "what's still a draft."
+
+## Data shown
+
+- Per story: title, `sub_title`, `narrator_type`, perspective character (with type identity), event count, character count, tags (truncated), published state, `updated_at`
+- Total count + filtered count
+- Sort + filter state
+
+## Primary actions
+
+- Search (title, sub_title, summary, detail — backed by `stories.search_vector` GIN)
+- Filter by `narrator_type` (`first_person|third_person|omniscient`), published state, tag, perspective character
+- Sort by `title`, `updated_at` (default), `created_at`
+- Create new story (top-right + shortcut)
+- Click row → story detail
+- Bulk multi-select for publish/unpublish/delete
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Stories                                                  [ + New story ]    │
+│  9 total · 6 shown                                                           │
+│                                                                              │
+│  ┌─────────────────┐  ┌────────────────────────────────────────────────────┐  │
+│  │ Filter          │  │ ⌕ Search title, summary, detail…                   │  │
+│  │                 │  │                                                    │  │
+│  │ Narrator        │  │ ┌──────────────────────────┬───────────┬────┐     │  │
+│  │ ☐ First-person 3│  │ │ Title                    │ Narrator  │Pub │     │  │
+│  │ ☐ Third-person 4│  │ ├──────────────────────────┼───────────┼────┤     │  │
+│  │ ☐ Omniscient  2 │  │ │ The Curies' Quest        │ 3rd-person│ ✓  │     │  │
+│  │                 │  │ │ A radium love story      │           │    │     │  │
+│  │ Perspective     │  │ │ 👤 Marie Curie · 8 ev·3ch│           │    │     │  │
+│  │ ▾ Any character │  │ ├──────────────────────────┼───────────┼────┤     │  │
+│  │                 │  │ │ Fall of Rome             │ Omniscient│ ✓  │     │  │
+│  │ Status          │  │ │ 14 ev · 9 ch             │           │    │     │  │
+│  │ ☐ Published   6 │  │ │ tragedy · war            │           │    │     │  │
+│  │ ☐ Draft       3 │  │ ├──────────────────────────┼───────────┼────┤     │  │
+│  │                 │  │ │ My Grandfather's War     │ 1st-person│ ─  │     │  │
+│  │ Tags            │  │ │ 👤 Étienne (narrator)    │           │draft│    │  │
+│  │ [ war ×]        │  │ │ 5 ev · 2 ch              │           │    │     │  │
+│  │ [ + tag ]       │  │ └──────────────────────────┴───────────┴────┘     │  │
+│  │                 │  │                                                    │  │
+│  │ Clear filters   │  │ ⟨ 1  ⟩                          Sort: Updated ▾    │  │
+│  └─────────────────┘  └────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Same left-rail + two-line-row list pattern** as characters/events/timelines ([03](03-characters-list.md), [07](07-events-list.md), [11](11-timeline-list.md)). Don't reinvent a fourth list idiom.
+2. **`narrator_type` is a column + filter**, three values (`first_person|third_person|omniscient`). It's identity-level for a story (the narrative voice), so it sits beside the title like character_type does for characters.
+3. **Perspective character renders with the finalized type identity** — the `perspective_character_id` shows as `👤 Name` using the character-type icon + tint from [03-aesthetic-notes.md](../03-aesthetic-notes.md) § _Character type as identity_. For `first_person` stories it carries a `(narrator)` qualifier. Stories with no perspective character (common for omniscient) omit the chip.
+4. **Counts on line 2** — `N ev · M ch` (events via `story_events`, characters via `story_characters`). Deferred-tolerant like the timelines list: render without them if the count contract isn't wired.
+5. **Tags** (the `tags TEXT[]` column) render on line 3 when present, and double as a filter (chip-input in the rail). Tags are free-form (genre/thematic/geographic per PRD §4.6.6), distinct from Categories (which don't attach to stories — see [24-category-management.md](24-category-management.md)).
+6. **Status uses the finalized `StatusBadge`** (Published ✓ emerald / Draft ─ zinc / Shared ⇄ blue) — stories are publishable (`published`/`published_at`). See [16-publish-workflow.md](16-publish-workflow.md) and [03-aesthetic-notes.md](../03-aesthetic-notes.md) § _Status badges_.
+7. **Sort default is `updated_at` desc** — stories are work surfaces (like timelines), so "what I touched last" wins over alphabetical.
+8. **No temporal column.** A story has no intrinsic date — its temporal footprint is derived from the events/periods it references. Surfacing a computed span here is deferred (Open Questions); the detail page is where temporal context lives.
+
+## Edge cases
+
+- **Empty list (zero stories).** Whole-panel empty state: "No stories yet. A story is a telling — your interpretation of events, from a point of view." Single CTA: **New story**.
+- **Filtered to zero.** Inline empty state + Clear filters.
+- **Story with no events/characters yet.** Counts render `0 ev · 0 ch`; the row is still valid (a story can be drafted before it's populated).
+- **Long titles / many tags.** Truncate title at row width (hover for full); tags truncate to 2 + `+N`.
+- **Bulk multi-select.** Sticky action bar: `2 selected · [Publish] [Unpublish] [Delete] [Cancel]`.
+- **Loading.** Skeleton rows; filter rail renders immediately.
+
+## Open questions
+
+- **Computed temporal span column** (min–max of referenced events' `sort_order_years`). Useful for scanning, but adds a per-row aggregate query; deferred until the count contract proves cheap. Tier 4.
+- **Filter by referenced event/character** — a `?character=` / `?event=` query param could drive "stories featuring X" without a rail control, mirroring the events-list deferral. Documented as future polish.

--- a/docs/design/admin/02-wireframes/19-story-editor.md
+++ b/docs/design/admin/02-wireframes/19-story-editor.md
@@ -1,0 +1,83 @@
+# 19 — Story Editor
+
+**Purpose.** Create or edit a story's narrative shell — voice, perspective, prose, tags. Like the timeline editor ([12](12-timeline-editor.md)), it owns only the row fields; the **associations that make a story (events, characters, periods) are managed on the [story detail](20-story-detail.md) page** after the story exists, because event _ordering_ (the heart of a story) needs the populated detail surface.
+
+## Data captured
+
+All `stories` row columns except generated (`search_vector`) and timestamps:
+
+- `title` (required)
+- `sub_title`
+- `slug` (auto-generated)
+- `summary`
+- `detail` (long-form narrative, Markdown)
+- `narrator_type` (`first_person|third_person|omniscient`)
+- `perspective_character_id` (FK `ON DELETE SET NULL`; conditional emphasis for first-person)
+- `tags` (`TEXT[]`, chip input)
+- `published` (toggle; canonical action on detail — see [16-publish-workflow.md](16-publish-workflow.md))
+
+## Primary actions
+
+- Save (create → `useCreateStory`; edit → `useUpdateStory`)
+- Cancel / discard (unsaved-changes guard)
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Stories ▸ New story                                 [ Cancel ] [ Save ]     │
+│                                                          Draft saved 4:20 PM │
+│  ┌─────────────────────────────────────┬──────────────────────────────────┐  │
+│  │  Identity                           │  Slug                            │  │
+│  │  ───────────────────────────────    │  the-curies-quest   [ edit slug ]│  │
+│  │  Title *                            │                                  │  │
+│  │  [ The Curies' Quest          ]     │  Narrative voice                 │  │
+│  │  Sub-title                          │  ───────────────────────────     │  │
+│  │  [ A radium love story        ]     │  Narrator                        │  │
+│  │                                     │  [ Third-person            ▾]    │  │
+│  │  Summary                            │                                  │  │
+│  │  ┌─────────────────────────────┐    │  Perspective character           │  │
+│  │  │ One-paragraph hook…         │    │  [ Marie Curie  👤         ▾]    │  │
+│  │  └─────────────────────────────┘    │   ⓘ whose eyes we see through    │  │
+│  │                                     │     (required for first-person)  │  │
+│  │  Detail (narrative)                 │                                  │  │
+│  │  ┌─────────────────────────────┐    │  Published                       │  │
+│  │  │ Full narrative, Markdown…   │    │  ◯ Draft (publish from detail)   │  │
+│  │  │                             │    │                                  │  │
+│  │  │                             │    │                                  │  │
+│  │  └─────────────────────────────┘    │                                  │  │
+│  │                                     │                                  │  │
+│  │  Tags                               │                                  │  │
+│  │  [ tragedy ×] [ war ×] [ + tag ]    │                                  │  │
+│  └─────────────────────────────────────┴──────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Same two-column editor shell** as the timeline/character/event editors. Left: narrative content. Right: voice + identity metadata. Slug behavior matches the others ([05](05-character-editor.md) annotation #3): live debounced regen on create, locked-with-unlock on edit; uniqueness `(user_id, slug)` via `stories_slug_idx`.
+2. **Narrator + perspective character are the story's defining choice**, so they sit together in a "Narrative voice" block on the right rail. `narrator_type` is a three-value select.
+3. **Perspective character is conditional in emphasis, not presence.** Per PRD §4.6.2, when `narrator_type = first_person` the `perspective_character_id` _should_ be set (whose eyes) and the field is required; for third-person/omniscient it's optional (it can still mark a focal character). The picker is a searchable combobox over the user's characters, rendering the **finalized character-type identity** (icon + tint, [03-aesthetic-notes.md](../03-aesthetic-notes.md) § _Character type as identity_). FK is `ON DELETE SET NULL` — a deleted character just clears the field.
+4. **`detail` is the long-form narrative** (Markdown per PRD §4.6.1), given a tall textarea — this is the one editor where prose is the primary content, not metadata. `summary` is the short hook.
+5. **Tags are a chip input** over the `tags TEXT[]` column (genre/thematic/geographic, PRD §4.6.6). Free-form — **not** Categories (categories don't attach to stories this pass; see [24-category-management.md](24-category-management.md)). Same chip pattern as character aliases ([05](05-character-editor.md) annotation #5).
+6. **Publish is a Draft toggle here; the canonical publish lives on detail** — same rationale as the timeline editor ([12](12-timeline-editor.md) annotation #5): you usually publish a story after arranging its events. Uses `StatusBadge` semantics ([16-publish-workflow.md](16-publish-workflow.md)).
+7. **No event/character/period association in this editor.** Those live on [story detail](20-story-detail.md) — event ordering especially needs the populated surface. On successful create, redirect to detail (where the author immediately starts adding events).
+8. **Auto-save to draft every 30s** + **unsaved-changes guard**, identical to the other editors (PRD §7.11.3).
+
+## Save flow
+
+1. Validate client-side (Zod): `title` required; `narrator_type` in enum; `perspective_character_id` required when `first_person`.
+2. `useCreateStory` / `useUpdateStory` (optimistic).
+3. On success, redirect to **story detail** (`/stories/[slug]`).
+
+## Edge cases
+
+- **First-person without a perspective character.** Hard validation error: "First-person stories need a perspective character (whose eyes)." Save blocked until set or voice changed.
+- **Switching `first_person` → omniscient with a perspective set.** Keep the value (it's still a valid focal character) but drop the "required" treatment; no destructive clear.
+- **Perspective character later deleted.** FK `ON DELETE SET NULL`; detail/editor show an empty picker on next open.
+- **Slug collision.** Caught via `stories_slug_idx`; `resolveCollision` appends a suffix, surfaced inline.
+
+## Open questions
+
+- **Markdown preview / rich editor** for `detail` — out of scope this pass (plain textarea + Markdown, consistent with other long-form fields). Revisit if authors ask. Tier 4.
+- **"Save and add another"** — less useful for stories than events (you don't bulk-create tellings); omitted unless demand surfaces.

--- a/docs/design/admin/02-wireframes/20-story-detail.md
+++ b/docs/design/admin/02-wireframes/20-story-detail.md
@@ -1,0 +1,102 @@
+# 20 — Story Detail
+
+**Purpose.** Read + manage a single story. This is the authoring workspace where a story becomes a _telling_: the narrative prose, the **ordered sequence of events** (the heart of it), the cast with their roles, and the periods it spans. The event-ordering surface is why associations live here, not in the editor.
+
+## Data shown
+
+- Identity: title, sub_title, slug, `narrator_type`, perspective character (type identity)
+- Narrative: summary, detail (rendered Markdown)
+- `published` state, timestamps, tags
+- **Events** in narrative order (`story_events` + `sort_order`, [#183](https://github.com/shaes-farm/time-traveler/issues/183))
+- **Characters** with `role_in_story` (`story_characters`)
+- **Periods** the story spans (`story_periods`)
+
+## Primary actions
+
+- Edit story (→ [19-story-editor.md](19-story-editor.md))
+- Publish / unpublish (header; owner-only — [16-publish-workflow.md](16-publish-workflow.md))
+- Delete (danger zone)
+- Add / reorder / remove events; add / re-role / remove characters; add / remove periods
+- Navigate to an event, character, or period
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Stories ▸ The Curies' Quest                         [Edit] [✓ Published ▾]   │
+│                                                                              │
+│  The Curies' Quest                                                           │
+│  A radium love story                                                         │
+│  Third-person · through 👤 Marie Curie · ✓ Published                         │
+│                                                                              │
+│  Summary                                                                     │
+│  ────────────────────────────────────────────────────────────────────────  │
+│  How two scientists turned grief and pitchblende into two Nobel Prizes.      │
+│                                                                              │
+│  ┌── Events (8) ──┬── Characters (3) ──┬── Periods (1) ──┐                   │
+│  ╞════════════════╧════════════════════╧═════════════════╡                   │
+│  │                                          [ + Add event ]                 │ │
+│  │  Narrative order · drag ⠿ to reorder                                     │ │
+│  │  ───────────────────────────────────────────────────────────────────   │ │
+│  │  ⠿ 1  1891 CE  Sklodowska arrives in Paris        milestone   ★7        │ │
+│  │  ⠿ 2  1895 CE  Marriage to Pierre Curie           ceremony    ★6        │ │
+│  │  ⠿ 3  1898 CE  Discovery of polonium              discovery   ★8        │ │
+│  │  ⠿ 4  1903 CE  Curies share Nobel in Physics      ceremony    ★9        │ │
+│  │  ⠿ 5  1906 CE  Pierre Curie killed                incident    ★10       │ │
+│  │  ⠿ 6  1891 CE  (flashback) Leaving Poland         milestone   ★5    [×] │ │
+│  │  ───────────────────────────────────────────────────────────────────   │ │
+│  │  8 events · narrative order (story_events.sort_order)                    │ │
+│  └────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ▸ Danger zone                                                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Header mirrors the other detail headers** ([08](08-event-detail.md)/[13](13-timeline-detail.md)): breadcrumb, title + `sub_title`, a voice metadata line (`narrator_type · through [perspective character]`), and `[Edit] [Publish ▾] [⋯]`. Perspective character uses the finalized type identity ([03-aesthetic-notes.md](../03-aesthetic-notes.md) § "Character type as identity"). Publish is the canonical owner-only control ([16-publish-workflow.md](16-publish-workflow.md)).
+2. **Rendered Markdown narrative** — `summary` then `detail`. This is the one detail page where prose dominates the overview; metadata is thin (it's all in the header).
+3. **Events tab is the centerpiece and is explicitly _ordered_.** Unlike the timeline detail Events tab (chronological by default), a story's events render in **narrative order** via `story_events.sort_order` ([#183](https://github.com/shaes-farm/time-traveler/issues/183)). The order index (`1, 2, 3…`) is shown, and the chronological date is shown alongside — so a **flashback reads as order-6 but dated 1891**, making non-chronological telling legible. Drag the `⠿` handle to reorder (rewrites `sort_order`).
+   - **Blocked on [#183](https://github.com/shaes-farm/time-traveler/issues/183):** until `story_events.sort_order` lands, events render chronologically (by `events.sort_order_years`), the order index and `⠿` drag handle are hidden, and the footer note reads "chronological (narrative ordering pending #183)."
+4. **`[ + Add event ]`** opens a searchable combobox over the user's events (same command-palette pattern as the timeline link-event picker, [13](13-timeline-detail.md) annotation #6). Adding inserts a `story_events` row at the end (`max(sort_order)+1`). Events keep their own home timeline and identity — a story _references_ events, it doesn't own them (an event can appear in many stories, PRD §4.6.3).
+5. **Event rows are read-mostly references** — date, type, importance (finalized importance ramp + era/`TemporalDisplay` per [03-aesthetic-notes.md](../03-aesthetic-notes.md)). `[×]` removes only the `story_events` link (the event is untouched). Clicking the title navigates to the event.
+6. **Characters tab — roles, not ordering.** `story_characters` with `role_in_story` (`protagonist|supporting|mentioned|narrator`). Each row: character (type identity) + an inline role select. Multiple characters can share a role (PRD §4.6.5). The `narrator` role pairs with first-person voice. `[ + Add character ]` opens a character picker.
+7. **Periods tab — span associations.** `story_periods` links the story to the eras it spans ("Age of Exploration" story ↔ "15th–17th Century Exploration" period, PRD §4.6.4). Simple add/remove (no ordering, no roles). Each period shows its span via `TemporalDisplay`. Links to [period detail](23-period-detail.md).
+8. **No media tab.** Stories have no `story_media` junction — media doesn't attach to stories this pass. (Media lives on events/characters/timelines via the [media library](17-media-library.md).)
+9. **Tabs lazy-load**; counts in labels.
+
+## Tab variations
+
+### Characters tab
+
+```
+  Characters (3)                                       [ + Add character ]
+  ───────────────────────────────────────────────────────────────────────
+  👤 Marie Curie       protagonist ▾                                  [×]
+  👤 Pierre Curie      protagonist ▾                                  [×]
+  👤 Henri Becquerel   supporting  ▾                                  [×]
+```
+
+### Periods tab
+
+```
+  Periods (1)                                          [ + Add period ]
+  ───────────────────────────────────────────────────────────────────────
+  ◷ Belle Époque   1871–1914 CE                                       [×]
+```
+
+## Edge cases
+
+- **404 / not found.** Lookup by `(user_id, slug)`; unresolved slug → 404 with link back to the stories list.
+- **Empty Events tab.** "No events in this story yet. A story is the order you tell them in." Single CTA (Add event).
+- **No characters / no periods.** Per-tab empty state with the add CTA.
+- **Reorder while #183 is open.** Reordering is disabled (no `sort_order`); the footer explains why and links #183.
+- **Removing a character with the `narrator` role on a first-person story.** Soft warning: "This is the narrator of a first-person story." Non-blocking (the perspective character on the story row is the canonical voice; this is a cast role).
+- **Permissions.** Stories are owner-scoped (no `timeline_collaborators` path); standard owner-or-admin edit/delete, read-only for others on published stories.
+- **Loading.** Skeleton header; tabs lazy-load with per-tab skeletons.
+
+## Open questions
+
+- **Reorder granularity** (#183 follow-up) — whether drag rewrites one row's `sort_order` or renumbers the set (sparse vs. dense). Fidelity-2 interaction detail.
+- **Story "reading" preview** — a read-only narrative view stitching `detail` + ordered events. That's closer to the public reader (out of admin scope); deferred.
+- **Bulk add events** (multi-select in the picker) — deferred, consistent with the timeline-detail bulk-link deferral.

--- a/docs/design/admin/02-wireframes/21-periods-list.md
+++ b/docs/design/admin/02-wireframes/21-periods-list.md
@@ -1,0 +1,75 @@
+# 21 — Periods List
+
+**Purpose.** Find and triage periods. A period is a **labeled temporal span** — an era/age/epoch — with significance and characteristic tags, **hierarchically nestable** (Mesozoic → Jurassic). The list optimizes for scanning the temporal structure: chronological by default, with nesting visible.
+
+## Data shown
+
+- Per period: title, span (`temporal_data`–`end_temporal_data` with era), `significance`, nesting indicator (parent/child), characteristic tags (truncated), overlaid-timeline count, published state
+- Total count + filtered count
+- Sort + filter state
+
+## Primary actions
+
+- Search (title — `periods` has **no `search_vector`**, so this is a `title ILIKE` match, not full-text; see annotation #6)
+- Filter by `significance` (`low|medium|high|critical`), era, published, nesting (`All` / `Top-level only` / `Nested only`), overlaid timeline
+- Sort by `sort_order_start` (default, chronological), title, `significance`, `updated_at`
+- Create new period (top-right + shortcut)
+- Click row → period detail
+- Bulk multi-select for publish/unpublish/delete
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Periods                                                  [ + New period ]   │
+│  23 total · 18 shown                                                         │
+│                                                                              │
+│  ┌─────────────────┐  ┌────────────────────────────────────────────────────┐  │
+│  │ Filter          │  │ ⌕ Search by title…                                 │  │
+│  │                 │  │                                                    │  │
+│  │ Significance    │  │ ┌──┬──────────────────────┬────────────┬─────┐    │  │
+│  │ ☐ Critical    3 │  │ │  │ Title                │ Span       │ Sig │    │  │
+│  │ ☐ High        7 │  │ ├──┼──────────────────────┼────────────┼─────┤    │  │
+│  │ ☐ Medium     10 │  │ │⌒ │ Mesozoic Era         │ 252–66 MYA │ ███ │    │  │
+│  │ ☐ Low         3 │  │ │  │ reptiles · warm      │            │ crit│    │  │
+│  │                 │  │ ├──┼──────────────────────┼────────────┼─────┤    │  │
+│  │ Show            │  │ │↳ │ Triassic             │ 252–201 MYA│ ██  │    │  │
+│  │ ◉ All           │  │ │  │ in Mesozoic Era      │            │ high│    │  │
+│  │ ◯ Top-level     │  │ ├──┼──────────────────────┼────────────┼─────┤    │  │
+│  │ ◯ Nested        │  │ │↳ │ Jurassic             │ 201–145 MYA│ ██  │    │  │
+│  │                 │  │ │  │ in Mesozoic Era      │            │ high│    │  │
+│  │ Era             │  │ ├──┼──────────────────────┼────────────┼─────┤    │  │
+│  │ ☐ MYA   …       │  │ │⌒ │ Industrial Revolution│ 1760–1840  │ ███ │    │  │
+│  │ ☐ CE    …       │  │ │  │ steam · factories    │ CE         │ crit│    │  │
+│  │                 │  │ └──┴──────────────────────┴────────────┴─────┘    │  │
+│  │ Status          │  │                                                    │  │
+│  │ ☐ Published  20 │  │ ⟨ 1  2  ⟩                  Sort: Start date ▾      │  │
+│  │ ☐ Draft       3 │  │                                                    │  │
+│  │ Clear filters   │  │                                                    │  │
+│  └─────────────────┘  └────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Same left-rail + row pattern** as the other lists. Periods read most like the events list — temporally dense, era-aware — so it borrows that layout.
+2. **Span renders via the finalized `TemporalDisplay`** ([03-aesthetic-notes.md](../03-aesthetic-notes.md) § _Era palette_): era code + hue, era-aware formatting (`252–66 MYA`, `1760–1840 CE`). End is expected for periods (they're closed spans) but the schema allows open (`end_temporal_data` optional) — render a single start with an "open" affordance if unset.
+3. **`significance` uses the finalized sequential ramp** ([03-aesthetic-notes.md](../03-aesthetic-notes.md) § _Significance scale_) — the single-hue amber importance ramp reused for `low/medium/high/critical`. Shown as a 4-step bar + label, right-aligned. This is the same visual language as event importance, deliberately.
+4. **Nesting indicator + Show filter** mirror the events list's fractal-scope control, but for the **kept** `parent_period_id` hierarchy: `⌒` top-level, `↳` nested (one level of indentation; `in [Parent]` on line 2). `Show: All / Top-level only / Nested only` keys on `parent_period_id IS NULL`. Unlike events (where event-to-event nesting was retired, [#180](https://github.com/shaes-farm/time-traveler/issues/180)), **periods keep `parent_period_id`** — a period genuinely _is_ a span that contains sub-spans (Mesozoic ⊃ Jurassic), which is the natural hierarchy, not a fractal-zoom mechanism.
+5. **Characteristic tags** (`characteristics TEXT[]`) render on line 2 when present, like event categories on the events list — descriptive attributes of the span ("reptiles", "warm climate"), not a filterable taxonomy.
+6. **Search is title-only.** The `periods` table has no `search_vector` (unlike events/timelines/characters/stories) — so search is a `title ILIKE '%…%'` match. Flagged as a possible future schema addition (a generated `search_vector` over title/summary/detail) if full-text becomes necessary; **not** added this pass.
+7. **`StatusBadge`** (Published/Draft) — periods are publishable (`published`/`published_at`). See [16-publish-workflow.md](16-publish-workflow.md).
+8. **Sort default is `sort_order_start` ascending** (chronological) — the natural reading order for temporal spans, same rationale as the events list.
+
+## Edge cases
+
+- **Empty list.** Whole-panel empty state: "No periods yet. Periods are the named spans — eras, ages, epochs — your events fall within." Single CTA: **New period**.
+- **Filtered to zero.** Inline empty state + Clear filters.
+- **Open-ended period** (`end_temporal_data` unset). Render `252 MYA – …` / "ongoing" rather than a bogus end.
+- **Deeply nested periods.** One level of indentation only in the list (like events); full ancestry shows on [period detail](23-period-detail.md). Avoids an unbounded tree in a flat list.
+- **Loading.** Skeleton rows; filter rail immediate.
+
+## Open questions
+
+- **`periods.search_vector`** — add a generated full-text column for parity with the other entities? Deferred; title-match covers the modest period counts expected. Tier 4.
+- **Tree view toggle** — a true expand/collapse tree (like [24-category-management.md](24-category-management.md)) as an alternative to the flat chronological list. Periods are both temporal _and_ hierarchical; the flat-chronological default serves scanning, a tree would serve structure. Documented as a future view option, not built this pass.

--- a/docs/design/admin/02-wireframes/22-period-editor.md
+++ b/docs/design/admin/02-wireframes/22-period-editor.md
@@ -1,0 +1,91 @@
+# 22 — Period Editor
+
+**Purpose.** Create or edit a period's row fields — span, significance, characteristics, and its place in the period hierarchy. Timeline overlays (`period_timelines`) are managed on [period detail](23-period-detail.md), matching the editor/detail split used for timelines and stories.
+
+## Data captured
+
+All `periods` row columns except generated (`sort_order_start`, `sort_order_end`) and timestamps:
+
+- `title` (required)
+- `slug` (auto-generated)
+- `summary`
+- `detail` (Markdown)
+- `temporal_data` (start of span)
+- `end_temporal_data` (end of span — expected for closed periods)
+- `parent_period_id` (hierarchical; cycle-prevented)
+- `significance` (`low|medium|high|critical`)
+- `characteristics` (`TEXT[]`, chip input)
+- `published` (toggle; canonical action on detail — [16-publish-workflow.md](16-publish-workflow.md))
+
+## Primary actions
+
+- Save (create → `useCreatePeriod`; edit → `useUpdatePeriod`)
+- Cancel / discard (unsaved-changes guard)
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Periods ▸ New period                                [ Cancel ] [ Save ]     │
+│                                                          Draft saved 4:31 PM │
+│  ┌─────────────────────────────────────┬──────────────────────────────────┐  │
+│  │  Identity                           │  Slug                            │  │
+│  │  ───────────────────────────────    │  jurassic        [ edit slug ]   │  │
+│  │  Title *                            │                                  │  │
+│  │  [ Jurassic                  ]      │  Significance                    │  │
+│  │                                     │  ───────────────────────────     │  │
+│  │  Summary                            │  ◯ Low  ◯ Medium  ◉ High  ◯ Crit │  │
+│  │  ┌─────────────────────────────┐    │   ███  (sequential ramp)         │  │
+│  │  │ Brief description…          │    │                                  │  │
+│  │  └─────────────────────────────┘    │  Published                       │  │
+│  │                                     │  ◯ Draft (publish from detail)   │  │
+│  │  Detail                             │                                  │  │
+│  │  ┌─────────────────────────────┐    │                                  │  │
+│  │  │ Full description, Markdown… │    │                                  │  │
+│  │  └─────────────────────────────┘    │                                  │  │
+│  │                                     │                                  │  │
+│  │  Span                               │                                  │  │
+│  │  ───────────────────────────────    │                                  │  │
+│  │  Start *  [ 201 MYA            ▾]    │                                  │  │
+│  │  End      [ 145 MYA            ▾]    │                                  │  │
+│  │                                     │                                  │  │
+│  │  Hierarchy                          │                                  │  │
+│  │  ───────────────────────────────    │                                  │  │
+│  │  Parent period  [ Mesozoic Era  ▾]  │                                  │  │
+│  │                 Range: 252–66 MYA   │                                  │  │
+│  │                                     │                                  │  │
+│  │  Characteristics                    │                                  │  │
+│  │  [ reptiles ×] [ warm ×] [ + add ]  │                                  │  │
+│  └─────────────────────────────────────┴──────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Same two-column editor shell** as the timeline/story editors. Slug behavior matches the others ([05](05-character-editor.md) annotation #3); uniqueness `(user_id, slug)` via `periods_slug_idx`.
+2. **Span uses the shared [TemporalInput control](10-temporal-input.md)** for start (`temporal_data`, required) and end (`end_temporal_data`). Periods are closed spans by intent, so the form nudges toward setting an end (a single-point period is unusual), but the schema allows open. **End-before-start is a hard validation error.**
+3. **`significance` is a four-way control on the right rail**, rendered with the finalized sequential ramp ([03-aesthetic-notes.md](../03-aesthetic-notes.md) § _Significance scale_) — the same amber ramp as event importance. Defaults to `medium` (schema default).
+4. **Parent period picker = hierarchy.** A searchable combobox over the user's periods; on selection it shows the parent's range so the author can sanity-check that the child span sits inside it. **Cycle prevention** (service-layer, per system-design §3.4): the picker excludes this period and its descendants — `parent_period_id` cycles are not DB-constrained. This is the **kept** self-nesting axis (periods are genuinely hierarchical spans; contrast the retired event `parent_event_id`, [#180](https://github.com/shaes-farm/time-traveler/issues/180)).
+5. **Characteristics are a chip input** over `characteristics TEXT[]` — defining attributes of the span ("reptiles", "warm climate"). Same chip pattern as character aliases / story tags ([05](05-character-editor.md) annotation #5). These are descriptive, not a filterable taxonomy (that's Categories, which don't attach to periods).
+6. **Publish is a Draft toggle here; canonical publish on detail** — same rationale as timelines/stories ([12](12-timeline-editor.md) annotation #5).
+7. **No timeline-overlay management in this editor.** `period_timelines` (which timelines this period overlays) is managed on [period detail](23-period-detail.md), because the overlay is about placing an existing period onto canvases — a post-creation act. On successful create, redirect to detail.
+8. **Auto-save to draft every 30s** + **unsaved-changes guard**, identical to the other editors.
+
+## Save flow
+
+1. Validate client-side (Zod): `title` required; `temporal_data` valid + required; end-after-start; `significance` in enum; parent picker excludes self/descendants.
+2. `useCreatePeriod` / `useUpdatePeriod` (optimistic).
+3. On success, redirect to **period detail** (`/periods/[slug]`).
+
+## Edge cases
+
+- **Child span outside parent range.** Soft, non-blocking warning beneath the parent field: "Mesozoic Era spans 252–66 MYA; this period's span is 300–280 MYA (outside)." Allowed — period boundaries are sometimes fuzzy/overlapping, same posture as the event/sub-timeline span-mismatch warnings.
+- **End before start.** Hard error; save blocked.
+- **Cycle attempt.** Picker pre-excludes descendants; if a race slips through, the service rejects and the form surfaces "That would create a circular period hierarchy."
+- **Deleting a parent period later.** FK `parent_period_id ... ON DELETE CASCADE` — deleting a parent **deletes its descendants**. This is surfaced as a blast-radius warning on [period detail](23-period-detail.md) Danger zone, not here.
+- **Slug collision.** `resolveCollision` appends a suffix, surfaced inline.
+
+## Open questions
+
+- **Cascade vs. reparent on parent delete.** The schema is `ON DELETE CASCADE` (deleting Mesozoic deletes Triassic/Jurassic/…). Is cascade the right policy, or should children reparent to the grandparent? Flagged for the period-detail Danger zone design ([23](23-period-detail.md)) and for the service hardening issue (#60). Schema currently dictates cascade; a reparent policy would be application-layer.
+- **Geological/cosmological metadata** (PRD §2.1.3 "geological and cosmological period metadata") — beyond `characteristics`, is there structured geological metadata (eon/era/period/epoch rank)? Not in the current schema (`metadata` JSONB is not on `periods`). Deferred; `characteristics` carries it as free text for now.

--- a/docs/design/admin/02-wireframes/23-period-detail.md
+++ b/docs/design/admin/02-wireframes/23-period-detail.md
@@ -1,0 +1,94 @@
+# 23 — Period Detail
+
+**Purpose.** Read + manage a single period. This is where the **span-overlay model** is visible: a period is a labeled band with a place in the period hierarchy, overlaying one or more timelines, and the events that fall **within its temporal range** (by date — not by explicit linkage) are surfaced as computed context.
+
+## Data shown
+
+- Identity: title, slug, `significance`
+- Narrative: summary, detail (rendered Markdown)
+- Span: `temporal_data`–`end_temporal_data` (via `TemporalDisplay`)
+- `characteristics` (tags), published state, timestamps
+- **Hierarchy:** parent period (breadcrumb), child periods (`parent_period_id`)
+- **Overlaid timelines:** `period_timelines` (add/remove)
+- **Events in range:** events whose `sort_order_years` fall within `[sort_order_start, sort_order_end]` (computed, read-only)
+
+## Primary actions
+
+- Edit period (→ [22-period-editor.md](22-period-editor.md))
+- Publish / unpublish (header; owner-only — [16-publish-workflow.md](16-publish-workflow.md))
+- Delete (danger zone — cascades to child periods)
+- Add / remove overlaid timelines; navigate to parent/child period, timeline, or an in-range event
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Periods ▸ Mesozoic Era ▸ Jurassic                   [Edit] [✓ Published ▾]   │
+│                                                                              │
+│  Jurassic                                                                    │
+│  201–145 MYA · ██ High significance                                          │
+│  reptiles · warm climate · shallow seas                                      │
+│                                                                              │
+│  ┌─────────────────────────────────────┬──────────────────────────────────┐  │
+│  │  Description                        │  Hierarchy                       │  │
+│  │  ───────────────────────────────    │  ───────────────────────────     │  │
+│  │  The middle period of the Mesozoic, │  Parent                          │  │
+│  │  marked by the diversification of   │  ⌒ Mesozoic Era · 252–66 MYA     │  │
+│  │  dinosaurs and the first birds.     │                                  │  │
+│  │                                     │  Child periods                   │  │
+│  │                                     │  — none —                        │  │
+│  └─────────────────────────────────────┴──────────────────────────────────┘  │
+│                                                                              │
+│  ┌── Overlaid timelines (1) ──┬── Events in range (12) ──┐                   │
+│  ╞════════════════════════════╧══════════════════════════╡                   │
+│  │                                       [ + Overlay a timeline ]           │ │
+│  │  ───────────────────────────────────────────────────────────────────   │ │
+│  │  ◷ Evolution of life on Earth     3.8 BYA – now           [ remove ]    │ │
+│  └────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ▸ Danger zone                                                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Header mirrors the other detail headers.** Breadcrumb shows the **period hierarchy** (`Mesozoic Era ▸ Jurassic`) — periods _do_ nest (kept `parent_period_id`), so "up" is the parent period. Title, a `span · significance` metadata line (`TemporalDisplay` + the finalized significance ramp), characteristic tags, and `[Edit] [Publish ▾] [⋯]`.
+2. **Two-column overview:** left = narrative (`summary`/`detail` Markdown); right = **Hierarchy** (parent + child periods, the navigation surface for the period tree). Child periods link down; parent links up. This is how authors traverse Mesozoic ⇄ Jurassic ⇄ ….
+3. **Overlaid timelines tab** = the `period_timelines` junction. A period is a **span that overlays timelines** — it doesn't contain events, it _bands_ one or more timeline canvases. `[ + Overlay a timeline ]` opens a timeline picker; `[ remove ]` deletes the junction row. This is the period's only explicit association.
+4. **Events in range tab is computed and read-only** — the heart of the **span-overlay decision**. It lists events whose `sort_order_years` fall within this period's `[sort_order_start, sort_order_end]`, **by date, not by any junction** (there is no `period_events` table). This answers "what happened during the Jurassic?" without anyone hand-linking events to the period.
+   - **Scope toggle:** "all events in range" vs. "only events on the overlaid timelines." Default to the latter when overlays exist (the period is contextualizing _those_ canvases), else all-in-range.
+   - It's read-only here: to put an event in a period you set the event's _date_, not a link. Each row links to the event; `TemporalDisplay` + importance ramp per the finalized language.
+5. **No `period_events` linking, by design** (resolved M7 decision). A period that needed explicit, curated event membership would be a _timeline_, not a period. This is the IA line between the two: **timelines contain events (curated); periods overlay timelines and gather events by date (computed).** And an `event_type='period'` event is a third, distinct thing — a discrete event that happens to span time — not a row in this table.
+6. **Significance + characteristics** are identity-level (header), not a tab — they describe the span itself.
+7. **No media tab** — periods have no `period_media` junction.
+8. **Danger zone — cascade warning.** `parent_period_id` is `ON DELETE CASCADE`, so deleting a period **deletes its child periods**. The confirm states the blast radius: "Delete Mesozoic Era? This also deletes 3 child periods (Triassic, Jurassic, Cretaceous). Events and timelines are unaffected." (Events/timelines are untouched — the period only overlaid them.) See [22-period-editor.md](22-period-editor.md) Open Questions on cascade-vs-reparent.
+9. **Permissions.** Periods are owner-scoped (no collaborator path of their own; system-design §9.2.2 derives any collaborator visibility via the timelines they overlay). Owner-or-admin edit/delete; read-only for others on published periods.
+
+## Tab variations
+
+### Events in range (computed)
+
+```
+  Events in range (12)        Scope: ◉ On overlaid timelines  ◯ All in range
+  ───────────────────────────────────────────────────────────────────────
+  201 MYA   First true dinosaurs diversify     milestone   ★7   ↗
+  155 MYA   Archaeopteryx                       discovery   ★8   ↗
+  150 MYA   Morrison Formation deposits         period      ★5   ↗
+  …
+  computed by date — events are not linked to periods (span-overlay model)
+```
+
+## Edge cases
+
+- **404 / not found.** Lookup by `(user_id, slug)` → 404 with link back to periods list.
+- **Open-ended period** (`end_temporal_data` unset). "Events in range" uses `sort_order_years >= sort_order_start` (no upper bound). Header renders `201 MYA – …`.
+- **No overlaid timelines.** Events-in-range defaults to "all in range" (no timelines to scope to); the Overlaid-timelines tab shows an empty state + CTA.
+- **No events in range.** "No events fall within 201–145 MYA yet." (Not an error — the span may predate any authored events.)
+- **Very large range** (e.g. a BYA-spanning period) returning thousands of in-range events. Paginate the computed list; it's read-only context, not a management surface.
+- **Loading.** Skeleton header; tabs lazy-load (the in-range query is the expensive one — load it last).
+
+## Open questions
+
+- **Cascade vs. reparent on delete** — carried from [22-period-editor.md](22-period-editor.md). Schema cascades; a "reparent children to grandparent" option would be application-layer. Decision tracked with the period-service hardening (#60).
+- **Events-in-range performance** — the computed query is `sort_order_years BETWEEN start AND end` (indexed via `idx_events_sort` / `idx_events_range`). For BYA spans this can be large; the scope-to-overlaid-timelines default mitigates. Cursor pagination (system-design §8.2) applies if it grows.
+- **Period bands on the timeline visualization** (Phase 7) — periods are the natural source of "era bands" behind a timeline render. Out of scope here; flagged for the visualization phase.

--- a/docs/design/admin/02-wireframes/24-category-management.md
+++ b/docs/design/admin/02-wireframes/24-category-management.md
@@ -1,0 +1,75 @@
+# 24 — Category Management
+
+**Purpose.** Manage the **category taxonomy** — a hierarchical tree of tags used to organize events. Unlike timelines/events/characters, a category is lightweight organizational metadata, not authored content: there's no list/detail/editor split and no publish state. One screen does it all — browse the tree, create/edit nodes, and delete with an explicit child policy.
+
+Categories attach to **events only** this pass (the `event_categories` junction); broader attachment to other entities is deferred (resolved M7 decision). Assignment happens in the [event editor](09-event-editor.md) (its category multi-select), **not** here — this screen owns the taxonomy, not the tagging.
+
+## Data shown
+
+- The category tree (`getCategoryTree`, hierarchical via `parent_category_id`)
+- Per node: `color` swatch, `icon`, `title`, `description` (on hover/expand), child count, **usage count** (events tagged via `event_categories`)
+
+## Primary actions
+
+- Expand / collapse tree nodes
+- Create a category (root or child)
+- Edit a category (`title`, `description`, `color`, `icon`, `parent_category_id`)
+- Delete a category (with explicit child-handling policy)
+- Reparent (move a subtree under a different parent)
+
+## Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Categories                                            [ + New category ]    │
+│  18 categories · 4 roots                                                     │
+│                                                                              │
+│  ┌────────────────────────────────────────────┬───────────────────────────┐ │
+│  │  ⌕ Filter categories…                       │  Edit category            │ │
+│  │  ──────────────────────────────────────────  │  ───────────────────────  │ │
+│  │  ▾ 🔴 Science                      42 events │  Title *                  │ │
+│  │     ▾ 🔵 Physics                   28 events │  [ Quantum Mechanics  ]   │ │
+│  │        • 🟣 Quantum Mechanics       9 events │                           │ │
+│  │        • 🟢 Relativity              6 events │  Description              │ │
+│  │     ▸ 🟠 Chemistry                 11 events │  [ Sub-atomic behavior… ] │ │
+│  │  ▾ 🔴 War                          63 events │                           │ │
+│  │     • 🟤 World Wars                31 events │  Color   [ 🟣 #8B5CF6  ]  │ │
+│  │     • ⚫ Ancient Warfare            8 events │  Icon    [ ⚛  atom     ]  │ │
+│  │  ▸ 🟡 Art                          15 events │  Parent  [ Physics    ▾]  │ │
+│  │  • ⚪ Uncategorized-bin (0 children) 4 events│                           │ │
+│  │                                              │  [ Delete ]      [ Save ] │ │
+│  │  [ + Add root category ]                     │                           │ │
+│  └────────────────────────────────────────────┴───────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Annotations
+
+1. **Tree + inspector, not list/detail.** Left: the category tree (expand/collapse). Right: an inspector panel that edits the selected node inline (or a "new category" form). This is the lightest-weight management surface in the admin — categories don't earn their own routes per node.
+2. **Tree comes from `getCategoryTree`** (the existing service builds it in-memory from `parent_category_id`). Ordering within a level is deterministic — alphabetical by `title` (categories have no `sort_order` and no temporal axis). Indentation shows depth; `▾`/`▸` expand/collapse; `•` = leaf.
+3. **Each node shows its own `color` + `icon`** — these are **author-chosen per category** (`color VARCHAR(7)` hex, `icon VARCHAR(100)`), distinct from the system token palette. They're the category's identity for the event-editor multi-select and event detail chips. The color is a small swatch; the icon renders from the stored identifier (lucide name or emoji).
+4. **Usage count per node** = events tagged via `event_categories`. This is the key triage signal ("is this category actually used?") and drives the delete policy (annotation #6). Deferred-tolerant: render the tree without counts if the aggregate isn't wired.
+5. **Create/edit inspector fields:** `title` (required), `description`, `color` (swatch + hex picker), `icon` (picker over the lucide set + emoji fallback), `parent` (combobox; empty = root). **No publish control** — categories have no `published` column; they're taxonomy, always "live" for their owner.
+6. **Delete requires an explicit child + usage policy** (issue #59/#63 acceptance). The schema is `parent_category_id ... ON DELETE CASCADE` and `event_categories ... ON DELETE CASCADE`, so a naive delete removes the subtree **and** untags every event. The confirm dialog makes this explicit and offers a safer path:
+   - Shows blast radius: "Delete _Physics_? This also deletes 2 child categories (Quantum Mechanics, Relativity) and removes the tag from 28 events."
+   - **Option A — Reparent children first** (recommended default when children exist): move children up to _Physics_' parent (or to root), then delete only _Physics_. Preserves the subtree.
+   - **Option B — Delete subtree** (the raw cascade): deletes _Physics_ and all descendants; untags all affected events.
+     The reparent path is application-layer (the DB only offers cascade); the UI performs the reparent then the delete.
+7. **Reparent (move subtree)** — changing a node's `parent` in the inspector (or drag in the tree) moves it and its descendants. **Cycle prevention** (service-layer, system-design §3.4 — `parent_category_id` cycles are not DB-constrained): the parent picker excludes the node and its descendants. This is the **kept** hierarchy axis (taxonomy trees are inherently nested; contrast the retired event `parent_event_id`, [#180](https://github.com/shaes-farm/time-traveler/issues/180)).
+8. **No temporal, no significance, no media, no publish** — categories are the simplest entity. The screen is deliberately spare.
+
+## Edge cases
+
+- **Empty (zero categories).** Whole-panel empty state: "No categories yet. Categories are the tags that organize your events — nest them into a tree (Science → Physics → Quantum Mechanics)." Single CTA: **New category**.
+- **Delete a category with children.** Always routes through the policy dialog (annotation #6); never a one-click cascade.
+- **Delete a category with high usage but no children.** Confirm still states usage ("removes the tag from 28 events"); single-option delete (no reparent needed).
+- **Reparent that would create a cycle.** Picker pre-excludes descendants; service rejects a slipped-through race ("That would create a circular category hierarchy").
+- **Color/icon unset.** Render a neutral swatch + a default tag icon; both fields are optional in the schema.
+- **Duplicate titles under different parents.** Allowed — uniqueness is `(user_id, slug)`, and slugs auto-resolve collisions. Two "Overview" categories under different parents are fine.
+- **Loading.** Tree skeleton; inspector empty until a node is selected.
+
+## Open questions
+
+- **Drag-to-reparent vs. picker-only.** The picker is the baseline (always works); drag-in-tree is the nicer interaction. Drag is documented as the target but may land after the picker (consistent with #63's non-goal note on drag polish "if not yet supported by design scope").
+- **Merge categories** (fold A into B, re-tagging A's events to B then deleting A) — a real taxonomy-maintenance need, but heavier; deferred to a follow-up. The reparent + delete-policy flow covers restructuring; merge covers de-duplication.
+- **Broader attachment** (characters/timelines/periods/stories) — deferred this pass (events-only). If adopted later it needs per-entity category junctions + assignment UI; tracked as the category-scope decision in the M7 inventory notes.

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -585,7 +585,12 @@ CREATE TABLE timeline_events (
   PRIMARY KEY (timeline_id, event_id)
 );
 
--- Periods ↔ Timelines
+-- Periods ↔ Timelines — a period is a SPAN-OVERLAY on timelines, not an event
+-- container. period_timelines is a period's ONLY association; there is no
+-- period_events junction (deliberate). Events fall "within" a period by date
+-- (sort_order_years BETWEEN the period's sort_order_start/_end), computed, not
+-- linked. Contrast: timelines contain curated events; an event_type='period'
+-- event is a discrete span event. See docs/design/admin (period detail, screen 23).
 CREATE TABLE period_timelines (
   period_id UUID REFERENCES periods(id) ON DELETE CASCADE,
   timeline_id UUID REFERENCES timelines(id) ON DELETE CASCADE,
@@ -608,10 +613,15 @@ CREATE TABLE story_characters (
   PRIMARY KEY (story_id, character_id)
 );
 
--- Stories ↔ Events
+-- Stories ↔ Events — a story is a NARRATIVE SEQUENCE of events. sort_order is
+-- editorial (the order the story tells them, which may be non-chronological —
+-- flashbacks, thematic grouping), defaulting to 0 ⇒ fall back to the event's
+-- chronological events.sort_order_years. Mirrors timeline_events.sort_order
+-- (00012). PENDING migration #183 — until then story_events renders chronologically.
 CREATE TABLE story_events (
   story_id UUID REFERENCES stories(id) ON DELETE CASCADE,
   event_id UUID REFERENCES events(id) ON DELETE CASCADE,
+  sort_order INTEGER DEFAULT 0,  -- editorial narrative order; PENDING (#183)
   PRIMARY KEY (story_id, event_id)
 );
 


### PR DESCRIPTION
## What this is

The design pass for **Phase 6 / milestone 7** (stories, categories, periods — issues #58–#64). **Docs only** — fidelity-1 wireframes + spec updates, no app code. Builds on the merged M6 work (PR #182): references the finalized visual language and numbers after the media-library wireframe (17).

## Key context: the data layer already exists

`story-service` / `category-service` / `period-service` (full CRUD + junctions, incl. `getCategoryTree`, `getChildPeriods`, story↔event/character/period linking), the `use-stories|categories|periods` hooks, and the Zustand `ui-store`/`navigation-store` are all already built. So:

- **#58–#61** are **verify/harden** tickets (refined to say so).
- **#62/#63/#64** are the UI — designed here for the first time (these three were "not in scope" through M5/M6).

## New wireframes (`docs/design/admin/02-wireframes/`)

| # | Screen | Issue |
|---|---|---|
| 18 | Stories list | #62 |
| 19 | Story editor | #62 |
| 20 | Story detail (narrative event ordering) | #62 |
| 21 | Periods list | #64 |
| 22 | Period editor | #64 |
| 23 | Period detail (span-overlay) | #64 |
| 24 | Category management (taxonomy tree) | #63 |

## Resolved model decisions

- **Story events get editorial `sort_order`** ([#183](https://github.com/shaes-farm/time-traveler/issues/183)) — a story is a narrative sequence, told in deliberate (possibly non-chronological) order. Story detail gets drag-to-reorder; chronological fallback until the migration. Mirrors `timeline_events`/00012.
- **Periods are span-overlays, not event containers** — a period overlays timelines (`period_timelines`) and gathers events **by date** (computed events-in-range); **no `period_events` junction**. This draws the IA line: *timelines contain curated events · periods band timelines · `event_type='period'` events are discrete span events.*
- **Categories tag events only** this pass; taxonomy tree with reparent + an explicit delete-child policy (reparent-first vs. cascade); not publishable.
- **`parent_period_id` / `parent_category_id` hierarchies kept** — genuine containment trees (Mesozoic ⊃ Jurassic; Science ⊃ Physics), unlike the retired event `parent_event_id` ([#180](https://github.com/shaes-farm/time-traveler/issues/180)). Cycle prevention is service-layer.
- **Publish** extends to stories + periods (both have `published`); **no media** surfaces anywhere in M7 (no `story_media`/`period_media`/`category_media`).

## Spec + integration

- `docs/system-design.md` — documents `story_events.sort_order` (PENDING #183) and the period span-overlay semantics (no `period_events`) in §3.4.
- Screen inventory: "Milestone 7 additions" section (screens 18–24 + decisions); stories/periods/categories moved out of "not in scope."
- User flows: story authoring (narrative ordering), period hierarchy + overlay, category-tree maintenance.
- App-shell nav: Stories, Periods, Categories now render active.

## Tracking issues

- **[#183](https://github.com/shaes-farm/time-traveler/issues/183)** — add `story_events.sort_order`. Story detail drag-reorder (#62) blocked on it; chronological fallback until then. Periods + categories need **no** schema changes.
- Issues **#58–#64** refined with design references, the resolved decisions, and dependency wiring (#183 → #58/#61/#62).

## Scope / non-goals

Docs only; no implementation. `package.json` / lockfiles left out of this commit (unrelated working-tree changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)