### PR TITLE
docs(adr): backfill retroactive ADR series 0001–0027

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,3 +146,11 @@ Run these in order — all must pass:
 ## When You Find a Spec or Upstream Bug
 
 If implementing a task reveals a bug in the spec (`docs/system-design.md`, PRD), schema, or another upstream artifact, do not silently work around it. File a separate GitHub issue documenting the bug, its evidence, the workaround applied in code, and the recommended upstream fix. Reference the tracking issue in the workaround comment if the workaround is non-obvious. See #73 for an example.
+
+## When to Write an ADR
+
+Architectural decisions are recorded as Architecture Decision Records in `docs/adr/`. The retroactive series ADR-0001 through ADR-0027 documents every load-bearing decision made to date; the index, format rules, and process live in `docs/adr/README.md`.
+
+- Write a new ADR when a decision is **hard to reverse, cross-cutting, or precedent-setting** — e.g., a new platform/dependency, a schema or RLS pattern, an API boundary, a state/data-flow choice, or a design-system rule. Routine, local, easily-reversible changes do not need one.
+- **Number new ADRs from 0028 onward.** Copy `docs/adr/adr-0000-template.md`, fill in every section, cite concrete evidence (a migration file/section or a doc section), and add a row to the `docs/adr/README.md` index.
+- If a new decision **supersedes or amends** an existing ADR, set the `supersedes`/`superseded_by` front matter on both ADRs and update the index status accordingly.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -152,5 +152,5 @@ If implementing a task reveals a bug in the spec (`docs/system-design.md`, PRD),
 Architectural decisions are recorded as Architecture Decision Records in `docs/adr/`. The retroactive series ADR-0001 through ADR-0027 documents every load-bearing decision made to date; the index, format rules, and process live in `docs/adr/README.md`.
 
 - Write a new ADR when a decision is **hard to reverse, cross-cutting, or precedent-setting** — e.g., a new platform/dependency, a schema or RLS pattern, an API boundary, a state/data-flow choice, or a design-system rule. Routine, local, easily-reversible changes do not need one.
-- **Number new ADRs from 0028 onward.** Copy `docs/adr/adr-0000-template.md`, fill in every section, cite concrete evidence (a migration file/section or a doc section), and add a row to the `docs/adr/README.md` index.
+- **Number new ADRs from 0029 onward** (0028 records the Milestone 7 period/category model). Copy `docs/adr/adr-0000-template.md`, fill in every section, cite concrete evidence (a migration file/section or a doc section), and add a row to the `docs/adr/README.md` index.
 - If a new decision **supersedes or amends** an existing ADR, set the `supersedes`/`superseded_by` front matter on both ADRs and update the index status accordingly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,11 @@ Run in order — all must pass:
 ## When you find a spec or upstream bug
 
 If implementing a task reveals a bug in the spec (`docs/system-design.md`, PRD), schema, or another upstream artifact, do not silently work around it. File a separate GitHub issue documenting the bug, its evidence, the workaround applied in code, and the recommended upstream fix. Reference the tracking issue in the workaround comment if the workaround is non-obvious. See #73 for the template.
+
+## When to write an ADR
+
+Architectural decisions are recorded as ADRs in [`docs/adr/`](docs/adr/). The retroactive series ADR-0001…0027 documents every load-bearing decision made to date; the index and process live in [`docs/adr/README.md`](docs/adr/README.md).
+
+- Write a new ADR when you make a decision that is **hard to reverse, cross-cutting, or sets a precedent** — a new dependency/platform, a schema/RLS pattern, an API boundary, a state/data-flow choice, or a design-system rule. Routine, local, easily-reversible changes do not need one.
+- **Number new ADRs from 0028 onward.** Copy [`docs/adr/adr-0000-template.md`](docs/adr/adr-0000-template.md), fill it in, cite concrete evidence (migration file/section or doc section), and add a row to the README index.
+- If a new decision **supersedes or amends** an existing ADR, set the `supersedes`/`superseded_by` front matter on both sides and update the index status.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,5 +95,5 @@ If implementing a task reveals a bug in the spec (`docs/system-design.md`, PRD),
 Architectural decisions are recorded as ADRs in [`docs/adr/`](docs/adr/). The retroactive series ADR-0001…0027 documents every load-bearing decision made to date; the index and process live in [`docs/adr/README.md`](docs/adr/README.md).
 
 - Write a new ADR when you make a decision that is **hard to reverse, cross-cutting, or sets a precedent** — a new dependency/platform, a schema/RLS pattern, an API boundary, a state/data-flow choice, or a design-system rule. Routine, local, easily-reversible changes do not need one.
-- **Number new ADRs from 0028 onward.** Copy [`docs/adr/adr-0000-template.md`](docs/adr/adr-0000-template.md), fill it in, cite concrete evidence (migration file/section or doc section), and add a row to the README index.
+- **Number new ADRs from 0029 onward** (0028 records the Milestone 7 period/category model). Copy [`docs/adr/adr-0000-template.md`](docs/adr/adr-0000-template.md), fill it in, cite concrete evidence (migration file/section or doc section), and add a row to the README index.
 - If a new decision **supersedes or amends** an existing ADR, set the `supersedes`/`superseded_by` front matter on both sides and update the index status.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,7 +13,8 @@ migration or PR that implemented it) and carries the status **Accepted
 (retroactively documented 2026-05-30)**. They record _what was decided_, not a
 re-litigation of decided questions.
 
-New decisions start at **`0028`** and follow the
+New (forward) decisions start at **`0028`** — the first of which records the
+Milestone 7 period/category model — and follow the
 [ADR process](#when-to-write-an-adr) below.
 
 ## Format
@@ -61,6 +62,7 @@ New decisions start at **`0028`** and follow the
 | [0025](adr-0025-shared-mediapicker-bespoke-tree.md)        | `MediaPicker` shared primitive; bespoke `Tree` only     | Accepted (retro) | —                                          |
 | [0026](adr-0026-testing-strategy.md)                       | Testing strategy: pgTAP + Vitest 80% + Storybook        | Accepted (retro) | —                                          |
 | [0027](adr-0027-upstream-spec-bug-protocol.md)             | Upstream-spec-bug + PRD-reconciliation protocol         | Accepted (retro) | —                                          |
+| [0028](adr-0028-period-span-overlay-and-hierarchy-axes.md) | Period span-overlays; period/category hierarchy axes    | Accepted         | —                                          |
 
 † ADR `0006` supersedes the original event-to-event `parent_event_id` nesting
 approach, which was never given its own ADR; it is documented inside `0006` as
@@ -68,7 +70,7 @@ the rejected/superseded prior decision and tombstoned per #180.
 
 ## When to write an ADR
 
-Write a new ADR (starting at `0028`) when a change does any of the following:
+Write a new ADR (the next free number, `0029` onward) when a change does any of the following:
 
 - Introduces, replaces, or removes a **platform, framework, or major dependency**
   (e.g., swapping a state manager, adding a queue, changing the host).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,93 @@
+# Architecture Decision Records
+
+This directory holds the Architecture Decision Records (ADRs) for **Time
+Traveler**. An ADR captures a single load-bearing architectural decision: the
+context that forced it, the option chosen, and the consequences accepted.
+
+ADRs `0001`–`0027` were **reconstructed retroactively** in a single
+documentation pass (May 2026) to close a knowledge gap — the decisions were made
+and implemented across the greenfield build (migrations `00001`–`00015`, the
+fidelity-1/2 design passes, and the monorepo bootstrap) but were never recorded
+as discrete records. Each retroactive ADR is dated to its evidence (the
+migration or PR that implemented it) and carries the status **Accepted
+(retroactively documented 2026-05-30)**. They record _what was decided_, not a
+re-litigation of decided questions.
+
+New decisions start at **`0028`** and follow the
+[ADR process](#when-to-write-an-adr) below.
+
+## Format
+
+- File naming: `adr-NNNN-[title-slug].md` (4-digit zero-padded sequence).
+- Front matter + body per [`adr-0000-template.md`](adr-0000-template.md), the
+  `create-architectural-decision-record` skill template.
+- Consequences/alternatives/implementation/references use coded bullets
+  (`POS-`, `NEG-`, `ALT-`, `IMP-`, `REF-`) for machine parsing.
+- Superseding a decision sets `superseded_by` on the old ADR and `supersedes` on
+  the new one, and flips the old ADR's status to **Superseded**.
+
+## Index
+
+| #                                                          | Title                                                   | Status           | Supersedes / Superseded by  |
+| ---------------------------------------------------------- | ------------------------------------------------------- | ---------------- | --------------------------- |
+| [0001](adr-0001-supabase-backend-platform.md)              | Supabase as the backend platform                        | Accepted (retro) | —                           |
+| [0002](adr-0002-pnpm-turborepo-monorepo.md)                | pnpm + Turborepo monorepo                               | Accepted (retro) | —                           |
+| [0003](adr-0003-nextjs-app-router-react19.md)              | Next.js 16 App Router + React 19, split apps            | Accepted (retro) | —                           |
+| [0004](adr-0004-engineering-standards.md)                  | Engineering standards (strict TS, zero-warning, ESM)    | Accepted (retro) | —                           |
+| [0005](adr-0005-hybrid-temporal-system.md)                 | Hybrid temporal system (JSONB + generated sort columns) | Accepted (retro) | —                           |
+| [0006](adr-0006-fractal-timeline-detail-timeline.md)       | Fractal timeline via forward `detail_timeline_id`       | Accepted (retro) | supersedes 0006-alt† (#180) |
+| [0007](adr-0007-seven-character-types.md)                  | Seven character types + type-specific columns           | Accepted (retro) | —                           |
+| [0008](adr-0008-character-relationships-directed-pairs.md) | Character relationships as directed pairs               | Accepted (retro) | amended by 0009             |
+| [0009](adr-0009-relationship-sub-role-taxonomy.md)         | Relationship sub-role taxonomy (`relationship_role`)    | Accepted (retro) | amends 0008 (#119)          |
+| [0010](adr-0010-junction-table-conventions.md)             | Junction tables: composite PK, no surrogate id/user_id  | Accepted (retro) | —                           |
+| [0011](adr-0011-publication-model.md)                      | Publication model: `published` boolean + `published_at` | Accepted (retro) | —                           |
+| [0012](adr-0012-postgrest-crud-thin-service-layer.md)      | PostgREST for all CRUD + thin TS service layer          | Accepted (retro) | —                           |
+| [0013](adr-0013-db-functions-read-only.md)                 | DB functions reserved for complex read-only queries     | Accepted (retro) | —                           |
+| [0014](adr-0014-rls-single-source-of-authorization.md)     | RLS as the single source of authorization               | Accepted (retro) | —                           |
+| [0015](adr-0015-rls-and-function-hardening.md)             | RLS + function hardening (DEFINER, search_path, perf)   | Accepted (retro) | —                           |
+| [0016](adr-0016-storage-buckets-graduated-access.md)       | Storage buckets with graduated access control           | Accepted (retro) | —                           |
+| [0017](adr-0017-auth-bootstrap-supporting-tables.md)       | Auth bootstrap (profile trigger, is_admin) + supporting | Accepted (retro) | —                           |
+| [0018](adr-0018-curated-content-library.md)                | Curated content library (admin-owned + import)          | Accepted (retro) | —                           |
+| [0019](adr-0019-services-package.md)                       | `@repo/services` package (clients, schemas, modules)    | Accepted (retro) | —                           |
+| [0020](adr-0020-ui-package-shadcn-tailwind.md)             | `@repo/ui` on shadcn/ui + Tailwind 4                    | Accepted (retro) | —                           |
+| [0021](adr-0021-tanstack-query-zustand.md)                 | TanStack Query (server) + Zustand (client) state        | Accepted (retro) | —                           |
+| [0022](adr-0022-design-tokens-dual-source.md)              | Design tokens dual TS/CSS source + OKLCH + lucide       | Accepted (retro) | —                           |
+| [0023](adr-0023-dark-mode-only-fidelity-2.md)              | Dark-mode-only for fidelity-2 (light mode deferred)     | Accepted (retro) | —                           |
+| [0024](adr-0024-accessibility-first-visual-language.md)    | Accessibility-first visual language                     | Accepted (retro) | —                           |
+| [0025](adr-0025-shared-mediapicker-bespoke-tree.md)        | `MediaPicker` shared primitive; bespoke `Tree` only     | Accepted (retro) | —                           |
+| [0026](adr-0026-testing-strategy.md)                       | Testing strategy: pgTAP + Vitest 80% + Storybook        | Accepted (retro) | —                           |
+| [0027](adr-0027-upstream-spec-bug-protocol.md)             | Upstream-spec-bug + PRD-reconciliation protocol         | Accepted (retro) | —                           |
+
+† ADR `0006` supersedes the original event-to-event `parent_event_id` nesting
+approach, which was never given its own ADR; it is documented inside `0006` as
+the rejected/superseded prior decision and tombstoned per #180.
+
+## When to write an ADR
+
+Write a new ADR (starting at `0028`) when a change does any of the following:
+
+- Introduces, replaces, or removes a **platform, framework, or major dependency**
+  (e.g., swapping a state manager, adding a queue, changing the host).
+- Establishes or changes a **cross-cutting convention** that future code must
+  follow (schema patterns, RLS patterns, auth flow, error handling, naming).
+- Makes a **security or data-integrity** trade-off (RLS model, `SECURITY
+DEFINER` usage, validation boundaries, storage access).
+- **Supersedes or amends an existing ADR** — even a small reversal of a recorded
+  decision needs its own record so the history stays readable.
+- Resolves a decision that was previously marked `// DECISION NEEDED` in code or
+  flagged as a divergence (e.g., #127).
+
+Do **not** write an ADR for routine feature work, bug fixes, or choices fully
+determined by an existing ADR. When in doubt, prefer a short ADR over an
+undocumented decision.
+
+### How to add one
+
+1. Copy [`adr-0000-template.md`](adr-0000-template.md) to
+   `adr-NNNN-[slug].md` using the next free number.
+2. Fill in front matter; set status to **Proposed** until accepted.
+3. Cite concrete evidence (migration file + section, doc section, or PR).
+4. Add a row to the [Index](#index) table.
+5. If it supersedes/amends another ADR, update both records' front matter and the
+   superseded ADR's status.
+6. `npx prettier --write "docs/adr/**/*.md"` before committing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,40 +23,44 @@ New decisions start at **`0028`** and follow the
   `create-architectural-decision-record` skill template.
 - Consequences/alternatives/implementation/references use coded bullets
   (`POS-`, `NEG-`, `ALT-`, `IMP-`, `REF-`) for machine parsing.
-- Superseding a decision sets `superseded_by` on the old ADR and `supersedes` on
-  the new one, and flips the old ADR's status to **Superseded**.
+- **Superseding** a decision sets `superseded_by` on the old ADR and
+  `supersedes` on the new one, and flips the old ADR's status to
+  **Superseded**.
+- **Amending** a decision (refining it without reversing it) sets `amended_by`
+  on the original ADR and `amends` on the amending ADR. An amended ADR keeps its
+  status (it is **not** Superseded); both ADRs stay in force and read together.
 
 ## Index
 
-| #                                                          | Title                                                   | Status           | Supersedes / Superseded by  |
-| ---------------------------------------------------------- | ------------------------------------------------------- | ---------------- | --------------------------- |
-| [0001](adr-0001-supabase-backend-platform.md)              | Supabase as the backend platform                        | Accepted (retro) | —                           |
-| [0002](adr-0002-pnpm-turborepo-monorepo.md)                | pnpm + Turborepo monorepo                               | Accepted (retro) | —                           |
-| [0003](adr-0003-nextjs-app-router-react19.md)              | Next.js 16 App Router + React 19, split apps            | Accepted (retro) | —                           |
-| [0004](adr-0004-engineering-standards.md)                  | Engineering standards (strict TS, zero-warning, ESM)    | Accepted (retro) | —                           |
-| [0005](adr-0005-hybrid-temporal-system.md)                 | Hybrid temporal system (JSONB + generated sort columns) | Accepted (retro) | —                           |
-| [0006](adr-0006-fractal-timeline-detail-timeline.md)       | Fractal timeline via forward `detail_timeline_id`       | Accepted (retro) | supersedes 0006-alt† (#180) |
-| [0007](adr-0007-seven-character-types.md)                  | Seven character types + type-specific columns           | Accepted (retro) | —                           |
-| [0008](adr-0008-character-relationships-directed-pairs.md) | Character relationships as directed pairs               | Accepted (retro) | amended by 0009             |
-| [0009](adr-0009-relationship-sub-role-taxonomy.md)         | Relationship sub-role taxonomy (`relationship_role`)    | Accepted (retro) | amends 0008 (#119)          |
-| [0010](adr-0010-junction-table-conventions.md)             | Junction tables: composite PK, no surrogate id/user_id  | Accepted (retro) | —                           |
-| [0011](adr-0011-publication-model.md)                      | Publication model: `published` boolean + `published_at` | Accepted (retro) | —                           |
-| [0012](adr-0012-postgrest-crud-thin-service-layer.md)      | PostgREST for all CRUD + thin TS service layer          | Accepted (retro) | —                           |
-| [0013](adr-0013-db-functions-read-only.md)                 | DB functions reserved for complex read-only queries     | Accepted (retro) | —                           |
-| [0014](adr-0014-rls-single-source-of-authorization.md)     | RLS as the single source of authorization               | Accepted (retro) | —                           |
-| [0015](adr-0015-rls-and-function-hardening.md)             | RLS + function hardening (DEFINER, search_path, perf)   | Accepted (retro) | —                           |
-| [0016](adr-0016-storage-buckets-graduated-access.md)       | Storage buckets with graduated access control           | Accepted (retro) | —                           |
-| [0017](adr-0017-auth-bootstrap-supporting-tables.md)       | Auth bootstrap (profile trigger, is_admin) + supporting | Accepted (retro) | —                           |
-| [0018](adr-0018-curated-content-library.md)                | Curated content library (admin-owned + import)          | Accepted (retro) | —                           |
-| [0019](adr-0019-services-package.md)                       | `@repo/services` package (clients, schemas, modules)    | Accepted (retro) | —                           |
-| [0020](adr-0020-ui-package-shadcn-tailwind.md)             | `@repo/ui` on shadcn/ui + Tailwind 4                    | Accepted (retro) | —                           |
-| [0021](adr-0021-tanstack-query-zustand.md)                 | TanStack Query (server) + Zustand (client) state        | Accepted (retro) | —                           |
-| [0022](adr-0022-design-tokens-dual-source.md)              | Design tokens dual TS/CSS source + OKLCH + lucide       | Accepted (retro) | —                           |
-| [0023](adr-0023-dark-mode-only-fidelity-2.md)              | Dark-mode-only for fidelity-2 (light mode deferred)     | Accepted (retro) | —                           |
-| [0024](adr-0024-accessibility-first-visual-language.md)    | Accessibility-first visual language                     | Accepted (retro) | —                           |
-| [0025](adr-0025-shared-mediapicker-bespoke-tree.md)        | `MediaPicker` shared primitive; bespoke `Tree` only     | Accepted (retro) | —                           |
-| [0026](adr-0026-testing-strategy.md)                       | Testing strategy: pgTAP + Vitest 80% + Storybook        | Accepted (retro) | —                           |
-| [0027](adr-0027-upstream-spec-bug-protocol.md)             | Upstream-spec-bug + PRD-reconciliation protocol         | Accepted (retro) | —                           |
+| #                                                          | Title                                                   | Status           | Supersedes / Superseded by                 |
+| ---------------------------------------------------------- | ------------------------------------------------------- | ---------------- | ------------------------------------------ |
+| [0001](adr-0001-supabase-backend-platform.md)              | Supabase as the backend platform                        | Accepted (retro) | —                                          |
+| [0002](adr-0002-pnpm-turborepo-monorepo.md)                | pnpm + Turborepo monorepo                               | Accepted (retro) | —                                          |
+| [0003](adr-0003-nextjs-app-router-react19.md)              | Next.js 16 App Router + React 19, split apps            | Accepted (retro) | —                                          |
+| [0004](adr-0004-engineering-standards.md)                  | Engineering standards (strict TS, zero-warning, ESM)    | Accepted (retro) | —                                          |
+| [0005](adr-0005-hybrid-temporal-system.md)                 | Hybrid temporal system (JSONB + generated sort columns) | Accepted (retro) | —                                          |
+| [0006](adr-0006-fractal-timeline-detail-timeline.md)       | Fractal timeline via forward `detail_timeline_id`       | Accepted (retro) | supersedes prior `parent_event_id`† (#180) |
+| [0007](adr-0007-seven-character-types.md)                  | Seven character types + type-specific columns           | Accepted (retro) | —                                          |
+| [0008](adr-0008-character-relationships-directed-pairs.md) | Character relationships as directed pairs               | Accepted (retro) | amended by 0009                            |
+| [0009](adr-0009-relationship-sub-role-taxonomy.md)         | Relationship sub-role taxonomy (`relationship_role`)    | Accepted (retro) | amends 0008 (#119)                         |
+| [0010](adr-0010-junction-table-conventions.md)             | Junction tables: composite PK, no surrogate id/user_id  | Accepted (retro) | —                                          |
+| [0011](adr-0011-publication-model.md)                      | Publication model: `published` boolean + `published_at` | Accepted (retro) | —                                          |
+| [0012](adr-0012-postgrest-crud-thin-service-layer.md)      | PostgREST for all CRUD + thin TS service layer          | Accepted (retro) | —                                          |
+| [0013](adr-0013-db-functions-read-only.md)                 | DB functions reserved for complex read-only queries     | Accepted (retro) | —                                          |
+| [0014](adr-0014-rls-single-source-of-authorization.md)     | RLS as the single source of authorization               | Accepted (retro) | —                                          |
+| [0015](adr-0015-rls-and-function-hardening.md)             | RLS + function hardening (DEFINER, search_path, perf)   | Accepted (retro) | —                                          |
+| [0016](adr-0016-storage-buckets-graduated-access.md)       | Storage buckets with graduated access control           | Accepted (retro) | —                                          |
+| [0017](adr-0017-auth-bootstrap-supporting-tables.md)       | Auth bootstrap (profile trigger, is_admin) + supporting | Accepted (retro) | —                                          |
+| [0018](adr-0018-curated-content-library.md)                | Curated content library (admin-owned + import)          | Accepted (retro) | —                                          |
+| [0019](adr-0019-services-package.md)                       | `@repo/services` package (clients, schemas, modules)    | Accepted (retro) | —                                          |
+| [0020](adr-0020-ui-package-shadcn-tailwind.md)             | `@repo/ui` on shadcn/ui + Tailwind 4                    | Accepted (retro) | —                                          |
+| [0021](adr-0021-tanstack-query-zustand.md)                 | TanStack Query (server) + Zustand (client) state        | Accepted (retro) | —                                          |
+| [0022](adr-0022-design-tokens-dual-source.md)              | Design tokens dual TS/CSS source + OKLCH + lucide       | Accepted (retro) | —                                          |
+| [0023](adr-0023-dark-mode-only-fidelity-2.md)              | Dark-mode-only for fidelity-2 (light mode deferred)     | Accepted (retro) | —                                          |
+| [0024](adr-0024-accessibility-first-visual-language.md)    | Accessibility-first visual language                     | Accepted (retro) | —                                          |
+| [0025](adr-0025-shared-mediapicker-bespoke-tree.md)        | `MediaPicker` shared primitive; bespoke `Tree` only     | Accepted (retro) | —                                          |
+| [0026](adr-0026-testing-strategy.md)                       | Testing strategy: pgTAP + Vitest 80% + Storybook        | Accepted (retro) | —                                          |
+| [0027](adr-0027-upstream-spec-bug-protocol.md)             | Upstream-spec-bug + PRD-reconciliation protocol         | Accepted (retro) | —                                          |
 
 † ADR `0006` supersedes the original event-to-event `parent_event_id` nesting
 approach, which was never given its own ADR; it is documented inside `0006` as
@@ -88,6 +92,9 @@ undocumented decision.
 2. Fill in front matter; set status to **Proposed** until accepted.
 3. Cite concrete evidence (migration file + section, doc section, or PR).
 4. Add a row to the [Index](#index) table.
-5. If it supersedes/amends another ADR, update both records' front matter and the
-   superseded ADR's status.
+5. If it **supersedes** another ADR, set `superseded_by` on the old ADR, set
+   `supersedes` on the new one, and flip the old ADR's status to **Superseded**.
+   If it merely **amends** another ADR (refines without reversing it), set
+   `amended_by` on the original and `amends` on the new one, and leave the
+   original's status unchanged.
 6. `npx prettier --write "docs/adr/**/*.md"` before committing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,15 +13,18 @@ migration or PR that implemented it) and carries the status **Accepted
 (retroactively documented 2026-05-30)**. They record _what was decided_, not a
 re-litigation of decided questions.
 
-New (forward) decisions start at **`0028`** — the first of which records the
-Milestone 7 period/category model — and follow the
+The first **forward** decision is `0028` (the Milestone 7 period/category
+model); the next new ADR is the next free number (`0029` onward), per the
 [ADR process](#when-to-write-an-adr) below.
 
 ## Format
 
 - File naming: `adr-NNNN-[title-slug].md` (4-digit zero-padded sequence).
 - Front matter + body per [`adr-0000-template.md`](adr-0000-template.md), the
-  `create-architectural-decision-record` skill template.
+  `create-architectural-decision-record` skill template. Every ADR carries the
+  full key set (`title`, `status`, `date`, `authors`, `tags`, `supersedes`,
+  `superseded_by`, `amends`, `amended_by`); relationship keys are empty strings
+  when not applicable.
 - Consequences/alternatives/implementation/references use coded bullets
   (`POS-`, `NEG-`, `ALT-`, `IMP-`, `REF-`) for machine parsing.
 - **Superseding** a decision sets `superseded_by` on the old ADR and

--- a/docs/adr/adr-0000-template.md
+++ b/docs/adr/adr-0000-template.md
@@ -6,6 +6,8 @@ authors: "[Stakeholder Names/Roles]"
 tags: ["architecture", "decision"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-NNNN: [Decision Title]

--- a/docs/adr/adr-0000-template.md
+++ b/docs/adr/adr-0000-template.md
@@ -1,0 +1,66 @@
+---
+title: "ADR-NNNN: [Decision Title]"
+status: "Proposed"
+date: "YYYY-MM-DD"
+authors: "[Stakeholder Names/Roles]"
+tags: ["architecture", "decision"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-NNNN: [Decision Title]
+
+## Status
+
+**Proposed** | Accepted | Rejected | Superseded | Deprecated
+
+> For decisions reconstructed after the fact, use:
+> **Accepted (retroactively documented YYYY-MM-DD)** and date the ADR to its
+> evidence (the migration or PR that implemented the decision).
+
+## Context
+
+[Problem statement, technical constraints, business requirements, and
+environmental factors requiring this decision.]
+
+## Decision
+
+[Chosen solution with clear rationale for selection.]
+
+## Consequences
+
+### Positive
+
+- **POS-001**: [Beneficial outcomes and advantages]
+- **POS-002**: [Performance, maintainability, scalability improvements]
+- **POS-003**: [Alignment with architectural principles]
+
+### Negative
+
+- **NEG-001**: [Trade-offs, limitations, drawbacks]
+- **NEG-002**: [Technical debt or complexity introduced]
+- **NEG-003**: [Risks and future challenges]
+
+## Alternatives Considered
+
+### [Alternative 1 Name]
+
+- **ALT-001**: **Description**: [Brief technical description]
+- **ALT-002**: **Rejection Reason**: [Why this option was not selected]
+
+### [Alternative 2 Name]
+
+- **ALT-003**: **Description**: [Brief technical description]
+- **ALT-004**: **Rejection Reason**: [Why this option was not selected]
+
+## Implementation Notes
+
+- **IMP-001**: [Key implementation considerations]
+- **IMP-002**: [Migration or rollout strategy if applicable]
+- **IMP-003**: [Monitoring and success criteria]
+
+## References
+
+- **REF-001**: [Related ADRs]
+- **REF-002**: [External documentation]
+- **REF-003**: [Standards or frameworks referenced]

--- a/docs/adr/adr-0001-supabase-backend-platform.md
+++ b/docs/adr/adr-0001-supabase-backend-platform.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "platform", "backend", "supabase"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0001: Supabase as the Backend Platform

--- a/docs/adr/adr-0001-supabase-backend-platform.md
+++ b/docs/adr/adr-0001-supabase-backend-platform.md
@@ -1,0 +1,104 @@
+---
+title: "ADR-0001: Supabase as the Backend Platform"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-03-01"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "platform", "backend", "supabase"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0001: Supabase as the Backend Platform
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — dated to the platform
+decision recorded in `docs/system-design.md` v3.0 (March 2026, §1.3, §2). This
+ADR records a decision that was already made and implemented; it does not
+re-open it.
+
+## Context
+
+Time Traveler is a greenfield temporal CMS that needs persistence, multi-user
+authentication, fine-grained authorization, file storage, real-time
+collaboration signals, and an API surface — across a data model that spans
+prehistoric/cosmological dates and seven character types. The team is small and
+the priority is shipping product features, not operating bespoke infrastructure.
+
+A conventional approach would be a hand-written backend API (Node/Express,
+NestJS, or similar) sitting in front of PostgreSQL, plus separately provisioned
+auth, object storage, and a websocket tier. That is a large amount of
+undifferentiated plumbing to build and maintain before any temporal feature
+ships.
+
+## Decision
+
+Adopt **Supabase** as the single backend platform. Supabase provides managed
+PostgreSQL, auto-generated REST (PostgREST), Auth, Realtime, Edge Functions
+(Deno), and Storage. There is **no custom backend API layer**: the schema _is_
+the API, authorization lives in Row Level Security (RLS), and the only
+server-side code is Edge Functions for orchestration that cannot run on the
+client. See `docs/system-design.md` §1.3 and §2.1–2.3.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Eliminates an entire backend service — PostgREST auto-generates
+  CRUD + nested joins from the schema, so there is no controller/route layer to
+  build or keep in sync with the database.
+- **POS-002**: Authorization is centralized in RLS (see ADR-0014), so every
+  access path — PostgREST, direct SQL, Edge Functions — enforces identical
+  rules.
+- **POS-003**: Auth, Storage, and Realtime are first-party and integrated with
+  the same Postgres identity (`auth.users` UUIDs), simplifying the data model
+  (see ADR-0017).
+- **POS-004**: `supabase gen types typescript` produces end-to-end types from
+  the database, feeding the typed service layer (ADR-0019).
+
+### Negative
+
+- **NEG-001**: Strong coupling to a single vendor's surface (PostgREST query
+  semantics, RLS, Edge Function runtime/timeouts). Portability away from
+  Supabase would require re-implementing the API and auth layers.
+- **NEG-002**: Business logic is pushed to two poles — the database (RLS,
+  generated columns, read functions) and the client/Edge Functions — with no
+  conventional middle tier, which constrains how some logic can be expressed.
+- **NEG-003**: Edge Functions inherit Deno + 30s timeout constraints, shaping
+  bulk import/export design (see `docs/system-design.md` §5.5).
+
+## Alternatives Considered
+
+### Custom Node/Express API + self-managed Postgres
+
+- **ALT-001**: **Description**: Hand-rolled REST/GraphQL API, separate auth
+  (e.g., Auth.js), object storage (S3), and websocket service.
+- **ALT-002**: **Rejection Reason**: Maximum control but maximum undifferentiated
+  work; the team would build auth, RLS-equivalent authorization, type
+  generation, and realtime from scratch before any temporal feature.
+
+### Firebase / Firestore
+
+- **ALT-003**: **Description**: Managed NoSQL document store with built-in auth
+  and realtime.
+- **ALT-004**: **Rejection Reason**: The temporal sort/range model and the
+  relational character/event/junction graph need SQL — generated columns,
+  recursive CTEs, full-text search, and relational integrity — which a document
+  store does not provide naturally.
+
+## Implementation Notes
+
+- **IMP-001**: All schema, RLS, functions, and views ship as numbered SQL
+  migrations under `supabase/migrations/` (`00001`–`00015`).
+- **IMP-002**: Local development uses the Supabase CLI (`pnpm run db:start`,
+  `db:reset`, `db:test`); deployment uses `supabase db push`.
+- **IMP-003**: Service-role secrets are server-only; the anon key is the only
+  Supabase credential exposed to the browser (see ADR-0017, ADR-0019).
+
+## References
+
+- **REF-001**: ADR-0012 (PostgREST for CRUD), ADR-0013 (read-only DB functions),
+  ADR-0014 (RLS authorization), ADR-0016 (Storage), ADR-0017 (Auth bootstrap)
+- **REF-002**: `docs/system-design.md` §1.3, §2.1–2.3, §5
+- **REF-003**: Supabase platform documentation (PostgREST, Auth, RLS, Realtime,
+  Storage, Edge Functions)

--- a/docs/adr/adr-0002-pnpm-turborepo-monorepo.md
+++ b/docs/adr/adr-0002-pnpm-turborepo-monorepo.md
@@ -1,0 +1,92 @@
+---
+title: "ADR-0002: pnpm + Turborepo Monorepo"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-03-01"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "monorepo", "tooling", "turborepo", "pnpm"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0002: pnpm + Turborepo Monorepo
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — dated to the project
+structure recorded in `docs/system-design.md` §11 and realized in the repository
+root (`pnpm-workspace.yaml`, `turbo.json`).
+
+## Context
+
+Time Traveler comprises multiple deployable surfaces (an admin app, a docs app,
+and a future public reader) plus shared infrastructure: UI primitives, the
+Supabase service layer, and shared lint/TypeScript configuration. These need to
+share types and components without publishing internal packages to a registry,
+and the build must guarantee that shared packages are built before the apps that
+consume them.
+
+## Decision
+
+Use a **pnpm workspace** orchestrated by **Turborepo**, with two top-level
+globs: `apps/*` (deployable Next.js apps — `admin`, `docs`) and `packages/*`
+(shared libraries — `@repo/ui`, `@repo/services`, `@repo/eslint-config`,
+`@repo/typescript-config`). The Turborepo task graph declares `build` depends on
+`^build`, so internal packages build before the apps. See
+`pnpm-workspace.yaml`, `turbo.json`, and `docs/system-design.md` §11.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Shared code (`@repo/ui`, `@repo/services`) is consumed by source
+  import across the workspace with no publish step and no version skew.
+- **POS-002**: pnpm's content-addressed store keeps installs fast and disk-cheap;
+  strict hoisting surfaces undeclared dependencies early.
+- **POS-003**: Turborepo caching makes incremental `build`/`lint`/`check-types`
+  near-instant ("FULL TURBO") and the `^build` edge prevents app-before-package
+  build ordering bugs.
+- **POS-004**: A single root `verify` script
+  (`format:check && lint && check-types && test:coverage && build`) gives one
+  command that mirrors CI.
+
+### Negative
+
+- **NEG-001**: Contributors must understand the task graph — building a single
+  app in isolation without its package dependencies is a known footgun (noted in
+  `CLAUDE.md`).
+- **NEG-002**: Workspace tooling (pnpm version pin, Turbo config) is additional
+  surface to keep current across Node/toolchain upgrades.
+
+## Alternatives Considered
+
+### Multiple independent repositories
+
+- **ALT-001**: **Description**: One repo per app/library, sharing code via
+  published npm packages.
+- **ALT-002**: **Rejection Reason**: Version-skew and release friction for code
+  that changes together; cross-cutting changes (a schema type plus its UI plus
+  its service) would span multiple PRs across repos.
+
+### npm/yarn workspaces without Turborepo
+
+- **ALT-003**: **Description**: A workspace using npm or Yarn and bespoke scripts
+  for task orchestration.
+- **ALT-004**: **Rejection Reason**: No incremental task cache or dependency-aware
+  task graph; build ordering and caching would be hand-maintained.
+
+## Implementation Notes
+
+- **IMP-001**: Workspace globs `apps/*`, `packages/*` in `pnpm-workspace.yaml`;
+  package manager pinned via `package.json` `packageManager` (`pnpm@11.2.2`).
+- **IMP-002**: Shared configs are themselves packages
+  (`@repo/eslint-config`, `@repo/typescript-config`) extended by each app/package
+  (see ADR-0004).
+- **IMP-003**: Coverage from every package is merged at the root
+  (`merge:coverage`) for a single repo-level report.
+
+## References
+
+- **REF-001**: ADR-0003 (apps), ADR-0004 (shared standards), ADR-0019/0020
+  (`@repo/services`, `@repo/ui`)
+- **REF-002**: `docs/system-design.md` §11; `pnpm-workspace.yaml`; `turbo.json`
+- **REF-003**: Turborepo + pnpm workspace documentation

--- a/docs/adr/adr-0002-pnpm-turborepo-monorepo.md
+++ b/docs/adr/adr-0002-pnpm-turborepo-monorepo.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "monorepo", "tooling", "turborepo", "pnpm"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0002: pnpm + Turborepo Monorepo

--- a/docs/adr/adr-0003-nextjs-app-router-react19.md
+++ b/docs/adr/adr-0003-nextjs-app-router-react19.md
@@ -1,0 +1,93 @@
+---
+title: "ADR-0003: Next.js 16 App Router + React 19, Split admin/docs Apps"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-03-01"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "frontend", "nextjs", "react"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0003: Next.js 16 App Router + React 19, Split admin/docs Apps
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — dated to the presentation
+layer recorded in `docs/system-design.md` §2 and §11 and realized in
+`apps/admin` and `apps/docs`.
+
+## Context
+
+The product needs server-rendered, auth-gated CRUD surfaces (the admin app), a
+separate documentation surface, and a future public reader surface. The frontend
+must integrate cleanly with Supabase server-side auth (cookie-based sessions),
+support React Server Components for data-heavy pages, and share a design system
+across surfaces.
+
+## Decision
+
+Build the frontends on **Next.js 16 (App Router)** with **React 19**, as
+**separate apps** in the monorepo (`apps/admin` on port 3000, `apps/docs` on
+port 3001). Both apps declare `"type": "module"` (ESM), extend the shared
+`@repo/typescript-config/nextjs.json`, and consume `@repo/ui` and
+`@repo/services`. Route groups (`(public)`, `(protected)`, `(admin)`, `auth`)
+segment access tiers, and Next 16's edge proxy (`apps/admin/proxy.ts`, the
+middleware successor) gates protected routes. See `docs/system-design.md` §2.2,
+§7.5, §11.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: App Router + Server Components allow auth and initial data to load
+  server-side (cookie session via `@supabase/ssr`), keeping the anon-key client
+  thin and avoiding auth flashes.
+- **POS-002**: Route groups express the public/protected/admin access tiers as
+  filesystem structure, aligning the app surface with the RLS model (ADR-0014).
+- **POS-003**: Splitting `admin` and `docs` keeps deploy units, dependencies, and
+  build times independent while still sharing `@repo/ui`/`@repo/services`.
+- **POS-004**: React 19 + Next 16 are the current major lines, aligning the team
+  with first-class Server Actions and modern data APIs.
+
+### Negative
+
+- **NEG-001**: Bleeding-edge majors (Next 16, React 19) carry ecosystem-maturity
+  risk; some libraries lag the React 19 release.
+- **NEG-002**: The App Router's server/client boundary and caching model have a
+  real learning curve and are easy to misuse.
+- **NEG-003**: Per-app duplication of some config (eslint/tsconfig wrappers,
+  `next.config.js`) is the cost of independent deploy units.
+
+## Alternatives Considered
+
+### A single Next.js app with everything
+
+- **ALT-001**: **Description**: One app hosting admin, docs, and public reader
+  under one deployment.
+- **ALT-002**: **Rejection Reason**: Couples deploy cadence and dependency sets of
+  surfaces with very different audiences and security postures; the public
+  reader's design genre diverges sharply from admin (see ADR-0024).
+
+### A client-only SPA (Vite/React Router)
+
+- **ALT-003**: **Description**: A non-SSR single-page app talking directly to
+  Supabase from the browser.
+- **ALT-004**: **Rejection Reason**: Loses server-side session handling, SSR/SEO
+  for public content, and Server Components for data-heavy admin pages.
+
+## Implementation Notes
+
+- **IMP-001**: Target host is Vercel for the frontends; Supabase hosts the
+  backend (`docs/system-design.md` §2.2, §10).
+- **IMP-002**: Auth route protection is in `apps/admin/proxy.ts`; auth utilities
+  live in `apps/admin/lib/auth/` (see ADR-0017).
+- **IMP-003**: The admin app is being built incrementally from the fidelity-2
+  design system (ADR-0020); placeholder routes precede data-driven pages.
+
+## References
+
+- **REF-001**: ADR-0002 (monorepo), ADR-0004 (standards), ADR-0017 (auth),
+  ADR-0020 (UI), ADR-0021 (state)
+- **REF-002**: `docs/system-design.md` §2.2, §7.5, §11;
+  `docs/design/admin/fidelity-2-plan.md`
+- **REF-003**: Next.js App Router + React 19 documentation

--- a/docs/adr/adr-0003-nextjs-app-router-react19.md
+++ b/docs/adr/adr-0003-nextjs-app-router-react19.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "frontend", "nextjs", "react"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0003: Next.js 16 App Router + React 19, Split admin/docs Apps

--- a/docs/adr/adr-0004-engineering-standards.md
+++ b/docs/adr/adr-0004-engineering-standards.md
@@ -1,0 +1,98 @@
+---
+title: "ADR-0004: Engineering Standards — Strict TS, Zero-Warning Lint, ESM, Supply-Chain Delay"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-03-01"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags:
+  ["architecture", "decision", "standards", "typescript", "eslint", "security"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0004: Engineering Standards — Strict TS, Zero-Warning Lint, ESM, Supply-Chain Delay
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — dated to the shared config
+packages and root tooling (`packages/eslint-config`, `packages/typescript-config`,
+`pnpm-workspace.yaml`, `.npmrc`).
+
+## Context
+
+A monorepo with a typed Supabase service layer, shared UI primitives, and several
+apps needs uniform, enforced engineering standards so that quality does not drift
+per-package and so that automated agents and contributors produce consistent
+code. The standards must be machine-enforced (in CI and pre-commit), not
+convention-by-documentation.
+
+## Decision
+
+Adopt four repo-wide, machine-enforced standards, packaged as shared config and
+root settings:
+
+1. **Strict TypeScript** — `strict`, `strictNullChecks`, and
+   `noUncheckedIndexedAccess` enabled in `@repo/typescript-config`; all types
+   explicit, no implicit `any`.
+2. **Zero-warning ESLint** — every app/package runs `eslint --max-warnings 0`
+   via `@repo/eslint-config`; a warning fails the build.
+3. **ESM everywhere** — apps and packages declare `"type": "module"` and use
+   ESM `import`/`export`.
+4. **Supply-chain release delay** — `minimumReleaseAge: 10` (minutes) in
+   `pnpm-workspace.yaml` and `minimum-release-age=10 minutes` in `.npmrc`, plus
+   an explicit `allowBuilds` allowlist (`esbuild`, `sharp`), so freshly published
+   (and quickly-withdrawn) malicious package versions cannot be installed
+   immediately.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: `noUncheckedIndexedAccess` + strict null checks catch a large
+  class of runtime errors at compile time, which matters for the dynamic JSONB
+  temporal data and generated DB types.
+- **POS-002**: Zero-warning lint prevents slow quality erosion; there is no
+  "acceptable warning" backlog.
+- **POS-003**: ESM-everywhere removes dual-module hazards and aligns with Next 16
+  / Deno Edge Functions.
+- **POS-004**: The release-age delay closes the immediate-publish supply-chain
+  attack window without blocking ordinary day-old dependencies.
+
+### Negative
+
+- **NEG-001**: Strict settings and zero-warning lint raise the cost of quick
+  prototypes; every change must be type-clean and lint-clean to merge.
+- **NEG-002**: `noUncheckedIndexedAccess` adds null-guard ceremony around array
+  and record access.
+- **NEG-003**: The release-age gate can briefly block adopting a just-published
+  fix; the `allowBuilds` allowlist must be maintained as native-build deps change.
+
+## Alternatives Considered
+
+### Loose/default TypeScript + warnings allowed
+
+- **ALT-001**: **Description**: Default `tsconfig` strictness and ESLint run
+  without `--max-warnings 0`.
+- **ALT-002**: **Rejection Reason**: Permits null-safety gaps and a growing
+  warning backlog that erodes signal; rejected for a typed, multi-author repo.
+
+### No supply-chain delay
+
+- **ALT-003**: **Description**: Install any published version immediately.
+- **ALT-004**: **Rejection Reason**: Leaves the repo exposed to publish-then-yank
+  malware; a 10-minute floor is a near-zero-cost mitigation.
+
+## Implementation Notes
+
+- **IMP-001**: Standards live in `@repo/typescript-config` (`base.json`,
+  `nextjs.json`, `react-library.json`) and `@repo/eslint-config` (`base`,
+  `next`, `react-internal`), extended by every app/package.
+- **IMP-002**: Enforced in CI (lint, type-check, build, test jobs) and locally
+  via Husky pre-commit and the root `verify` script.
+- **IMP-003**: `prettier` formats `{ts,tsx,md}`; `format:check` gates CI.
+
+## References
+
+- **REF-001**: ADR-0002 (monorepo), ADR-0026 (testing strategy)
+- **REF-002**: `packages/typescript-config/*`, `packages/eslint-config/*`,
+  `pnpm-workspace.yaml`, `.npmrc`, `.github/copilot-instructions.md`
+- **REF-003**: pnpm `minimumReleaseAge` documentation

--- a/docs/adr/adr-0004-engineering-standards.md
+++ b/docs/adr/adr-0004-engineering-standards.md
@@ -7,6 +7,8 @@ tags:
   ["architecture", "decision", "standards", "typescript", "eslint", "security"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0004: Engineering Standards — Strict TS, Zero-Warning Lint, ESM, Supply-Chain Delay

--- a/docs/adr/adr-0005-hybrid-temporal-system.md
+++ b/docs/adr/adr-0005-hybrid-temporal-system.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "data-model", "temporal", "jsonb"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0005: Hybrid Temporal System (JSONB + Generated Sort Columns)

--- a/docs/adr/adr-0005-hybrid-temporal-system.md
+++ b/docs/adr/adr-0005-hybrid-temporal-system.md
@@ -1,0 +1,119 @@
+---
+title: "ADR-0005: Hybrid Temporal System (JSONB + Generated Sort Columns)"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-21"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "data-model", "temporal", "jsonb"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0005: Hybrid Temporal System (JSONB + Generated Sort Columns)
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00001_initial_schema.sql` (2026-05-21); specified in
+`docs/system-design.md` §4.
+
+## Context
+
+Time Traveler must represent dates spanning the Big Bang (~14 billion years ago)
+through the speculative future, with precision metadata, uncertainty ranges, and
+scientific dating provenance. Native date types cannot express this:
+`TIMESTAMPTZ` bottoms out around 4713 BC and JavaScript `Date` is even more
+restrictive; a `VARCHAR` date is unbounded but unsortable, unqueryable, and
+unvalidated (`docs/system-design.md` §4.1). The system also needs cheap
+chronological ordering and range-overlap queries across these wildly different
+scales.
+
+## Decision
+
+Store every temporal point as a structured **`temporal_data JSONB`** column
+(`{ year, era, precision, uncertainty, geological_period, … }`, eras
+`CE/BCE/KYA/MYA/BYA`) and derive an indexable single numeric axis with a
+generated column `sort_order_* BIGINT GENERATED ALWAYS AS (… era conversion …)
+STORED`. Supporting decisions, all in `00001`:
+
+- **Separate start/end columns** — `temporal_data`/`sort_order_*` and
+  `end_temporal_data`/`sort_order_end` are distinct column pairs, not nested,
+  enabling range-overlap queries and one-schema-per-object validation
+  (§4.3).
+- **Computed `TIMESTAMPTZ` for CE dates** — a generated `computed_*_date` column
+  materializes a native timestamp for in-range CE dates only, via
+  `make_timestamp(...) AT TIME ZONE 'UTC'` (both `IMMUTABLE`, so legal in a
+  generated column; `make_timestamptz` is `STABLE` and cannot be used) (§4.5).
+- **Integer-only year** — the `(temporal_data->>'year')::BIGINT` cast rejects
+  fractional years; sub-year precision is meaningless at KYA/MYA/BYA scale, so
+  validation enforces whole integers (§4.4, issues #23/#24).
+- **Validation in Zod, not DB CHECK** — JSONB shape is validated in TypeScript
+  (`packages/services/src/schemas/temporal.ts`), shared across form/API/seed
+  (§4.6).
+
+The era-conversion formula in the generated columns is the canonical sort
+mapping reused everywhere; the `TemporalService` (ADR-0019) mirrors it in TS.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: One representation covers cosmological to second-level dates, with
+  precision/uncertainty/provenance carried alongside the value.
+- **POS-002**: `sort_order_*` collapses all eras to a comparable `BIGINT`, so
+  ordering and `WHERE sort_order_years <= :end AND sort_order_end >= :start`
+  range queries work across scales and are indexable (ADR-0026 indexes).
+- **POS-003**: CE dates still get native timestamp operations via the computed
+  column without sacrificing the universal axis.
+- **POS-004**: Validation is testable TypeScript shared by forms, services, and
+  seeds, not brittle JSONB CHECK constraints.
+
+### Negative
+
+- **NEG-001**: Temporal correctness depends on application-layer (Zod) validation
+  — the database does not enforce JSONB shape, so a bad writer bypassing Zod can
+  insert malformed `temporal_data`.
+- **NEG-002**: Generated columns are constrained to `IMMUTABLE` expressions,
+  which forced non-obvious choices (`immutable_array_to_string`,
+  `make_timestamp … AT TIME ZONE`) — easy to get wrong when extending.
+- **NEG-003**: The era model (`CE/BCE/KYA/MYA/BYA`) is fixed; adding a new scale
+  means touching every generated column and the `TemporalService`.
+
+## Alternatives Considered
+
+### Native TIMESTAMPTZ columns
+
+- **ALT-001**: **Description**: Store dates in PostgreSQL's native timestamp type.
+- **ALT-002**: **Rejection Reason**: Cannot represent anything before ~4713 BC —
+  excludes the prehistoric/geological/cosmological range that is core to the
+  product.
+
+### VARCHAR date strings
+
+- **ALT-003**: **Description**: Free-form date text.
+- **ALT-004**: **Rejection Reason**: No sorting, no range queries, no validation
+  — unusable for a timeline product.
+
+### End dates nested inside the start JSONB (the v2 design)
+
+- **ALT-005**: **Description**: Embed `end_year`/`end_era` inside `temporal_data`.
+- **ALT-006**: **Rejection Reason**: Breaks clean range-overlap queries and forces
+  a two-schema JSONB object; separate columns are simpler (§4.3).
+
+## Implementation Notes
+
+- **IMP-001**: Era conversion: `CE → year`, `BCE → -year`, `KYA → -year×1e3`,
+  `MYA → -year×1e6`, `BYA → -year×1e9` (`00001`; `docs/system-design.md` §4.4).
+- **IMP-002**: `immutable_array_to_string` is the sanctioned `IMMUTABLE` wrapper
+  for `array_to_string` inside generated `search_vector` columns — reuse it,
+  don't reinvent (`00001`).
+- **IMP-003**: Logarithmic display positioning (`sign × log10(|sort| + 1)`) is a
+  client concern in `TemporalService`, not stored (§6.3).
+
+## References
+
+- **REF-001**: ADR-0011 (publication columns alongside temporal),
+  ADR-0013 (`events_in_temporal_range` read function), ADR-0019 (TemporalService),
+  ADR-0026 (temporal indexes)
+- **REF-002**: `supabase/migrations/00001_initial_schema.sql`;
+  `docs/system-design.md` §4, §6
+- **REF-003**: PostgreSQL generated columns + `IMMUTABLE` function requirements

--- a/docs/adr/adr-0006-fractal-timeline-detail-timeline.md
+++ b/docs/adr/adr-0006-fractal-timeline-detail-timeline.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "data-model", "fractal", "timeline"]
 supersedes: "Original event-to-event parent_event_id nesting (never given its own ADR; tombstoned per #180)"
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0006: Fractal Timeline via Forward detail_timeline_id

--- a/docs/adr/adr-0006-fractal-timeline-detail-timeline.md
+++ b/docs/adr/adr-0006-fractal-timeline-detail-timeline.md
@@ -1,0 +1,113 @@
+---
+title: "ADR-0006: Fractal Timeline via Forward detail_timeline_id"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-21"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "data-model", "fractal", "timeline"]
+supersedes: "Original event-to-event parent_event_id nesting (never given its own ADR; tombstoned per #180)"
+superseded_by: ""
+---
+
+# ADR-0006: Fractal Timeline via Forward detail_timeline_id
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — the schema is in
+`supabase/migrations/00001_initial_schema.sql` (2026-05-21); the forward-only
+model and the deprecation of `parent_event_id` are specified in
+`docs/system-design.md` §1.2 and §3.2 (issues #177, #180). This ADR
+**supersedes** the original event-to-event `parent_event_id` nesting approach.
+
+## Context
+
+Fractal time navigation — zooming seamlessly from billion-year geological scales
+to individual seconds — is a defining feature (`docs/system-design.md` §1.2).
+The recursion needs a representation that (a) preserves the committed event RLS
+model, (b) avoids cross-timeline integrity holes, and (c) keeps each zoom level
+to a bounded query.
+
+The initial schema included `events.parent_event_id` (a self-referential FK) for
+event-to-event nesting. This conflates two distinct axes — _containment_ (which
+timeline shows an event) and _decomposition_ (what an event expands into) — and
+permits parent links that cross timeline boundaries, creating RLS and integrity
+ambiguity.
+
+## Decision
+
+Make nesting **forward-only** through the timeline: the recursion unit is the
+**timeline**, and an event expands into its own sub-timeline via
+`events.detail_timeline_id` (`ON DELETE SET NULL`). The hierarchy is
+`timeline → events → (event expands into) sub-timeline → events`, recursing on
+the timeline. The two event↔timeline axes are kept strictly separate
+(`docs/system-design.md` §3.2):
+
+| Mechanism             | Axis          | Meaning                                              |
+| --------------------- | ------------- | ---------------------------------------------------- |
+| `events.timeline_id`  | containment   | Primary/home timeline — **the RLS source**           |
+| `timeline_events`     | containment   | Additional "also appears in" membership (not RLS)    |
+| `detail_timeline_id`  | decomposition | The sub-timeline this event drills into              |
+| ~~`parent_event_id`~~ | decomposition | **Deprecated (#180)** — tombstoned and to be dropped |
+
+Access flows from the containing timeline _down_ to its events; a sub-timeline's
+collaborators never gain access to the parent event through the fractal link.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Event RLS stays keyed on the _containing_ `timeline_id`, never the
+  child `detail_timeline_id`, so the fractal feature ships without touching the
+  committed `read_events`/`update_events` policies (ADR-0014).
+- **POS-002**: Eliminates the cross-timeline parent-link integrity holes that
+  `parent_event_id` permitted.
+- **POS-003**: Each zoom level is one bounded query (the sub-timeline's events),
+  not an unbounded recursive event tree walk.
+- **POS-004**: Matches the admin wireframes' information architecture
+  (`docs/design/admin/`), which spec the forward drill-down.
+
+### Negative
+
+- **NEG-001**: Decomposition cycles (an event expands into a timeline that
+  transitively contains it) are **not** DB-constrained; the service layer must
+  reject cycle-closing `detail_timeline_id` assignments (#177,
+  `docs/system-design.md` §3.4).
+- **NEG-002**: The full transition is staged — `detail_timeline_id` is pending
+  migration #177 and `parent_event_id` is tombstoned pending its drop (#180), so
+  the schema temporarily carries both mechanisms.
+
+## Alternatives Considered
+
+### Event-to-event nesting via `parent_event_id` (the original approach — superseded)
+
+- **ALT-001**: **Description**: A self-referential FK on `events` forming a parent
+  tree of events.
+- **ALT-002**: **Rejection Reason**: Conflates containment with decomposition,
+  allows parent links across timelines (RLS/integrity holes), and turns each zoom
+  into a recursive tree walk. Superseded by the forward model; tombstoned (#180).
+
+### Materialized-path / nested-set on events
+
+- **ALT-003**: **Description**: Encode the hierarchy with a path or left/right
+  bounds column.
+- **ALT-004**: **Rejection Reason**: Heavy write-time maintenance and still
+  event-centric; the timeline-as-recursion-unit model fits the product's zoom
+  semantics and existing RLS better.
+
+## Implementation Notes
+
+- **IMP-001**: `detail_timeline_id` and `timeline_id` are both
+  `ON DELETE SET NULL` to `timelines`; deleting a sub-timeline detaches the
+  drill-down rather than cascading into the parent event (§3.2, §3.4).
+- **IMP-002**: Reverse-lookup index
+  `idx_events_detail_timeline ON events (detail_timeline_id) WHERE detail_timeline_id IS NOT NULL`
+  (pending #177) answers "which event details this timeline?".
+- **IMP-003**: `parent_event_id` and `idx_events_parent` are deprecated and
+  dropped in a later migration once confirmed unused (#180).
+
+## References
+
+- **REF-001**: ADR-0010 (junction conventions, `timeline_events`),
+  ADR-0014 (event RLS keyed on `timeline_id`)
+- **REF-002**: `supabase/migrations/00001_initial_schema.sql`;
+  `docs/system-design.md` §1.2, §3.2, §3.4; issues #177, #180
+- **REF-003**: `docs/design/admin/` wireframes (forward drill-down IA)

--- a/docs/adr/adr-0006-fractal-timeline-detail-timeline.md
+++ b/docs/adr/adr-0006-fractal-timeline-detail-timeline.md
@@ -53,6 +53,12 @@ the timeline. The two event↔timeline axes are kept strictly separate
 Access flows from the containing timeline _down_ to its events; a sub-timeline's
 collaborators never gain access to the parent event through the fractal link.
 
+This rejection is **event-specific**: it is the conflation of containment and
+decomposition on `events` that fails. Genuine single-axis containment trees keep
+their self-referential parent FK — `periods.parent_period_id` and
+`categories.parent_category_id` are retained for exactly this reason
+(ADR-0028).
+
 ## Consequences
 
 ### Positive
@@ -109,7 +115,8 @@ collaborators never gain access to the parent event through the fractal link.
 ## References
 
 - **REF-001**: ADR-0010 (junction conventions, `timeline_events`),
-  ADR-0014 (event RLS keyed on `timeline_id`)
+  ADR-0014 (event RLS keyed on `timeline_id`), ADR-0028 (period/category
+  containment hierarchies retain their parent FK)
 - **REF-002**: `supabase/migrations/00001_initial_schema.sql`;
   `docs/system-design.md` §1.2, §3.2, §3.4; issues #177, #180
 - **REF-003**: `docs/design/admin/` wireframes (forward drill-down IA)

--- a/docs/adr/adr-0007-seven-character-types.md
+++ b/docs/adr/adr-0007-seven-character-types.md
@@ -1,0 +1,103 @@
+---
+title: "ADR-0007: Seven Character Types with Type-Specific Columns + profile_data JSONB"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-21"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "data-model", "characters"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0007: Seven Character Types with Type-Specific Columns + profile_data JSONB
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00001_initial_schema.sql` (2026-05-21); specified in
+`docs/system-design.md` §1.2, §3.2 (`characters`), §14.
+
+## Context
+
+Time Traveler models not just _what_ happened but _who_ was involved, across very
+different kinds of actors: real people, animals, mythological figures, fictional
+characters, organizations, deities, and artifacts. These share a common spine
+(name, biography, temporal birth/death, significance, media, relationships, event
+participation) but diverge in a few filterable attributes (an animal has a
+species/breed; a deity has a domain) and in long-tail, type-specific metadata.
+
+## Decision
+
+Model all actors in a single `characters` table with a `character_type VARCHAR
+CHECK` enum of **seven values**: `human`, `animal`, `mythological`, `fictional`,
+`organization`, `divine`, `artifact`. Attribute storage is split three ways:
+
+- **Shared columns** for the common spine (`name`, `biography`, `aliases TEXT[]`,
+  `significance`, `birth_temporal`/`death_temporal` JSONB, etc.).
+- **Dedicated columns for a few filterable type-specific fields** — `species`,
+  `breed`, `domain` — because they are queried/filtered and deserve indexing,
+  not burial in JSONB.
+- **`profile_data JSONB`** for open-ended, type-specific metadata that should not
+  cost a schema change.
+
+Birth/death use the hybrid temporal JSONB (ADR-0005), so a species' emergence and
+extinction can be expressed at MYA scale just like a person's CE birth date.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: One table + one enum keeps events, relationships, media, and RLS
+  uniform across all actor kinds — a deity and an organization both participate in
+  events and relationships through the same junctions.
+- **POS-002**: Filterable fields (`species`, `breed`, `domain`) stay first-class
+  and indexable (`idx_characters_type`), while `profile_data` absorbs the long
+  tail without migrations.
+- **POS-003**: Temporal birth/death reuse ADR-0005, so prehistoric/mythological
+  actors are representable with the same precision/uncertainty machinery.
+
+### Negative
+
+- **NEG-001**: Type-specific columns are sparse — `species`/`breed` are null for
+  most non-animal rows; the cost of a wide-but-sparse table is accepted over
+  per-type tables.
+- **NEG-002**: `profile_data` is schema-less JSONB: its per-type shape is a
+  client/Zod convention, not a DB constraint, so structure drift is possible.
+- **NEG-003**: The seven-value enum is fixed in a CHECK constraint; adding an
+  eighth type (the PRD hints at places/languages) requires a migration and
+  visual-language extension (ADR-0024).
+
+## Alternatives Considered
+
+### One table per character type
+
+- **ALT-001**: **Description**: Separate `humans`, `animals`, `deities`, …
+  tables.
+- **ALT-002**: **Rejection Reason**: Multiplies junctions, RLS policies, and
+  service code by seven; every event-participant query would need a union across
+  type tables.
+
+### Single table, everything in JSONB
+
+- **ALT-003**: **Description**: Only `character_type` + a single JSONB blob for
+  all attributes.
+- **ALT-004**: **Rejection Reason**: Loses indexable/filterable columns and
+  full-text search on `name`/`biography`/`aliases`; filtering by species/type
+  would require JSONB expression indexes everywhere.
+
+## Implementation Notes
+
+- **IMP-001**: `character_type` enum and the type-specific columns are defined in
+  `00001`; `idx_characters_type` and `idx_characters_aliases` (GIN) support
+  lookups (`docs/system-design.md` §8.1).
+- **IMP-002**: `search_vector` over `name`/`biography`/`aliases` uses
+  `immutable_array_to_string` (ADR-0005).
+- **IMP-003**: The visual system gives each type an icon + low-chroma tint +
+  label (ADR-0024); the enum list is the contract for that mapping.
+
+## References
+
+- **REF-001**: ADR-0005 (temporal birth/death), ADR-0008 (relationships),
+  ADR-0024 (character-type-as-identity visuals)
+- **REF-002**: `supabase/migrations/00001_initial_schema.sql`;
+  `docs/system-design.md` §3.2, §14
+- **REF-003**: PRD §3 (character system)

--- a/docs/adr/adr-0007-seven-character-types.md
+++ b/docs/adr/adr-0007-seven-character-types.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "data-model", "characters"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0007: Seven Character Types with Type-Specific Columns + profile_data JSONB

--- a/docs/adr/adr-0008-character-relationships-directed-pairs.md
+++ b/docs/adr/adr-0008-character-relationships-directed-pairs.md
@@ -5,7 +5,9 @@ date: "2026-05-21"
 authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "data-model", "relationships"]
 supersedes: ""
-superseded_by: "Amended by ADR-0009 (relationship_role sub-roles, #119)"
+superseded_by: ""
+amends: ""
+amended_by: "ADR-0009 (relationship_role sub-roles, #119)"
 ---
 
 # ADR-0008: Character Relationships as Directed Pairs with Application-Layer Symmetry

--- a/docs/adr/adr-0008-character-relationships-directed-pairs.md
+++ b/docs/adr/adr-0008-character-relationships-directed-pairs.md
@@ -1,0 +1,107 @@
+---
+title: "ADR-0008: Character Relationships as Directed Pairs with Application-Layer Symmetry"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-21"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "data-model", "relationships"]
+supersedes: ""
+superseded_by: "Amended by ADR-0009 (relationship_role sub-roles, #119)"
+---
+
+# ADR-0008: Character Relationships as Directed Pairs with Application-Layer Symmetry
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00002_relationships_junctions.sql` (2026-05-21); specified
+in `docs/system-design.md` §3.3. **Amended by ADR-0009**, which adds the
+`relationship_role` sub-role taxonomy.
+
+## Context
+
+Characters relate to one another (family, professional, rivalry, mentorship,
+ownership, worship, …), and those relationships are temporally scoped (they have
+start/end dates) and can be of multiple types between the same pair. The model
+needs to support both inherently directional relationships (mentor→student,
+owner→pet) and symmetric ones (friendship), without duplicating every symmetric
+edge.
+
+## Decision
+
+Store relationships in a dedicated `character_relationships` table as **directed
+pairs**: `(character_id, related_character_id, relationship_type)` with its own
+`user_id` (unlike the junction tables — see ADR-0010), temporal scope
+(`start_temporal`/`end_temporal` JSONB), and `description`/`metadata`.
+Constraints:
+
+- `CHECK (character_id != related_character_id)` — no self-relationships.
+- `UNIQUE (character_id, related_character_id, relationship_type)` — prevents
+  duplicate edges while allowing the same pair to carry multiple types.
+
+**Symmetry is an application-layer concern**: bidirectional relationships
+(friendship) are not double-stored; the service/UI queries in both directions
+(`character_id = X OR related_character_id = X`). Because the table owns a
+`user_id`, RLS is simple ownership (ADR-0014), rather than the more expensive
+"visible if either character is visible" interpretation, which was explicitly
+rejected (`docs/system-design.md` §9.2.5).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: A single row per relationship edge — no symmetric duplication to
+  keep in sync.
+- **POS-002**: Directional relationships are natural (the pair order encodes
+  direction); the unique index still allows multiple distinct types per pair.
+- **POS-003**: The owning `user_id` gives deterministic, cheap ownership-based RLS
+  without recursive evaluation through the characters policy.
+- **POS-004**: Temporal scoping reuses ADR-0005, so a mentorship that ran
+  1200–1210 CE or a species-rivalry at MYA scale are both expressible.
+
+### Negative
+
+- **NEG-001**: Symmetry correctness lives in application code — every query that
+  wants "all relationships of X" must remember to check both columns.
+- **NEG-002**: The `relationship_type` enum collapses semantically distinct
+  sub-roles (family = spouse/parent/child/…) into one value — the gap addressed
+  by ADR-0009.
+- **NEG-003**: `character_id`/`related_character_id` traversal direction in
+  network queries needed later clarification (flagged
+  `// DECISION NEEDED` in the service layer).
+
+## Alternatives Considered
+
+### Double-stored symmetric edges
+
+- **ALT-001**: **Description**: Insert both `(A,B)` and `(B,A)` for symmetric
+  relationships.
+- **ALT-002**: **Rejection Reason**: Doubles storage and creates a consistency
+  burden (update/delete both rows); a single row + bidirectional query is
+  cheaper.
+
+### "Visible if either character is visible" RLS
+
+- **ALT-003**: **Description**: A relationship is readable if either endpoint
+  character is readable.
+- **ALT-004**: **Rejection Reason**: Requires recursive RLS evaluation through the
+  characters policy; rejected in favor of the deterministic `user_id` ownership
+  check (§9.2.5).
+
+## Implementation Notes
+
+- **IMP-001**: Table, `CHECK`, and `char_rels_unique` index in `00002`; indexes
+  `idx_char_rels_char` / `idx_char_rels_related` support both traversal
+  directions (`docs/system-design.md` §8.1).
+- **IMP-002**: `character_network(p_character_id, p_depth)` recursive read
+  function consumes these edges (ADR-0013).
+- **IMP-003**: The unique index is later **extended** to include
+  `relationship_role` (ADR-0009, migration `00014`).
+
+## References
+
+- **REF-001**: ADR-0009 (sub-role taxonomy — amends this ADR), ADR-0010
+  (why this table _does_ carry `user_id`), ADR-0013 (`character_network`),
+  ADR-0014 (ownership RLS)
+- **REF-002**: `supabase/migrations/00002_relationships_junctions.sql`;
+  `docs/system-design.md` §3.3, §9.2.5
+- **REF-003**: PRD §3 (relationships)

--- a/docs/adr/adr-0009-relationship-sub-role-taxonomy.md
+++ b/docs/adr/adr-0009-relationship-sub-role-taxonomy.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "data-model", "relationships"]
 supersedes: ""
 superseded_by: ""
+amends: "ADR-0008 (character relationships directed pairs, #119)"
+amended_by: ""
 ---
 
 # ADR-0009: Relationship Sub-Role Taxonomy (relationship_role)

--- a/docs/adr/adr-0009-relationship-sub-role-taxonomy.md
+++ b/docs/adr/adr-0009-relationship-sub-role-taxonomy.md
@@ -1,0 +1,98 @@
+---
+title: "ADR-0009: Relationship Sub-Role Taxonomy (relationship_role)"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-24"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "data-model", "relationships"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0009: Relationship Sub-Role Taxonomy (relationship_role)
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00014_relationship_role.sql` (2026-05-24, issue #119).
+This ADR **amends** ADR-0008.
+
+## Context
+
+ADR-0008's `relationship_type` enum collapses semantically distinct sub-roles
+into one value for three types: `family` (spouse / parent / child / sibling / …),
+`professional` (employer / employee / colleague / …), and `collaboration`
+(co_author / co_founder / research_partner / …). The other eight types are
+already specific or encode direction by type pairing
+(`00014_relationship_role.sql` header). Users need to record the specific role
+without an explosion of top-level enum values, and the model must remain
+backwards-compatible with rows that predate the distinction.
+
+## Decision
+
+Adopt **Option A from #119**: add a single **nullable `relationship_role`**
+column to `character_relationships`, governed by **type-conditional CHECK
+constraints** (the allowed `relationship_role` values depend on
+`relationship_type`; for the eight already-specific types the role is null).
+Extend the uniqueness key to include the new column using
+`UNIQUE NULLS NOT DISTINCT (character_id, related_character_id, relationship_type,
+relationship_role)`, so that rare-but-real cases (e.g., adoptive **and**
+biological parent of the same child) coexist as separate rows, while two
+`NULL`-role rows of the same type still collide as duplicates.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Captures sub-role precision (spouse vs. sibling) without inflating
+  the top-level `relationship_type` enum.
+- **POS-002**: Backwards-compatible — existing rows get `relationship_role = NULL`
+  automatically; no data migration needed.
+- **POS-003**: `NULLS NOT DISTINCT` keeps the uniqueness guarantee intact for the
+  null-role case while permitting multiple distinct sub-roles per pair/type.
+- **POS-004**: Type-conditional CHECK keeps role values valid for their type at
+  the database level.
+
+### Negative
+
+- **NEG-001**: The type→allowed-role mapping is encoded in CHECK constraints,
+  which must be kept in sync with the application's role lists and the relationship
+  editor UI.
+- **NEG-002**: `NULLS NOT DISTINCT` is a relatively recent Postgres feature; the
+  uniqueness semantics are subtler than a plain unique index and need to be
+  understood when extending.
+
+## Alternatives Considered
+
+### Expand the top-level `relationship_type` enum
+
+- **ALT-001**: **Description**: Add `spouse`, `parent`, `colleague`, `co_author`,
+  … directly to `relationship_type`.
+- **ALT-002**: **Rejection Reason**: Explodes the enum, conflates two levels of
+  meaning (category vs. role), and breaks existing type-based queries/UX
+  grouping.
+
+### Separate `relationship_roles` lookup/junction table
+
+- **ALT-003**: **Description**: Model roles in their own table keyed to the
+  relationship.
+- **ALT-004**: **Rejection Reason**: Over-engineered for a single optional
+  sub-role per edge; a nullable column with conditional CHECK is sufficient and
+  keeps reads flat.
+
+## Implementation Notes
+
+- **IMP-001**: Column, type-conditional CHECK, and extended
+  `NULLS NOT DISTINCT` unique index in `00014_relationship_role.sql`.
+- **IMP-002**: The relationship editor UX (Batch H, #119) surfaces the sub-role
+  selector conditioned on the chosen type (ADR-0020, ADR-0025).
+- **IMP-003**: Service/Zod schemas
+  (`packages/services/src/schemas/character-relationship.ts`) carry the matching
+  type→role validation.
+
+## References
+
+- **REF-001**: ADR-0008 (base relationship model — amended here), ADR-0020/0025
+  (relationship editor UI)
+- **REF-002**: `supabase/migrations/00014_relationship_role.sql`;
+  `docs/system-design.md` §7.5; issue #119
+- **REF-003**: PostgreSQL `UNIQUE NULLS NOT DISTINCT` documentation

--- a/docs/adr/adr-0010-junction-table-conventions.md
+++ b/docs/adr/adr-0010-junction-table-conventions.md
@@ -1,0 +1,106 @@
+---
+title: "ADR-0010: Junction Table Conventions — Composite PK, No Surrogate id, No user_id"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-21"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "data-model", "junction-tables", "rls"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0010: Junction Table Conventions — Composite PK, No Surrogate id, No user_id
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00002_relationships_junctions.sql` (2026-05-21), with the
+single-primary refinement in `00013_character_media_single_primary.sql`
+(2026-05-24, #125). Specified in `docs/system-design.md` §3.4.
+
+## Context
+
+The schema has eleven many-to-many junctions (`event_categories`, `event_media`,
+`event_characters`, `timeline_events`, `period_timelines`, `story_periods`,
+`story_characters`, `story_events`, `character_media`, `timeline_media`, and the
+collaborator table). A prior schema put a surrogate `id` and a `user_id` on every
+junction for RLS — but a junction `user_id` can disagree with the parent entity's
+owner, creating an integrity/authorization hole (a user inserts a junction row
+with their own `user_id` pointing at someone else's entities).
+
+## Decision
+
+Standardize all junction tables on:
+
+- **Composite primary key** of the two (or more) FK columns; **no surrogate
+  `id`**.
+- **No `user_id`** — ownership is derived from the parent entity in RLS
+  (ADR-0014, `docs/system-design.md` §9.2.3). The sole exception is
+  `timeline_collaborators`, whose `user_id` _is_ the data (it associates a user
+  with a timeline).
+- **`ON DELETE CASCADE`** on every FK, so deleting a parent removes its junction
+  rows without manual cleanup (ADR-0012).
+- **`sort_order INTEGER`** where editorial ordering matters (`event_media`,
+  `timeline_events` — the latter added in `00012`, #122).
+- **Single-primary flag** enforced with a **partial unique index**, not a trigger
+  or app check: `CREATE UNIQUE INDEX … (group_col) WHERE is_primary = true`
+  (applied to `character_media` in `00013`, #125).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Removes the junction-`user_id`-vs-parent-owner integrity hole;
+  authorization has a single source (the parent entity).
+- **POS-002**: Composite PKs are the natural uniqueness constraint for an edge and
+  give a free index on the leading column.
+- **POS-003**: `ON DELETE CASCADE` eliminates manual junction-cleanup code/stored
+  procedures (ADR-0012).
+- **POS-004**: The partial-unique-index pattern enforces "one primary per group"
+  declaratively, with no trigger to maintain.
+
+### Negative
+
+- **NEG-001**: Junction RLS policies are slightly more complex — each must
+  `EXISTS`-check ownership of its parent entity (`docs/system-design.md` §9.2.3).
+- **NEG-002**: No surrogate `id` means a junction row is referenced by its
+  composite key; adding per-row attributes that need their own FK target would
+  require revisiting the design.
+- **NEG-003**: Reverse-FK lookups need explicit secondary indexes (e.g.,
+  `idx_event_chars_char`) since only the leading PK column is indexed for free.
+
+## Alternatives Considered
+
+### Surrogate `id` + `user_id` on every junction (the prior schema)
+
+- **ALT-001**: **Description**: Each junction has its own `id` PK and a `user_id`
+  for RLS.
+- **ALT-002**: **Rejection Reason**: `user_id` can diverge from the parent owner
+  (integrity/authorization hole); the surrogate `id` adds an index with no benefit
+  over the composite key.
+
+### Trigger/app-enforced single-primary
+
+- **ALT-003**: **Description**: Enforce "one primary media per character" with a
+  `BEFORE INSERT/UPDATE` trigger or service-layer check.
+- **ALT-004**: **Rejection Reason**: A partial unique index is atomic,
+  race-free, and declarative; triggers and app checks are more code and can be
+  bypassed (`00013`).
+
+## Implementation Notes
+
+- **IMP-001**: All eleven junctions defined in `00002`; `timeline_events.sort_order`
+  added in `00012`; `character_media_one_primary` partial unique index in `00013`.
+- **IMP-002**: Reverse-FK indexes (`idx_event_chars_char`,
+  `idx_timeline_events_event`, …) in `00005` (`docs/system-design.md` §8.1).
+- **IMP-003**: New junctions must follow this pattern; if `event_media`/
+  `timeline_media` later gain a primary flag, reuse the partial-unique-index
+  recipe (`docs/system-design.md` §3.4).
+
+## References
+
+- **REF-001**: ADR-0011 (CASCADE/publication), ADR-0012 (cascades replace
+  delete procedures), ADR-0014 (parent-derived junction RLS), ADR-0015 (RLS perf)
+- **REF-002**: `supabase/migrations/00002_relationships_junctions.sql`,
+  `00012_timeline_events_sort_order.sql`,
+  `00013_character_media_single_primary.sql`; `docs/system-design.md` §3.4, §9.2.3
+- **REF-003**: PostgreSQL partial unique index documentation

--- a/docs/adr/adr-0010-junction-table-conventions.md
+++ b/docs/adr/adr-0010-junction-table-conventions.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "data-model", "junction-tables", "rls"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0010: Junction Table Conventions — Composite PK, No Surrogate id, No user_id

--- a/docs/adr/adr-0010-junction-table-conventions.md
+++ b/docs/adr/adr-0010-junction-table-conventions.md
@@ -40,7 +40,11 @@ Standardize all junction tables on:
 - **`ON DELETE CASCADE`** on every FK, so deleting a parent removes its junction
   rows without manual cleanup (ADR-0012).
 - **`sort_order INTEGER`** where editorial ordering matters (`event_media`,
-  `timeline_events` — the latter added in `00012`, #122).
+  `timeline_events` — the latter added in `00012`, #122; `story_events` for
+  editorial narrative order is **pending** migration #183, mirroring `00012`).
+- **Deliberate non-junctions**: a many-to-many is only given a junction when the
+  link is curated. Periods have **no `period_events`** junction — period↔event
+  membership is computed by date, not stored (ADR-0028).
 - **Single-primary flag** enforced with a **partial unique index**, not a trigger
   or app check: `CREATE UNIQUE INDEX … (group_col) WHERE is_primary = true`
   (applied to `character_media` in `00013`, #125).
@@ -90,6 +94,7 @@ Standardize all junction tables on:
 
 - **IMP-001**: All eleven junctions defined in `00002`; `timeline_events.sort_order`
   added in `00012`; `character_media_one_primary` partial unique index in `00013`.
+  `story_events.sort_order` (editorial narrative order) is pending #183.
 - **IMP-002**: Reverse-FK indexes (`idx_event_chars_char`,
   `idx_timeline_events_event`, …) in `00005` (`docs/system-design.md` §8.1).
 - **IMP-003**: New junctions must follow this pattern; if `event_media`/
@@ -99,7 +104,8 @@ Standardize all junction tables on:
 ## References
 
 - **REF-001**: ADR-0011 (CASCADE/publication), ADR-0012 (cascades replace
-  delete procedures), ADR-0014 (parent-derived junction RLS), ADR-0015 (RLS perf)
+  delete procedures), ADR-0014 (parent-derived junction RLS), ADR-0015 (RLS perf),
+  ADR-0028 (`story_events.sort_order`; the deliberate absence of `period_events`)
 - **REF-002**: `supabase/migrations/00002_relationships_junctions.sql`,
   `00012_timeline_events_sort_order.sql`,
   `00013_character_media_single_primary.sql`; `docs/system-design.md` §3.4, §9.2.3

--- a/docs/adr/adr-0011-publication-model.md
+++ b/docs/adr/adr-0011-publication-model.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "data-model", "publishing", "rls"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0011: Publication Model — published Boolean + published_at, Not a Status Enum

--- a/docs/adr/adr-0011-publication-model.md
+++ b/docs/adr/adr-0011-publication-model.md
@@ -1,0 +1,92 @@
+---
+title: "ADR-0011: Publication Model — published Boolean + published_at, Not a Status Enum"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-21"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "data-model", "publishing", "rls"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0011: Publication Model — published Boolean + published_at, Not a Status Enum
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00001_initial_schema.sql` (2026-05-21); the publish
+workflow is specified in `docs/system-design.md` §5.5.6.
+
+## Context
+
+Content entities (timelines, periods, events, stories, characters) move between a
+private draft state and a publicly visible state. The visibility distinction is
+load-bearing for authorization: anonymous and non-owner users may read
+**published** content but not drafts (ADR-0014). The model needs to express "is
+this public?" cheaply in RLS, plus "when did it go public?" for ordering and
+notifications.
+
+## Decision
+
+Represent publication with **two columns on each content table**: a
+`published BOOLEAN DEFAULT false` flag and a nullable `published_at TIMESTAMPTZ`
+timestamp — **not** a multi-value status enum. RLS reads test `published = true`
+directly. Setting the flag and timestamp (and any downstream effects such as
+collaborator notifications) is handled by a `publish` Edge Function rather than a
+stored procedure (`docs/system-design.md` §5.5.6).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: `published = true` is a trivial, index-friendly predicate in every
+  read policy (ADR-0014) — no enum parsing or status-set logic in RLS.
+- **POS-002**: `published_at` gives a real publish time for ordering public feeds
+  and for notification context, independent of `created_at`/`updated_at`.
+- **POS-003**: Keeping the publish side effects (notifications, future cache
+  invalidation/analytics) in an Edge Function avoids accreting business logic in
+  the database (ADR-0013), where the prior schema's `publish_*` functions had
+  parameter-shadowing bugs.
+
+### Negative
+
+- **NEG-001**: A boolean cannot express richer lifecycle states (e.g.,
+  `in_review`, `scheduled`, `archived`); adding them later means a migration to a
+  status column and rewriting the RLS predicate.
+- **NEG-002**: The flag and timestamp can drift if a writer sets `published`
+  without `published_at`; correctness depends on going through the publish path.
+
+## Alternatives Considered
+
+### A `status` enum (`draft` / `published` / `archived` / …)
+
+- **ALT-001**: **Description**: A single `status VARCHAR CHECK` column encoding the
+  lifecycle.
+- **ALT-002**: **Rejection Reason**: Over-models current needs (only public/not is
+  required), and complicates the hot RLS predicate that every anonymous read
+  evaluates. Can be revisited via a future ADR if richer states are required.
+
+### Visibility carried only by the `visibility` column
+
+- **ALT-003**: **Description**: Reuse `timelines.visibility`
+  (`private`/`public`/`shared`) as the publication signal for all entities.
+- **ALT-004**: **Rejection Reason**: `visibility` models sharing scope and exists
+  only on timelines; the `published` flag is a uniform per-entity gate that the
+  RLS pattern in §9.2 depends on.
+
+## Implementation Notes
+
+- **IMP-001**: `published`/`published_at` on `timelines`, `periods`, `events`,
+  `stories`, `characters` in `00001`.
+- **IMP-002**: The `publish` Edge Function sets both fields and fans out
+  collaborator notifications (`docs/system-design.md` §5.5.6; ADR-0017
+  notifications).
+- **IMP-003**: RLS read policies across §9.2 begin with `published = true OR …`
+  (ADR-0014).
+
+## References
+
+- **REF-001**: ADR-0013 (publish as Edge Function, not stored proc), ADR-0014
+  (published in RLS), ADR-0017 (notifications on publish)
+- **REF-002**: `supabase/migrations/00001_initial_schema.sql`;
+  `docs/system-design.md` §5.5.6, §9.2
+- **REF-003**: PRD §4.9 (publishing/visibility)

--- a/docs/adr/adr-0011-publication-model.md
+++ b/docs/adr/adr-0011-publication-model.md
@@ -76,7 +76,9 @@ stored procedure (`docs/system-design.md` §5.5.6).
 ## Implementation Notes
 
 - **IMP-001**: `published`/`published_at` on `timelines`, `periods`, `events`,
-  `stories`, `characters` in `00001`.
+  `stories`, `characters` in `00001`. **Categories are intentionally excluded** —
+  they are taxonomy, not audience-facing content, and have no `published` column
+  or publish control (ADR-0028).
 - **IMP-002**: The `publish` Edge Function sets both fields and fans out
   collaborator notifications (`docs/system-design.md` §5.5.6; ADR-0017
   notifications).
@@ -86,7 +88,8 @@ stored procedure (`docs/system-design.md` §5.5.6).
 ## References
 
 - **REF-001**: ADR-0013 (publish as Edge Function, not stored proc), ADR-0014
-  (published in RLS), ADR-0017 (notifications on publish)
+  (published in RLS), ADR-0017 (notifications on publish), ADR-0028 (categories
+  excluded from the publication model)
 - **REF-002**: `supabase/migrations/00001_initial_schema.sql`;
   `docs/system-design.md` §5.5.6, §9.2
 - **REF-003**: PRD §4.9 (publishing/visibility)

--- a/docs/adr/adr-0012-postgrest-crud-thin-service-layer.md
+++ b/docs/adr/adr-0012-postgrest-crud-thin-service-layer.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "api", "postgrest", "services"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0012: PostgREST for CRUD with a Thin TypeScript Service Layer

--- a/docs/adr/adr-0012-postgrest-crud-thin-service-layer.md
+++ b/docs/adr/adr-0012-postgrest-crud-thin-service-layer.md
@@ -1,0 +1,94 @@
+---
+title: "ADR-0012: PostgREST for CRUD with a Thin TypeScript Service Layer"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-21"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "api", "postgrest", "services"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0012: PostgREST for CRUD with a Thin TypeScript Service Layer
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — specified in
+`docs/system-design.md` §5 (Appendix B Design Decision #2); realized by the
+schema in `00001`/`00002` (FKs + `ON DELETE CASCADE`) and the
+`@repo/services` modules.
+
+## Context
+
+Every content entity needs create/read/update/delete. The team had to choose
+between writing stored-procedure CRUD in the database, building a bespoke API
+server, or using Supabase's auto-generated PostgREST endpoints. A prior schema
+exposed `create_*`/`update_*`/`publish_*` SQL functions and hit
+parameter-shadowing bugs and duplicated validation already expressed in the
+schema and RLS.
+
+## Decision
+
+Use **PostgREST (the Supabase auto-generated REST/`supabase-js` query API) for
+all standard CRUD**. Do **not** write stored-procedure CRUD. A **thin TypeScript
+service layer** (`@repo/services`) wraps PostgREST to:
+
+- compose multi-step operations (e.g., create an event _then_ insert its
+  `event_characters`/`event_media` junction rows),
+- run Zod validation at the boundary (ADR-0019),
+- and shape typed results for the apps.
+
+Multi-step junction writes are **non-atomic** by default — accepted because RLS
+guarantees no partial write can escape the owner's own data, and the affected
+operations are low-stakes link inserts (`docs/system-design.md` §5). Referential
+cleanup is handled by `ON DELETE CASCADE` (ADR-0010), not delete procedures.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: No CRUD code to write or maintain in SQL — the schema + RLS + Zod
+  are the contract; eliminates the prior `create_*`/`publish_*` function bugs.
+- **POS-002**: `supabase-js` gives typed, filterable queries directly from the
+  apps; the service layer only exists where composition/validation adds value.
+- **POS-003**: `ON DELETE CASCADE` removes the need for delete stored procedures.
+
+### Negative
+
+- **NEG-001**: Multi-step junction inserts are non-atomic — a partial failure can
+  leave an event without all its links; mitigated by RLS scoping and, where true
+  atomicity is required later, a targeted RPC (ADR-0013) can be added.
+- **NEG-002**: Business rules that PostgREST/RLS can't express must live in the
+  TypeScript service, so logic is split between DB constraints and app code.
+- **NEG-003**: Direct PostgREST access from apps means query correctness/policy
+  awareness is partly the caller's responsibility.
+
+## Alternatives Considered
+
+### Stored-procedure CRUD (the prior schema)
+
+- **ALT-001**: **Description**: `create_event()`, `update_character()`,
+  `publish_timeline()`, … in SQL.
+- **ALT-002**: **Rejection Reason**: Duplicates schema/RLS validation, suffered
+  parameter-shadowing bugs, and couples the API surface to migrations.
+
+### A bespoke Node/Next API server in front of the database
+
+- **ALT-003**: **Description**: Hand-written REST/GraphQL endpoints.
+- **ALT-004**: **Rejection Reason**: Re-implements what PostgREST + RLS already
+  provide; more infrastructure and auth plumbing for no current benefit.
+
+## Implementation Notes
+
+- **IMP-001**: Service modules live in `packages/services/src/modules/`; clients
+  in `packages/services/src/supabase/` (ADR-0019).
+- **IMP-002**: Complex/relational **reads** are the exception and go through
+  STABLE SQL functions (ADR-0013), not PostgREST chained queries.
+- **IMP-003**: If an operation needs atomic multi-row writes, add a focused
+  `SECURITY INVOKER` RPC rather than reintroducing CRUD procedures.
+
+## References
+
+- **REF-001**: ADR-0013 (read-only DB functions), ADR-0010 (CASCADE cleanup),
+  ADR-0019 (services package + Zod), ADR-0014 (RLS as the guardrail)
+- **REF-002**: `docs/system-design.md` §5 and Appendix B Decision #2
+- **REF-003**: PostgREST / Supabase data API documentation

--- a/docs/adr/adr-0013-db-functions-read-only.md
+++ b/docs/adr/adr-0013-db-functions-read-only.md
@@ -1,0 +1,100 @@
+---
+title: "ADR-0013: Database Functions for Complex Reads Only"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-22"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "api", "database-functions"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0013: Database Functions for Complex Reads Only
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00008_database_functions.sql` (2026-05-22), extended by
+`00015_get_user_recent_counts.sql` (2026-05-29, #41); specified in
+`docs/system-design.md` §5.4 (Appendix B Decision #3).
+
+## Context
+
+PostgREST handles CRUD (ADR-0012), but some reads are graph/range/aggregate
+queries that are awkward or impossible to express as chained client queries:
+events within a hybrid-temporal range, a character's relationship network to N
+hops, events shared by two characters, and per-user dashboard metrics. The
+question is where that logic should live.
+
+## Decision
+
+Implement **complex reads as SQL functions**, and reserve database functions for
+**reads (and read-like aggregates) only** — never CRUD. The set:
+
+- `events_in_temporal_range(...)` — range query over the `sort_order` encoding
+  (ADR-0005),
+- `character_network(p_character_id, p_depth)` — recursive relationship traversal
+  (ADR-0008),
+- `events_shared_by_characters(...)` — intersection of event participation,
+- `get_user_metrics(...)` — dashboard counts,
+- `get_user_recent_counts(...)` — "▴ N new since" badge counts (`00015`,
+  mirroring `get_user_metrics`).
+
+Functions are `STABLE` where they only read. Aggregate/metrics functions that must
+read across users are `SECURITY DEFINER` with `search_path = ''` (ADR-0015) and
+return only counts.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Graph/range/aggregate logic runs close to the data in one round
+  trip, instead of N chained client queries.
+- **POS-002**: A clear rule — "functions read, PostgREST writes" — keeps the API
+  surface predictable and avoids the prior schema's CRUD-in-SQL problems
+  (ADR-0012).
+- **POS-003**: `get_user_recent_counts` reuses the exact shape of
+  `get_user_metrics`, so the dashboard's metric and "new since" badges share a
+  pattern.
+
+### Negative
+
+- **NEG-001**: Read logic is split between SQL functions and the TypeScript
+  service layer; contributors must know which reads are functions.
+- **NEG-002**: `SECURITY DEFINER` metric functions bypass RLS by design, so they
+  must be written defensively (count-only output, hardened `search_path`) — a
+  standing review burden (ADR-0015).
+- **NEG-003**: Function signatures are migration-versioned; changing a return
+  shape needs a migration and a `db:gen:types` regeneration.
+
+## Alternatives Considered
+
+### Express everything through PostgREST chained queries / client-side joins
+
+- **ALT-001**: **Description**: Build network/range/shared-event reads from
+  multiple `supabase-js` calls.
+- **ALT-002**: **Rejection Reason**: Recursive network traversal and temporal-range
+  scans are impractical client-side and chatty; SQL does them in one call.
+
+### Put complex reads in the TypeScript service with raw SQL
+
+- **ALT-003**: **Description**: Hold the SQL as strings in `@repo/services`.
+- **ALT-004**: **Rejection Reason**: Loses migration versioning, type generation,
+  and the ability to grant/secure the function; DB functions are the better home
+  for stable read contracts.
+
+## Implementation Notes
+
+- **IMP-001**: All read functions in `00008`; `get_user_recent_counts` in `00015`
+  (`SECURITY DEFINER`, `search_path = ''`, count-only).
+- **IMP-002**: `events_in_temporal_range` consumes the era-conversion `sort_order`
+  from ADR-0005 (`docs/system-design.md` §4, §5.4).
+- **IMP-003**: All functions are search-path-hardened per ADR-0015 (`00010`).
+
+## References
+
+- **REF-001**: ADR-0012 (PostgREST for CRUD), ADR-0005 (temporal sort_order),
+  ADR-0008 (relationship graph), ADR-0015 (function hardening), ADR-0021
+  (dashboard consuming metrics)
+- **REF-002**: `supabase/migrations/00008_database_functions.sql`,
+  `00015_get_user_recent_counts.sql`; `docs/system-design.md` §5.4
+- **REF-003**: PRD §4 (dashboard, networks, temporal queries)

--- a/docs/adr/adr-0013-db-functions-read-only.md
+++ b/docs/adr/adr-0013-db-functions-read-only.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "api", "database-functions"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0013: Database Functions for Complex Reads Only

--- a/docs/adr/adr-0014-rls-single-source-of-authorization.md
+++ b/docs/adr/adr-0014-rls-single-source-of-authorization.md
@@ -1,0 +1,98 @@
+---
+title: "ADR-0014: Row-Level Security as the Single Source of Authorization"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-22"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "security", "rls", "authorization"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0014: Row-Level Security as the Single Source of Authorization
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00007_rls_policies.sql` (2026-05-22); specified in
+`docs/system-design.md` §9 (Appendix B Decisions #8, #20).
+
+## Context
+
+Because apps talk to the database directly through PostgREST (ADR-0012), there is
+no API server to centralize authorization. Authorization must therefore be
+enforced where the data lives, and it must hold uniformly for anonymous reads of
+published content, owners, admins, and timeline collaborators.
+
+## Decision
+
+Make **Row-Level Security the single source of authorization**. Every content
+table has RLS enabled with policies built from one read pattern and one write
+pattern:
+
+- **Read**: `published = true` (ADR-0011) **OR** `user_id = auth.uid()` (owner)
+  **OR** `is_admin()` (ADR-0017) **OR** the row is reachable by a timeline
+  **collaborator** (ADR-0015 helpers).
+- **Write**: owner **OR** admin **OR** collaborator-with-edit, depending on the
+  table.
+
+Global-read carve-outs exist for reference/shared data: `categories`, `media`,
+and `profiles` are world-readable (with write still restricted), because they are
+lookup/shared resources rather than private content
+(`docs/system-design.md` §9.3). Junction tables have **no `user_id`** (ADR-0010)
+and derive their policy from the parent entity via `EXISTS` checks.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: One enforcement point — there is no path (PostgREST, SQL function,
+  or app) that can read/write around the policies.
+- **POS-002**: The uniform "published OR owner OR admin OR collaborator" shape
+  makes policies reviewable and consistent across every table.
+- **POS-003**: Anonymous public browsing works without app-side gating, because
+  `published = true` is the first clause of every read policy.
+
+### Negative
+
+- **NEG-001**: RLS evaluated per row can be a performance hazard (re-running
+  `auth.uid()`/`is_admin()` per row, duplicate permissive policies) — addressed
+  by ADR-0015 (`00011`).
+- **NEG-002**: Collaborator and ownership checks risk recursive policy evaluation;
+  this forced the `SECURITY DEFINER` helper functions in ADR-0015.
+- **NEG-003**: Global-read tables (`categories`, `media`, `profiles`) must be kept
+  genuinely non-sensitive, since any authenticated/anon user can read them.
+
+## Alternatives Considered
+
+### Enforce authorization in an application/API layer
+
+- **ALT-001**: **Description**: Centralize checks in a Node/Next API in front of
+  the DB.
+- **ALT-002**: **Rejection Reason**: Contradicts the PostgREST-direct architecture
+  (ADR-0012) and creates a bypass risk if anything ever queries the DB directly.
+
+### Per-row `user_id` on every table including junctions
+
+- **ALT-003**: **Description**: Give junctions their own `user_id` for simpler
+  policies.
+- **ALT-004**: **Rejection Reason**: Creates the owner-divergence integrity hole
+  (ADR-0010); deriving from the parent is both correct and the documented
+  convention.
+
+## Implementation Notes
+
+- **IMP-001**: All policies in `00007`; global-read carve-outs for `categories`,
+  `media`, `profiles` per `docs/system-design.md` §9.3.
+- **IMP-002**: Collaborator/ownership helper functions and InitPlan/performance
+  rewrites are split into ADR-0015 (`00010`, `00011`).
+- **IMP-003**: pgTAP tests in `supabase/tests/database/` assert the policy matrix
+  (ADR-0026).
+
+## References
+
+- **REF-001**: ADR-0011 (published flag), ADR-0010 (junction RLS from parent),
+  ADR-0015 (helpers + perf hardening), ADR-0017 (`is_admin`), ADR-0016 (storage
+  RLS), ADR-0026 (RLS tests)
+- **REF-002**: `supabase/migrations/00007_rls_policies.sql`;
+  `docs/system-design.md` §9
+- **REF-003**: PRD §9 (security/permissions)

--- a/docs/adr/adr-0014-rls-single-source-of-authorization.md
+++ b/docs/adr/adr-0014-rls-single-source-of-authorization.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "security", "rls", "authorization"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0014: Row-Level Security as the Single Source of Authorization

--- a/docs/adr/adr-0015-rls-and-function-hardening.md
+++ b/docs/adr/adr-0015-rls-and-function-hardening.md
@@ -1,0 +1,109 @@
+---
+title: "ADR-0015: RLS and Function Hardening — SECURITY DEFINER Helpers, search_path, InitPlan, security_invoker Views"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-23"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "security", "rls", "performance"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0015: RLS and Function Hardening — SECURITY DEFINER Helpers, search_path, InitPlan, security_invoker Views
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented across
+`00006_database_views.sql` (2026-05-22),
+`00007_rls_policies.sql` (2026-05-22),
+`00010_function_search_path_hardening.sql` (2026-05-23, #112), and
+`00011_rls_performance_hardening.sql` (2026-05-23, #115). Specified in
+`docs/system-design.md` §3.2 and §9.
+
+## Context
+
+The RLS model (ADR-0014) introduced three follow-on problems that the initial
+policy migration could not all solve at once: (1) ownership/collaborator checks
+that reference the same tables they protect cause **recursive policy evaluation**
+(Postgres error `42P17`); (2) functions without a fixed `search_path` are exposed
+to **search-path injection**; and (3) naive policies re-evaluate `auth.uid()` /
+`is_admin()` **per row** and stack duplicate permissive `SELECT` policies, which
+is slow at scale. Views over RLS tables also need to respect the querying user's
+permissions.
+
+## Decision
+
+Fold four related hardening measures into one standard:
+
+1. **`SECURITY DEFINER` helper functions** — `is_timeline_owner()`,
+   `is_timeline_collaborator()`, `is_timeline_collab_editor()` — to break the
+   `42P17` recursion by checking membership outside the recursive policy context.
+2. **`search_path = ''` on every function** (`00010`) — all six existing
+   functions are pinned to an empty search path with fully-qualified references,
+   closing the injection vector.
+3. **InitPlan wrapping + split policies** (`00011`) — wrap `auth.uid()` /
+   `is_admin()` in `(select …)` so Postgres evaluates them **once per query**
+   (InitPlan) rather than per row, and split each `write_* FOR ALL` policy into
+   separate `INSERT`/`UPDATE`/`DELETE` policies to remove the duplicate permissive
+   `SELECT` branch.
+4. **`security_invoker` views** (`00006`) — views run with the querying user's
+   privileges so RLS still applies through them.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Eliminates `42P17` recursive-policy failures while keeping
+  collaborator-aware authorization.
+- **POS-002**: All functions are injection-hardened (`search_path = ''`),
+  satisfying Supabase's linter and #112.
+- **POS-003**: RLS predicates evaluate auth helpers once per query, and removing
+  duplicate permissive SELECT policies measurably cuts per-row overhead (#115).
+- **POS-004**: `security_invoker` views cannot be used to leak rows past RLS.
+
+### Negative
+
+- **NEG-001**: `SECURITY DEFINER` helpers run with elevated privileges and must be
+  written defensively (fixed `search_path`, minimal surface) — a permanent review
+  obligation.
+- **NEG-002**: Splitting `FOR ALL` into per-command policies multiplies the number
+  of policies to maintain and keep in sync.
+- **NEG-003**: The `(select auth.uid())` InitPlan idiom is non-obvious; future
+  policy authors must follow it or silently reintroduce per-row evaluation.
+
+## Alternatives Considered
+
+### Inline ownership/collaborator checks directly in each policy
+
+- **ALT-001**: **Description**: Subquery the collaborator/owner tables inside every
+  policy.
+- **ALT-002**: **Rejection Reason**: Triggers `42P17` recursion and duplicates the
+  logic across many policies; centralizing in `SECURITY DEFINER` helpers is both
+  correct and DRY.
+
+### Leave functions on the default search_path / keep `FOR ALL` policies
+
+- **ALT-003**: **Description**: Accept the linter warnings and per-row evaluation.
+- **ALT-004**: **Rejection Reason**: Leaves an injection vector (#112) and a
+  documented performance regression (#115); both were explicitly remediated.
+
+## Implementation Notes
+
+- **IMP-001**: Helpers + base policies in `00006`/`00007`; search-path hardening in
+  `00010` (37 lines, config-only over 6 functions); InitPlan/split-policy rewrite
+  in `00011` (593 lines).
+- **IMP-002**: New functions must declare `search_path = ''`; new policies must
+  wrap auth calls in `(select …)` and avoid `FOR ALL` where a permissive SELECT
+  would be duplicated.
+- **IMP-003**: These migrations are pure security/perf refactors — no schema or
+  data change.
+
+## References
+
+- **REF-001**: ADR-0014 (the RLS model being hardened), ADR-0013 (functions also
+  hardened), ADR-0006 (views)
+- **REF-002**: `supabase/migrations/00006_database_views.sql`,
+  `00007_rls_policies.sql`, `00010_function_search_path_hardening.sql`,
+  `00011_rls_performance_hardening.sql`; `docs/system-design.md` §3.2, §9; issues
+  #112, #115
+- **REF-003**: Supabase database linter (function_search_path_mutable, RLS InitPlan)
+  guidance

--- a/docs/adr/adr-0015-rls-and-function-hardening.md
+++ b/docs/adr/adr-0015-rls-and-function-hardening.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "security", "rls", "performance"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0015: RLS and Function Hardening — SECURITY DEFINER Helpers, search_path, InitPlan, security_invoker Views

--- a/docs/adr/adr-0016-storage-buckets-graduated-access.md
+++ b/docs/adr/adr-0016-storage-buckets-graduated-access.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "security", "storage"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0016: Storage Buckets with Graduated Access (Public Media/Avatars, Private Exports)

--- a/docs/adr/adr-0016-storage-buckets-graduated-access.md
+++ b/docs/adr/adr-0016-storage-buckets-graduated-access.md
@@ -1,0 +1,90 @@
+---
+title: "ADR-0016: Storage Buckets with Graduated Access (Public Media/Avatars, Private Exports)"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-22"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "security", "storage"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0016: Storage Buckets with Graduated Access (Public Media/Avatars, Private Exports)
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00009_storage_buckets_and_policies.sql` (2026-05-22);
+specified in `docs/system-design.md` §5.7 and §9.3.
+
+## Context
+
+The system stores three kinds of binary assets: media attached to public content
+(images for events/characters/timelines), user avatars, and generated data
+exports. These have different sensitivity: content media and avatars are meant to
+be embeddable on public pages, while an export is a user's own data dump that
+must not be world-readable.
+
+## Decision
+
+Define **three storage buckets with graduated access**:
+
+- **`media`** — **public** bucket for content imagery (referenced by the `media`
+  table; world-readable to match the global-read `media` RLS carve-out in
+  ADR-0014). Writes are restricted by storage RLS to the owner.
+- **`avatars`** — **public** bucket for profile pictures (embeddable anywhere).
+  Writes restricted to the owning user.
+- **`exports`** — **private** bucket; objects are reachable only via **time-limited
+  signed URLs** generated server-side for the owner.
+
+Per-object write/read authorization is enforced with **storage RLS policies**
+keyed on the object path/owner, mirroring the database RLS model (ADR-0014).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Public content imagery and avatars are directly embeddable (CDN
+  cacheable) without per-request signing.
+- **POS-002**: Exports stay private by construction — no public URL exists; access
+  requires a short-lived signed URL for the owner.
+- **POS-003**: Storage authorization follows the same owner/RLS mental model as
+  the database, so there is one consistent permission story.
+
+### Negative
+
+- **NEG-001**: Public buckets mean any object placed there is world-readable;
+  contributors must not put sensitive assets in `media`/`avatars`.
+- **NEG-002**: Signed-URL access for exports adds an expiry/regeneration concern in
+  the app (links go stale by design).
+- **NEG-003**: Storage RLS path conventions must be kept in sync with how the app
+  constructs object keys.
+
+## Alternatives Considered
+
+### One private bucket for everything, all access signed
+
+- **ALT-001**: **Description**: Sign every media/avatar URL on read.
+- **ALT-002**: **Rejection Reason**: Defeats CDN caching and adds latency/work for
+  inherently public content; sensitivity only differs for exports.
+
+### One public bucket for everything
+
+- **ALT-003**: **Description**: Put exports in a public bucket too.
+- **ALT-004**: **Rejection Reason**: Exports are private user data; a public bucket
+  would leak them via guessable/listable URLs.
+
+## Implementation Notes
+
+- **IMP-001**: Bucket definitions and storage RLS policies in `00009`.
+- **IMP-002**: The `media` bucket pairs with the global-read `media` table policy
+  (ADR-0014, `docs/system-design.md` §9.3).
+- **IMP-003**: Export generation (and its signed-URL issuance) is an Edge Function
+  concern alongside the library-import/publish functions (ADR-0018).
+
+## References
+
+- **REF-001**: ADR-0014 (RLS model + global-read `media`), ADR-0018 (Edge
+  Functions incl. exports)
+- **REF-002**: `supabase/migrations/00009_storage_buckets_and_policies.sql`;
+  `docs/system-design.md` §5.7, §9.3
+- **REF-003**: Supabase Storage access-control / signed URL documentation

--- a/docs/adr/adr-0017-auth-bootstrap-supporting-tables.md
+++ b/docs/adr/adr-0017-auth-bootstrap-supporting-tables.md
@@ -1,0 +1,97 @@
+---
+title: "ADR-0017: Auth Bootstrap and Supporting Tables (Profile Trigger, is_admin, Notifications, Content Reports)"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-21"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "auth", "data-model"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0017: Auth Bootstrap and Supporting Tables (Profile Trigger, is_admin, Notifications, Content Reports)
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in
+`supabase/migrations/00003_supporting_tables.sql` (2026-05-21) and
+`00004_is_admin_and_profile_trigger.sql` (2026-05-21); specified in
+`docs/system-design.md` §9.1 (Appendix B Decisions #15, #18, #19).
+
+## Context
+
+Supabase Auth owns `auth.users`, but the app needs an application-level
+`profiles` row per user, a way to distinguish admins for RLS (ADR-0014), a
+notifications channel (e.g., publish/collaborator events — ADR-0011), and an audit
+trail for user-reported content. These supporting concerns underpin authorization
+and moderation across the rest of the schema.
+
+## Decision
+
+Establish auth bootstrap and supporting tables:
+
+- **`handle_new_user` trigger** on `auth.users` insert auto-creates a `profiles`
+  row, **deriving a display name** from the signup metadata/email and **padding**
+  it to satisfy the profile name constraint when the source is too short
+  (Decision #15).
+- **`is_admin()` function** — the single admin predicate consumed by RLS policies
+  (ADR-0014), rather than scattering role checks.
+- **`notifications` table** — **write-once** records (insert + read/mark-read, no
+  arbitrary update of content), owner-scoped by RLS.
+- **`content_reports` table** — a moderation **audit trail** that is
+  **polymorphic** via (`entity_type`, `entity_id`) so any content type can be
+  reported through one table (Decisions #18, #19).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Every authenticated user deterministically has a `profiles` row from
+  first sign-in; downstream FKs and RLS can rely on it.
+- **POS-002**: `is_admin()` centralizes the admin check, so policies stay uniform
+  and a single function governs elevation (ADR-0015 hardening applies to it).
+- **POS-003**: Write-once `notifications` and polymorphic `content_reports` cover
+  notification and moderation needs without per-entity report tables.
+
+### Negative
+
+- **NEG-001**: The name-derivation/padding logic is a small piece of business
+  logic living in a trigger; edge cases (very short/empty names) are handled by
+  padding rather than rejection.
+- **NEG-002**: Polymorphic (`entity_type`, `entity_id`) reports cannot use a real
+  FK, so referential integrity of a report's target is not DB-enforced.
+- **NEG-003**: `is_admin()` is `SECURITY`-sensitive and must remain hardened
+  (`search_path = ''`, ADR-0015).
+
+## Alternatives Considered
+
+### Create the profile lazily in app code on first action
+
+- **ALT-001**: **Description**: Insert `profiles` from the app the first time a user
+  does something.
+- **ALT-002**: **Rejection Reason**: Race-prone and easy to miss; a DB trigger on
+  `auth.users` guarantees the row exists exactly once.
+
+### Per-entity report tables / a role column instead of is_admin()
+
+- **ALT-003**: **Description**: `event_reports`, `character_reports`, … and inline
+  role checks in policies.
+- **ALT-004**: **Rejection Reason**: Multiplies tables and scatters the admin
+  check; one polymorphic audit table + one `is_admin()` predicate is simpler and
+  consistent.
+
+## Implementation Notes
+
+- **IMP-001**: `notifications` and `content_reports` in `00003`; `is_admin()` and
+  the `handle_new_user` trigger in `00004`.
+- **IMP-002**: `is_admin()` is referenced throughout `00007` RLS policies
+  (ADR-0014) and hardened in `00010` (ADR-0015).
+- **IMP-003**: Notifications are produced by the `publish` Edge Function
+  (ADR-0011/0018).
+
+## References
+
+- **REF-001**: ADR-0014 (`is_admin` in RLS), ADR-0015 (function hardening),
+  ADR-0011/0018 (notifications on publish)
+- **REF-002**: `supabase/migrations/00003_supporting_tables.sql`,
+  `00004_is_admin_and_profile_trigger.sql`; `docs/system-design.md` §9.1
+- **REF-003**: PRD §9 (accounts, moderation, notifications)

--- a/docs/adr/adr-0017-auth-bootstrap-supporting-tables.md
+++ b/docs/adr/adr-0017-auth-bootstrap-supporting-tables.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "auth", "data-model"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0017: Auth Bootstrap and Supporting Tables (Profile Trigger, is_admin, Notifications, Content Reports)

--- a/docs/adr/adr-0018-curated-content-library.md
+++ b/docs/adr/adr-0018-curated-content-library.md
@@ -1,0 +1,92 @@
+---
+title: "ADR-0018: Curated Content Library via Admin-Owned Content + Deep-Copy Import Edge Function"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-22"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "content", "edge-functions"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0018: Curated Content Library via Admin-Owned Content + Deep-Copy Import Edge Function
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — specified in
+`docs/system-design.md` §12 (Appendix B Decision #17); enabled by the existing
+schema (`00001`/`00002`), RLS (`00007`), and storage (`00009`).
+
+## Context
+
+The product needs a starter/curated library of timelines, periods, events, and
+characters that users can browse and bring into their own workspace as an editable
+starting point. This requires deciding how "library" content is stored, how it is
+distinguished from user content, and what "import" means (reference vs. copy).
+
+## Decision
+
+Model the curated library as **ordinary admin-owned content** (the same tables as
+user content), flagged with **`metadata.is_library_content = true`** rather than a
+separate schema. Library rows are published (ADR-0011), so they are globally
+readable via the existing RLS read pattern (ADR-0014) — no special-case policy.
+
+**Importing is a deep copy**, performed by a **`library-import` Edge Function**:
+it clones the selected library entity graph (entity + its junctions + media
+references) into new rows **owned by the importing user**, so the user's copy is
+fully editable and independent of the original. Import is an Edge Function (not
+PostgREST/CRUD) because it is a multi-step, atomic, cross-entity operation
+(ADR-0012's non-atomic-junction caveat is exactly what a deep copy must avoid).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Zero new tables/policies — library content reuses the content
+  schema, RLS, and storage already in place; the only marker is a metadata flag.
+- **POS-002**: Deep copy gives users a clean, owned, editable starting point with
+  no shared-mutation coupling to the source library entity.
+- **POS-003**: Putting import in an Edge Function gives it atomicity and a single
+  trusted place for the clone logic, avoiding the non-atomic junction problem of
+  client-side multi-step writes (ADR-0012).
+
+### Negative
+
+- **NEG-001**: Deep copy duplicates data — library updates do **not** propagate to
+  already-imported copies (accepted: imports are meant to be independent forks).
+- **NEG-002**: `metadata.is_library_content` is a JSONB convention, not a typed
+  column, so library-vs-user filtering depends on querying JSONB consistently.
+- **NEG-003**: The Edge Function must faithfully walk the entity graph; missing a
+  junction type in the clone would yield an incomplete import.
+
+## Alternatives Considered
+
+### Reference (shallow link) instead of deep copy
+
+- **ALT-001**: **Description**: Point the user's workspace at shared library rows.
+- **ALT-002**: **Rejection Reason**: Users couldn't edit without mutating the
+  shared original (or needing copy-on-write); a deep copy is simpler and matches
+  "starting point you own."
+
+### A separate library schema / dedicated tables
+
+- **ALT-003**: **Description**: Parallel `library_*` tables distinct from user
+  content.
+- **ALT-004**: **Rejection Reason**: Doubles the schema and forces import to map
+  between two shapes; admin-owned + flag reuses everything.
+
+## Implementation Notes
+
+- **IMP-001**: Library entities are admin-owned, `published = true`, with
+  `metadata.is_library_content = true` (`docs/system-design.md` §12).
+- **IMP-002**: `library-import` Edge Function clones the entity graph into
+  user-owned rows; sits alongside `publish` and export functions (ADR-0011,
+  ADR-0016).
+- **IMP-003**: Discoverability/seeding of library content is covered by
+  `docs/seeding-discovery.md` and `scripts/seed-discovery.mts`.
+
+## References
+
+- **REF-001**: ADR-0011 (published library content), ADR-0012 (why import is an
+  Edge Function, not CRUD), ADR-0014 (global-read RLS), ADR-0017 (admin ownership)
+- **REF-002**: `docs/system-design.md` §12; `docs/seeding-discovery.md`
+- **REF-003**: PRD §12 (content library / starter content)

--- a/docs/adr/adr-0018-curated-content-library.md
+++ b/docs/adr/adr-0018-curated-content-library.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "content", "edge-functions"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0018: Curated Content Library via Admin-Owned Content + Deep-Copy Import Edge Function

--- a/docs/adr/adr-0019-services-package.md
+++ b/docs/adr/adr-0019-services-package.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "frontend", "services", "validation"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0019: @repo/services Package — Clients, Zod Schemas, Modules, Generated Types

--- a/docs/adr/adr-0019-services-package.md
+++ b/docs/adr/adr-0019-services-package.md
@@ -1,0 +1,97 @@
+---
+title: "ADR-0019: @repo/services Package — Clients, Zod Schemas, Modules, Generated Types"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-22"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "frontend", "services", "validation"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0019: @repo/services Package — Clients, Zod Schemas, Modules, Generated Types
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented as
+`packages/services` (`@repo/services`); specified in `docs/system-design.md` §11.
+Consumes the thin-service-layer decision (ADR-0012).
+
+## Context
+
+Both apps (`admin`, and later a reader surface) need to talk to Supabase with the
+same client setup, validation, and typed result shapes. Duplicating Supabase
+client creation, Zod schemas, and the generated DB types in each app would drift.
+The temporal logic (era-conversion `sort_order` math, ADR-0005) also needs one
+canonical TypeScript home.
+
+## Decision
+
+Create a shared **`@repo/services`** package as the single data-access layer. It
+contains four concerns, mirrored by its `src/` layout:
+
+- **`src/supabase/`** — Supabase client factories (browser/server via
+  `@supabase/ssr`) and the **generated `types.ts`** (`pnpm run db:gen:types`),
+  keeping the database schema and TS types in lockstep.
+- **`src/schemas/`** — **Zod schemas** that validate at the boundary (ADR-0012),
+  including the per-`character_type` `profile_data` shapes (ADR-0007) and the
+  type→`relationship_role` rules (ADR-0009).
+- **`src/modules/`** — the **thin service modules** that compose PostgREST calls
+  and the read functions (ADR-0013) into typed operations.
+- **`src/utils/`** — shared helpers, including the **TemporalService** logic that
+  computes/validates the hybrid temporal encoding (ADR-0005).
+
+The package is ESM, strict-TS, lint-clean, and Vitest-tested with an 80% coverage
+gate (ADR-0026).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: One place for clients, schemas, types, and temporal logic — no
+  per-app duplication or drift.
+- **POS-002**: Generated `types.ts` ties application types to the actual schema;
+  regenerating after a migration surfaces breakages at compile time.
+- **POS-003**: Zod schemas centralize boundary validation that PostgREST/RLS can't
+  express (per-type JSONB, conditional roles), keeping apps thin.
+
+### Negative
+
+- **NEG-001**: `types.ts` must be regenerated whenever migrations change shapes;
+  forgetting leaves the package out of sync with the DB.
+- **NEG-002**: Zod schemas duplicate some constraints already in the schema
+  (CHECKs, enums); they must be kept consistent with migrations by convention.
+- **NEG-003**: Centralizing temporal math here means any era-conversion change must
+  match the SQL `sort_order` generated columns exactly (ADR-0005).
+
+## Alternatives Considered
+
+### Per-app data layers
+
+- **ALT-001**: **Description**: Each app builds its own Supabase clients, schemas,
+  and types.
+- **ALT-002**: **Rejection Reason**: Guarantees drift across apps and duplicates
+  the temporal logic that must stay identical.
+
+### Generated types only, no service/schema layer
+
+- **ALT-003**: **Description**: Ship just `types.ts` and call `supabase-js`
+  directly from apps.
+- **ALT-004**: **Rejection Reason**: Leaves boundary validation and multi-step
+  composition (ADR-0012) scattered in UI code.
+
+## Implementation Notes
+
+- **IMP-001**: Layout `packages/services/src/{supabase,schemas,modules,utils}`;
+  exports via `@repo/services/*` (`packages/services/package.json`).
+- **IMP-002**: `pnpm run db:gen:types` writes
+  `packages/services/src/supabase/types.ts`.
+- **IMP-003**: Vitest config + 80% coverage gate in
+  `packages/services/vitest.config.ts` (ADR-0026).
+
+## References
+
+- **REF-001**: ADR-0005 (temporal logic), ADR-0007 (per-type schemas), ADR-0009
+  (role schemas), ADR-0012 (thin service layer), ADR-0013 (read functions),
+  ADR-0026 (testing)
+- **REF-002**: `packages/services/`; `docs/system-design.md` §11
+- **REF-003**: `@supabase/ssr`, Zod, Supabase type generation docs

--- a/docs/adr/adr-0020-ui-package-shadcn-tailwind.md
+++ b/docs/adr/adr-0020-ui-package-shadcn-tailwind.md
@@ -1,0 +1,94 @@
+---
+title: "ADR-0020: @repo/ui Design System on shadcn/ui + Tailwind 4 (in packages/ui, Storybook workbench)"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-26"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "frontend", "design-system", "ui"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0020: @repo/ui Design System on shadcn/ui + Tailwind 4 (in packages/ui, Storybook workbench)
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented across
+fidelity-2 Batches A–H (PRs #149–#162); specified in
+`docs/design/admin/fidelity-2-plan.md`. Closes #37/#38.
+
+## Context
+
+`apps/admin` started as Turborepo boilerplate. The fidelity-1 wireframes
+(`docs/design/admin/02-wireframes/`) require a dense, dark, table-first admin UI.
+The team needed a component foundation that is customizable enough to escape the
+"generic shadcn dashboard" look the aesthetic notes explicitly reject, while
+remaining shared across apps.
+
+## Decision
+
+Build a shared **`@repo/ui` design system on shadcn/ui + Tailwind 4**, with these
+placement and tooling decisions:
+
+- **shadcn lives in `packages/ui`, not `apps/admin`** — primitives are shared
+  infrastructure, exported via `@repo/ui/components/*`. (Diverges from #37's "init
+  in `apps/admin`" instruction — flagged in the closing PR.)
+- **Tailwind 4 CSS-first** config (no `tailwind.config.js`); `@theme` block in
+  `tokens.css` (ADR-0022). Existing CSS Modules stay for route-level layout.
+- **Storybook 10 + Vite preset** as the component workbench in `packages/ui`, with
+  colocated `*.stories.tsx` and composite "Pages > \*" mockups for each wireframed
+  screen.
+- **shadcn for every primitive except `Tree`** — `Tree` is the only bespoke
+  primitive (no shadcn equivalent); `DataTable` uses tanstack-table + shadcn
+  `Table` markup (ADR-0025).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Primitives are monorepo-shared and consumable by any app via
+  `@repo/ui`, not trapped in `apps/admin`.
+- **POS-002**: A heavily themed shadcn base gives accessible, well-tested
+  primitives while the token system (ADR-0022) escapes the generic look.
+- **POS-003**: Storybook + composite page stories let every wireframed screen be
+  reviewed visually before a production route exists.
+
+### Negative
+
+- **NEG-001**: Placing shadcn in `packages/ui` diverges from shadcn's app-centric
+  defaults, so `components.json`/aliases needed custom wiring.
+- **NEG-002**: Tailwind 4 CSS-first + tokens-in-two-files is newer ground; token
+  sync is a manual discipline (ADR-0022).
+- **NEG-003**: Maintaining Storybook (Vite) alongside Vitest adds a second tooling
+  surface in `packages/ui`.
+
+## Alternatives Considered
+
+### Initialize shadcn directly in `apps/admin` (per #37)
+
+- **ALT-001**: **Description**: Keep primitives inside the admin app.
+- **ALT-002**: **Rejection Reason**: Not monorepo-correct — primitives are shared
+  infrastructure; a second app would have to duplicate or reach into `apps/admin`.
+
+### A different component library (MUI, Mantine, Chakra)
+
+- **ALT-003**: **Description**: Adopt a batteries-included component kit.
+- **ALT-004**: **Rejection Reason**: Harder to theme to the dense/dark/editorial
+  target; shadcn's copy-in, own-the-code model fits the heavy customization the
+  aesthetic notes demand.
+
+## Implementation Notes
+
+- **IMP-001**: Primitives in `packages/ui/src/components/`; tokens in
+  `packages/ui/src/styles/` (ADR-0022); `components.json` in `packages/ui`.
+- **IMP-002**: Storybook config in `packages/ui/.storybook/`; `storybook-static/`
+  git/eslint-ignored.
+- **IMP-003**: App shell + route groups in
+  `apps/admin/app/{(public),(protected),(admin),auth}/` consume `@repo/ui`.
+
+## References
+
+- **REF-001**: ADR-0022 (tokens), ADR-0023 (dark-mode-only), ADR-0024 (visual
+  language), ADR-0025 (primitive sourcing), ADR-0026 (Storybook/tests)
+- **REF-002**: `docs/design/admin/fidelity-2-plan.md`;
+  `docs/design/admin/03-aesthetic-notes.md`; `packages/ui/`
+- **REF-003**: shadcn/ui, Tailwind 4, Storybook 10 docs

--- a/docs/adr/adr-0020-ui-package-shadcn-tailwind.md
+++ b/docs/adr/adr-0020-ui-package-shadcn-tailwind.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "frontend", "design-system", "ui"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0020: @repo/ui Design System on shadcn/ui + Tailwind 4 (in packages/ui, Storybook workbench)

--- a/docs/adr/adr-0021-tanstack-query-zustand.md
+++ b/docs/adr/adr-0021-tanstack-query-zustand.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "frontend", "state-management"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0021: TanStack Query for Server State, Zustand for Client State

--- a/docs/adr/adr-0021-tanstack-query-zustand.md
+++ b/docs/adr/adr-0021-tanstack-query-zustand.md
@@ -1,0 +1,88 @@
+---
+title: "ADR-0021: TanStack Query for Server State, Zustand for Client State"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-03-01"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "frontend", "state-management"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0021: TanStack Query for Server State, Zustand for Client State
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — specified in
+`docs/system-design.md` §2.2 (Appendix B Decision #12); consumed by the apps and
+`@repo/services` (ADR-0019).
+
+## Context
+
+The admin app is data-heavy: lists of timelines/events/characters, dashboard
+metrics (ADR-0013), relationship networks, and forms. It also has purely local UI
+state (sidebar open/closed, editor draft state, selected era in a temporal input).
+Conflating remote/cached data with local UI state in one store leads to manual
+cache-invalidation and stale-data bugs.
+
+## Decision
+
+Split state by origin:
+
+- **TanStack Query** owns **server state** — fetching, caching, background
+  refetch, and invalidation of everything that comes from Supabase/PostgREST and
+  the read functions (ADR-0012/0013). Mutations invalidate the relevant query
+  keys.
+- **Zustand** owns **client/UI state** — ephemeral, local-only state (shell
+  layout, modal/sheet state, in-progress editor selections) that never needs
+  caching or server reconciliation.
+
+The boundary rule: if a value originates from or must be reconciled with the
+database, it is a Query; if it is purely UI ephemeral, it is Zustand.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Caching, dedup, and background refresh come from TanStack Query
+  instead of hand-rolled fetch/cache logic.
+- **POS-002**: Zustand keeps UI state lightweight without forcing server data
+  through a global store.
+- **POS-003**: A clear origin-based rule prevents the "everything in one store"
+  anti-pattern and the stale-cache bugs that follow.
+
+### Negative
+
+- **NEG-001**: Two state libraries means contributors must know which tool a given
+  piece of state belongs in.
+- **NEG-002**: Query-key conventions must be disciplined so mutations invalidate
+  the right caches; a missed key yields stale UI.
+
+## Alternatives Considered
+
+### A single global store (Redux/Zustand) for everything
+
+- **ALT-001**: **Description**: Put server data and UI state in one store.
+- **ALT-002**: **Rejection Reason**: Re-implements caching/refetch/invalidation
+  that TanStack Query already solves; couples remote and local concerns.
+
+### Server data via React Context + manual fetch
+
+- **ALT-003**: **Description**: Fetch in effects and hold results in context.
+- **ALT-004**: **Rejection Reason**: No caching/dedup/background refetch; reinvents
+  TanStack Query poorly.
+
+## Implementation Notes
+
+- **IMP-001**: Query client/provider wired in the admin app
+  (`apps/admin/app/providers.tsx`); query hooks call `@repo/services` modules
+  (ADR-0019).
+- **IMP-002**: Dashboard metric badges consume `get_user_metrics` /
+  `get_user_recent_counts` via Query (ADR-0013).
+- **IMP-003**: Zustand stores hold shell/editor UI state only.
+
+## References
+
+- **REF-001**: ADR-0012/0013 (data sources behind Query), ADR-0019 (service
+  modules), ADR-0020 (UI consuming state)
+- **REF-002**: `docs/system-design.md` §2.2; `apps/admin/app/providers.tsx`
+- **REF-003**: TanStack Query, Zustand docs

--- a/docs/adr/adr-0022-design-tokens-dual-source.md
+++ b/docs/adr/adr-0022-design-tokens-dual-source.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "frontend", "design-tokens"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0022: Dual-Source Design Tokens (tokens.ts + tokens.css), OKLCH, Locked Icon/Font Set

--- a/docs/adr/adr-0022-design-tokens-dual-source.md
+++ b/docs/adr/adr-0022-design-tokens-dual-source.md
@@ -1,0 +1,101 @@
+---
+title: "ADR-0022: Dual-Source Design Tokens (tokens.ts + tokens.css), OKLCH, Locked Icon/Font Set"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-26"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "frontend", "design-tokens"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0022: Dual-Source Design Tokens (tokens.ts + tokens.css), OKLCH, Locked Icon/Font Set
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in fidelity-2
+Batch A (PR #149); specified in `docs/design/admin/fidelity-2-plan.md`
+("Locked-in stack", "Where things live") and
+`docs/design/admin/03-aesthetic-notes.md`.
+
+## Context
+
+The design system needs a single conceptual source for color/typography/radius
+tokens that is consumable both by TypeScript code (for typed token references in
+components/stories) and by Tailwind 4's CSS-first `@theme` mechanism. A full
+token build pipeline (e.g., Style Dictionary) is more machinery than two small
+files justify at this stage.
+
+## Decision
+
+Adopt a **dual-source token system** with a hand-sync discipline:
+
+- **`packages/ui/src/styles/tokens.ts`** — the **TypeScript source-of-truth**
+  (typed token objects).
+- **`packages/ui/src/styles/tokens.css`** — the Tailwind 4 `@theme` block,
+  **hand-synced** from `tokens.ts`. The two files are intentionally small; a build
+  step isn't worth the indirection "until they diverge."
+- Colors are expressed in **OKLCH** (perceptually uniform — load-bearing for the
+  accessible era palette in ADR-0024).
+- **Icon set locked to lucide-react**; **fonts locked** to **Fraunces** (display,
+  standing in for licensed GT Sectra), **Inter Tight** (body), **JetBrains Mono**
+  (IDs/slugs/JSONB), loaded via `next/font` and bound to CSS variables.
+- `globals.css` is the entry point (sets `color-scheme: dark`, tabular-numeral
+  font-feature-settings); `apps/admin` re-imports `@repo/ui/styles/globals.css`.
+
+`tokens.ts`/`tokens.css` are declared the canonical values; design docs defer to
+them if they drift.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: One conceptual token source feeds both typed TS references and
+  Tailwind's CSS-first theme without a codegen step.
+- **POS-002**: OKLCH makes lightness/chroma adjustments perceptually predictable —
+  essential for the colorblind-safe era hues (ADR-0024) and the sequential
+  importance/significance ramps.
+- **POS-003**: Locking the icon set and fonts (with documented substitutions)
+  keeps the visual language consistent and the bundle predictable.
+
+### Negative
+
+- **NEG-001**: The two token files are **hand-synced** — they can drift; the
+  discipline is "code wins, update docs." A future divergence is the documented
+  trigger to introduce codegen.
+- **NEG-002**: Fraunces/Inter Tight are acknowledged substitutes/"slop-tier" picks
+  pending licensed alternatives; the font choice is provisional.
+- **NEG-003**: Some character-type tint token slots are specified but not yet added
+  to the files (deferred to the type-badge primitive — ADR-0024).
+
+## Alternatives Considered
+
+### A token build pipeline (Style Dictionary / codegen)
+
+- **ALT-001**: **Description**: Generate `tokens.css` from `tokens.ts`
+  automatically.
+- **ALT-002**: **Rejection Reason**: More machinery than two tiny files warrant
+  now; revisit when they diverge.
+
+### Single source (CSS-only or TS-only)
+
+- **ALT-003**: **Description**: Keep tokens in just one file.
+- **ALT-004**: **Rejection Reason**: CSS-only loses typed TS references; TS-only
+  can't feed Tailwind 4's `@theme` directly — both consumers are needed.
+
+## Implementation Notes
+
+- **IMP-001**: `tokens.ts`, `tokens.css`, `globals.css` in
+  `packages/ui/src/styles/`; token Storybook stories (`colors`, `spacing`,
+  `typography`) document them.
+- **IMP-002**: Fonts via `next/font` in `apps/admin/app/layout.tsx`, bound to
+  `--font-*` variables.
+- **IMP-003**: OKLCH era/importance/type values live here as the source of truth
+  for ADR-0024.
+
+## References
+
+- **REF-001**: ADR-0020 (design system), ADR-0023 (dark-mode default in
+  globals.css), ADR-0024 (palette values consuming these tokens)
+- **REF-002**: `packages/ui/src/styles/{tokens.ts,tokens.css,globals.css}`;
+  `docs/design/admin/fidelity-2-plan.md`; `docs/design/admin/03-aesthetic-notes.md`
+- **REF-003**: Tailwind 4 `@theme`, OKLCH, lucide-react docs

--- a/docs/adr/adr-0023-dark-mode-only-fidelity-2.md
+++ b/docs/adr/adr-0023-dark-mode-only-fidelity-2.md
@@ -1,0 +1,86 @@
+---
+title: "ADR-0023: Dark-Mode-Only for Fidelity-2 (Light Mode Deferred)"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-26"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "frontend", "theming"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0023: Dark-Mode-Only for Fidelity-2 (Light Mode Deferred)
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — implemented in fidelity-2
+Batch A (PR #149); specified in `docs/design/admin/fidelity-2-plan.md`
+("Locked-in stack" → Dark mode strategy) and
+`docs/design/admin/03-aesthetic-notes.md` ("Color direction").
+
+## Context
+
+The aesthetic notes commit to dark mode as the default for a CMS where users
+stare at structured forms for hours, and state that light mode "should exist but
+not be the default." Supporting both themes from day one doubles the token surface
+(every era/importance/type color needs a verified light variant) and slows the
+fidelity-2 push to replace boilerplate with a working themed shell.
+
+## Decision
+
+Ship **dark mode only** in fidelity-2: set **`color-scheme: dark` as the default**
+in `globals.css` and **defer the class-based light-mode toggle**. The token system
+(ADR-0022) carries only dark-mode values for now; light-mode era values and the
+toggle are explicitly postponed. (This diverges from #37's expectations and is
+flagged in the closing PR.)
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Keeps the token surface small — one set of OKLCH values to verify
+  for contrast and colorblind-safety (ADR-0024) instead of two.
+- **POS-002**: Matches the documented "dark default" product intent for long
+  editing sessions.
+- **POS-003**: Unblocks the fidelity-2 shell/auth/primitive work without waiting on
+  a full light palette.
+
+### Negative
+
+- **NEG-001**: No light mode yet — users who prefer/ need light themes are
+  unserved until the deferred work lands.
+- **NEG-002**: Adding light mode later requires authoring and verifying a full
+  parallel set of era/importance/type tokens plus a class-based toggle, retrofitted
+  across already-built primitives.
+- **NEG-003**: Diverges from #37's stated expectation (flagged, not silent).
+
+## Alternatives Considered
+
+### Support light + dark from the start
+
+- **ALT-001**: **Description**: Build both themes and a toggle in fidelity-2.
+- **ALT-002**: **Rejection Reason**: Doubles the token/verification surface
+  (especially the colorblind-safe era hues) and slows the boilerplate-removal
+  milestone for a mode the product treats as secondary.
+
+### Light-mode default
+
+- **ALT-003**: **Description**: Ship light first.
+- **ALT-004**: **Rejection Reason**: Contradicts the documented dark-default intent
+  for a dense, long-session CMS.
+
+## Implementation Notes
+
+- **IMP-001**: `color-scheme: dark` set in
+  `packages/ui/src/styles/globals.css`; no light token block authored.
+- **IMP-002**: Light-mode era values are listed as deferred in
+  `03-aesthetic-notes.md` alongside the rest of light mode.
+- **IMP-003**: A future ADR should record the light-mode token system + toggle when
+  built.
+
+## References
+
+- **REF-001**: ADR-0022 (token system this constrains), ADR-0024 (era/type colors
+  authored dark-only), ADR-0020 (design system)
+- **REF-002**: `packages/ui/src/styles/globals.css`;
+  `docs/design/admin/fidelity-2-plan.md`; `docs/design/admin/03-aesthetic-notes.md`
+- **REF-003**: `color-scheme` / `prefers-color-scheme` docs

--- a/docs/adr/adr-0023-dark-mode-only-fidelity-2.md
+++ b/docs/adr/adr-0023-dark-mode-only-fidelity-2.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "frontend", "theming"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0023: Dark-Mode-Only for Fidelity-2 (Light Mode Deferred)

--- a/docs/adr/adr-0024-accessibility-first-visual-language.md
+++ b/docs/adr/adr-0024-accessibility-first-visual-language.md
@@ -7,6 +7,8 @@ tags:
   ["architecture", "decision", "frontend", "accessibility", "visual-language"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0024: Accessibility-First Visual Language — Era Hue-Spread + Character-Type Identity

--- a/docs/adr/adr-0024-accessibility-first-visual-language.md
+++ b/docs/adr/adr-0024-accessibility-first-visual-language.md
@@ -1,0 +1,101 @@
+---
+title: "ADR-0024: Accessibility-First Visual Language — Era Hue-Spread + Character-Type Identity"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-26"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags:
+  ["architecture", "decision", "frontend", "accessibility", "visual-language"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0024: Accessibility-First Visual Language — Era Hue-Spread + Character-Type Identity
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — specified in
+`docs/design/admin/03-aesthetic-notes.md` ("Visual design language (finalized)")
+and `docs/design/admin/fidelity-2-plan.md` (Batch J). **Reconciles PRD §7.2.2 in
+place** (no separate issue — fixed directly, mirroring the #127 approach).
+
+## Context
+
+Eras (CE/BCE/KYA/MYA/BYA) and the seven character types (ADR-0007) must be
+scannable in dense lists, headers, and pickers. PRD §7.2.2's original era palette
+(blue/amber/brown/green/purple) clustered brown↔amber↔green in the warm-to-yellow
+band — exactly where red-green colorblind users lose separation. Color used as the
+_only_ signal also fails accessibility.
+
+## Decision
+
+Adopt an **accessibility-first visual language**:
+
+- **Era differentiates by hue spread evenly around the wheel** (OKLCH): CE amber
+  (60), BCE gold (100), KYA teal (200), MYA blue (260), BYA magenta (320) — maximizing
+  inter-era hue distance instead of the clustered PRD set. **PRD §7.2.2 was updated
+  in place** to this palette; `tokens.css`/`tokens.ts` remain the source of truth.
+- **Hue is never the only signal.** `TemporalDisplay` (#158) renders the literal era
+  code in mono beside the value, so colorblind users read the token regardless of
+  hue. Uncertainty renders quietly (muted prefix `c.`/`~`/`est.`, `± years`,
+  hairline range bar only when ambiguity is real — >100yr OR >1000yr span OR crosses
+  an era boundary).
+- **Character type is identity:** each of the seven types gets a **lucide icon +
+  low-chroma tint + the literal label** — **never icon-alone**. Tints stay
+  low-chroma so seven categorical colors don't fight the era accents or the
+  importance/significance sequential ramp when co-occurring in a row.
+- **Significance reuses the importance sequential single-hue ramp** (amber 55,
+  rising lightness/chroma) — same visual language for "how much does this matter."
+- Anti-patterns enforced: **no purple gradients**; **density over delight** (no
+  scroll-driven animation, custom cursors, parallax, magnetic buttons).
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Era separation survives red-green colorblindness (hue spread) and
+  monochrome (literal era code), satisfying the load-bearing accessibility goal.
+- **POS-002**: Character type, era, and significance each have a consistent,
+  reinforced (color + text/icon) encoding that reads fast without relying on color
+  alone.
+- **POS-003**: Reusing the importance ramp for significance avoids a second color
+  language and keeps dense rows calm.
+
+### Negative
+
+- **NEG-001**: Maintaining colorblind-safe hue distances constrains future palette
+  additions (an 8th era/type must preserve separation).
+- **NEG-002**: The "never icon-alone / always literal era code" rules add markup
+  obligations to every list/badge primitive.
+- **NEG-003**: Character-type tint token slots are specified but not yet added to
+  `tokens.ts`/`tokens.css` (deferred to the type-badge primitive).
+
+## Alternatives Considered
+
+### Keep PRD §7.2.2's original clustered era palette
+
+- **ALT-001**: **Description**: blue/amber/brown/green/purple per the PRD.
+- **ALT-002**: **Rejection Reason**: brown↔amber↔green cluster fails red-green
+  colorblindness; replaced by an evenly hue-spread palette.
+
+### Color-only era/type encoding (no literal label/code)
+
+- **ALT-003**: **Description**: Rely on the tint/hue alone.
+- **ALT-004**: **Rejection Reason**: Fails colorblind and monochrome users; the
+  literal era code and type label are mandatory reinforcement.
+
+## Implementation Notes
+
+- **IMP-001**: Era/importance OKLCH values in `tokens.ts`/`tokens.css` (ADR-0022);
+  `TemporalDisplay` (#158) and `StatusBadge` consume them.
+- **IMP-002**: Range-bar trigger rule from wireframe
+  `02-wireframes/08-event-detail.md` annotation #5.
+- **IMP-003**: PRD §7.2.2 reconciled in place; divergence table recorded in
+  `03-aesthetic-notes.md`.
+
+## References
+
+- **REF-001**: ADR-0007 (seven types), ADR-0005 (temporal display source),
+  ADR-0022 (tokens), ADR-0023 (dark-only), ADR-0027 (PRD-reconciliation protocol)
+- **REF-002**: `docs/design/admin/03-aesthetic-notes.md`;
+  `docs/design/admin/fidelity-2-plan.md`; PRD §7.2.2; PRD §7.11
+- **REF-003**: OKLCH, WCAG color-contrast, colorblind-simulation guidance

--- a/docs/adr/adr-0025-shared-mediapicker-bespoke-tree.md
+++ b/docs/adr/adr-0025-shared-mediapicker-bespoke-tree.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "frontend", "ui", "primitives"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0025: Primitive Sourcing — shadcn for Everything Except a Bespoke Tree; Shared MediaPicker

--- a/docs/adr/adr-0025-shared-mediapicker-bespoke-tree.md
+++ b/docs/adr/adr-0025-shared-mediapicker-bespoke-tree.md
@@ -1,0 +1,93 @@
+---
+title: "ADR-0025: Primitive Sourcing — shadcn for Everything Except a Bespoke Tree; Shared MediaPicker"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-26"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "frontend", "ui", "primitives"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0025: Primitive Sourcing — shadcn for Everything Except a Bespoke Tree; Shared MediaPicker
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — specified in
+`docs/design/admin/fidelity-2-plan.md` ("Locked-in stack" → Bespoke primitives;
+Batch I). Batch I (#49 follow-up) introduces the shared `MediaPicker`.
+
+## Context
+
+The fidelity-2 system needs many primitives (buttons, tables, dialogs, sheets,
+badges, forms, a hierarchy view for nested timelines/periods, a media picker used
+on multiple editors). Hand-building primitives that shadcn already provides wastes
+effort and loses accessibility; but some surfaces (a nested tree, a cross-entity
+media picker) have no good shadcn equivalent.
+
+## Decision
+
+Establish a **primitive-sourcing rule**:
+
+- **shadcn/ui is the source for every primitive except one.** `DataTable` is
+  tanstack-table + shadcn `Table` markup; dialogs/sheets/badges/forms/etc. are
+  shadcn.
+- **`Tree` is the only bespoke primitive** — no shadcn equivalent exists for the
+  nested timeline/period hierarchy, so it is built in-house in `packages/ui`.
+- **`MediaPicker` is a shared primitive** (Batch I, #49 follow-up): a single
+  reusable cross-entity media library + picker, consumed by the event, character,
+  and timeline editors rather than re-implemented per editor.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Maximizes reuse of accessible, tested shadcn primitives; minimizes
+  bespoke surface to exactly one component (`Tree`).
+- **POS-002**: A single shared `MediaPicker` keeps media attachment behavior
+  consistent across every editor and avoids duplicated upload/selection logic.
+- **POS-003**: The explicit "Tree only" rule prevents scope creep into hand-rolling
+  primitives shadcn already covers.
+
+### Negative
+
+- **NEG-001**: `Tree` is fully owned in-house — its accessibility, keyboard nav,
+  and theming are the team's responsibility, with no upstream to track.
+- **NEG-002**: A shared `MediaPicker` must satisfy several editors' needs, so its
+  API has to stay general enough without becoming a god-component.
+
+## Alternatives Considered
+
+### Build all primitives bespoke
+
+- **ALT-001**: **Description**: Hand-roll tables, dialogs, etc.
+- **ALT-002**: **Rejection Reason**: Throws away shadcn's accessible, tested base
+  for no benefit; huge maintenance surface.
+
+### Per-editor media pickers
+
+- **ALT-003**: **Description**: Each editor implements its own media selection.
+- **ALT-004**: **Rejection Reason**: Duplicates upload/selection logic and drifts
+  in behavior; a shared primitive is consistent and cheaper.
+
+### Find/adopt a third-party tree component
+
+- **ALT-005**: **Description**: Use an external tree library.
+- **ALT-006**: **Rejection Reason**: Would reintroduce a non-shadcn dependency and
+  theming mismatch; a small in-house `Tree` fits the token system cleanly.
+
+## Implementation Notes
+
+- **IMP-001**: Primitives in `packages/ui/src/components/`; `Tree` is the lone
+  bespoke entry, `DataTable` wraps tanstack-table + shadcn `Table`.
+- **IMP-002**: `MediaPicker` (Batch I) backed by the `media` storage bucket
+  (ADR-0016) and `media` table (ADR-0014 global-read).
+- **IMP-003**: All primitives consume the token system (ADR-0022) and visual
+  language (ADR-0024) and are exercised in Storybook (ADR-0020/0026).
+
+## References
+
+- **REF-001**: ADR-0020 (design system), ADR-0016 (media storage), ADR-0014
+  (media RLS), ADR-0022 (tokens), ADR-0026 (Storybook/tests)
+- **REF-002**: `docs/design/admin/fidelity-2-plan.md` (Bespoke primitives; Batch
+  I); issue #49
+- **REF-003**: shadcn/ui, tanstack-table docs

--- a/docs/adr/adr-0026-testing-strategy.md
+++ b/docs/adr/adr-0026-testing-strategy.md
@@ -1,0 +1,95 @@
+---
+title: "ADR-0026: Testing Strategy — pgTAP for the Database, Vitest (80%) for Packages, Storybook for UI"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-22"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "testing", "quality"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0026: Testing Strategy — pgTAP for the Database, Vitest (80%) for Packages, Storybook for UI
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — realized by
+`supabase/tests/database/` (pgTAP), `packages/{ui,services}/vitest.config.ts`
+(Vitest + coverage), and `packages/ui/.storybook/` (Storybook). Reflected in the
+root `coverage/` merge and `scripts/fix-lcov-paths.mjs`.
+
+## Context
+
+The system's correctness lives in three different layers: the database (schema
+constraints, RLS policies, functions — ADR-0014/0015), shared TypeScript logic
+(temporal math, schemas, service modules — ADR-0019), and UI primitives
+(ADR-0020). Each layer needs a test tool suited to it; a single framework can't
+meaningfully assert RLS behavior _and_ React rendering. There is no app-level test
+suite yet because the apps are still being built out.
+
+## Decision
+
+Adopt a **layered testing strategy**:
+
+- **pgTAP** for the **database** — tests in `supabase/tests/database/`, run via
+  `pnpm run db:test`, asserting schema constraints, the RLS policy matrix
+  (published/owner/admin/collaborator), and function behavior. This is the only
+  way to test RLS the way it actually runs.
+- **Vitest with an 80% coverage gate** for **`packages/ui` and
+  `packages/services`** — `pnpm run test` / `pnpm run test:coverage`. Coverage
+  reports are merged at the repo root (`coverage/lcov.info`), with
+  `scripts/fix-lcov-paths.mjs` normalizing monorepo paths.
+- **Storybook** for **UI primitives** — colocated `*.stories.tsx` plus composite
+  "Pages > \*" mockups provide visual review/snapshots (ADR-0020).
+- **Apps are not yet in the test workspace** — they are added only once they
+  contain unit-testable logic, to avoid coverage theater on boilerplate.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: RLS and DB functions are tested in-database (pgTAP), where their
+  real behavior is observable — not approximated in app mocks.
+- **POS-002**: The 80% Vitest gate enforces real coverage on the shared logic
+  (temporal math, schemas, services) that the apps depend on.
+- **POS-003**: Storybook gives the design system a visual regression/review
+  surface aligned with the component workbench (ADR-0020).
+
+### Negative
+
+- **NEG-001**: Three test tools mean three skill sets and three CI/local
+  invocations to keep green.
+- **NEG-002**: The 80% gate can pressure low-value tests if applied to trivial
+  code; mitigated by keeping apps out until they have real logic.
+- **NEG-003**: Merging coverage across packages requires the
+  `fix-lcov-paths.mjs` shim — a small piece of bespoke tooling to maintain.
+
+## Alternatives Considered
+
+### One framework for everything
+
+- **ALT-001**: **Description**: Test RLS/DB logic from TypeScript with mocks.
+- **ALT-002**: **Rejection Reason**: Can't faithfully exercise RLS/policies/SQL
+  functions; pgTAP runs the real policy engine.
+
+### No coverage gate
+
+- **ALT-003**: **Description**: Run Vitest without a threshold.
+- **ALT-004**: **Rejection Reason**: Loses the enforced quality bar on shared
+  packages; 80% is the documented contract.
+
+## Implementation Notes
+
+- **IMP-001**: pgTAP tests in `supabase/tests/database/`, run by `pnpm run db:test`.
+- **IMP-002**: Vitest configs + 80% threshold in
+  `packages/{ui,services}/vitest.config.ts`; root coverage merge via
+  `scripts/fix-lcov-paths.mjs`.
+- **IMP-003**: Add apps to the test workspace only when they hold unit-testable
+  code.
+
+## References
+
+- **REF-001**: ADR-0014/0015 (RLS under pgTAP), ADR-0019 (services under Vitest),
+  ADR-0020 (Storybook)
+- **REF-002**: `supabase/tests/database/`; `packages/{ui,services}/vitest.config.ts`;
+  `scripts/fix-lcov-paths.mjs`; `coverage/`
+- **REF-003**: pgTAP, Vitest, Storybook docs

--- a/docs/adr/adr-0026-testing-strategy.md
+++ b/docs/adr/adr-0026-testing-strategy.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "testing", "quality"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0026: Testing Strategy — pgTAP for the Database, Vitest (80%) for Packages, Storybook for UI

--- a/docs/adr/adr-0027-upstream-spec-bug-protocol.md
+++ b/docs/adr/adr-0027-upstream-spec-bug-protocol.md
@@ -1,0 +1,98 @@
+---
+title: "ADR-0027: Upstream Spec/Schema Bug Protocol and PRD Reconciliation"
+status: "Accepted (retroactively documented 2026-05-30)"
+date: "2026-05-22"
+authors: "Time Traveler engineering (reconstructed retroactively)"
+tags: ["architecture", "decision", "process", "governance"]
+supersedes: ""
+superseded_by: ""
+---
+
+# ADR-0027: Upstream Spec/Schema Bug Protocol and PRD Reconciliation
+
+## Status
+
+**Accepted (retroactively documented 2026-05-30)** — codified in
+`.github/copilot-instructions.md` and `CLAUDE.md` ("When you find a spec or
+upstream bug"); exemplified by #73 (workaround template), #127 (wireframe↔PRD
+divergence), and the PRD §7.2.2 in-place reconciliation (ADR-0024).
+
+## Context
+
+Implementation routinely reveals that an upstream artifact — `docs/system-design.md`,
+the PRD, the schema, or a wireframe — is wrong or has drifted from what the code
+actually does. Silently coding around such bugs hides them, lets the spec rot, and
+recreates the exact knowledge gap this ADR series exists to close. A consistent
+protocol is needed for both code-level upstream bugs and documentation divergences.
+
+## Decision
+
+Adopt a two-track **upstream-discrepancy protocol**:
+
+- **Upstream _bug_ → file a tracking issue, don't work around it silently.** When
+  implementation reveals a bug in the spec/schema/wireframe, file a separate GitHub
+  issue documenting the bug, its evidence, the workaround applied in code, and the
+  recommended upstream fix; reference the tracking issue in the workaround comment
+  when the workaround is non-obvious (template: #73).
+- **Documentation _divergence_ → reconcile in place and record it.** When a doc
+  (e.g., the PRD) merely needs to catch up to a sound implementation decision,
+  update the doc in place and record the divergence in the relevant design doc —
+  optionally without a separate issue (as done for PRD §7.2.2 in
+  `03-aesthetic-notes.md`, ADR-0024; and tracked for wireframe↔PRD §7.11 in #127).
+- **Block, don't guess.** Missing API/service → `// BLOCKED:`; missing credential →
+  `// NEEDS:`; ambiguous business logic → `// DECISION NEEDED:` + the conservative
+  path; conflict with an existing convention → follow the convention and flag it.
+- **Going forward, architectural decisions are captured as ADRs** in `docs/adr/`
+  (this series); new decisions continue from **ADR-0028+**.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Upstream bugs become visible/trackable instead of buried in silent
+  workarounds, keeping the spec trustworthy.
+- **POS-002**: The block-don't-guess rules keep contributors (human and agent) from
+  inventing values or business logic.
+- **POS-003**: Pairing this with the ADR process closes the documentation gap this
+  backfill addressed and prevents its recurrence.
+
+### Negative
+
+- **NEG-001**: Filing issues and writing ADRs is overhead on top of shipping code;
+  the discipline must be sustained to pay off.
+- **NEG-002**: The bug-vs-divergence distinction requires judgment; borderline
+  cases could be handled inconsistently without review attention.
+
+## Alternatives Considered
+
+### Fix upstream artifacts silently in the same PR
+
+- **ALT-001**: **Description**: Patch the spec/schema inline without an issue or
+  record.
+- **ALT-002**: **Rejection Reason**: Hides the discrepancy and its rationale;
+  reviewers and future contributors lose the trail — the exact failure mode this
+  ADR prevents.
+
+### No formal decision record going forward
+
+- **ALT-003**: **Description**: Rely on PRs/commit messages for architectural
+  rationale.
+- **ALT-004**: **Rejection Reason**: That is precisely the gap that required this
+  retroactive backfill; ADRs make decisions first-class and findable.
+
+## Implementation Notes
+
+- **IMP-001**: Protocol text lives in `.github/copilot-instructions.md` and
+  `CLAUDE.md`; a "When to write an ADR" rule is added there pointing at
+  `docs/adr/`.
+- **IMP-002**: Reference examples: #73 (bug+workaround template), #127 (tracked
+  divergence), PRD §7.2.2 in-place reconciliation (ADR-0024).
+- **IMP-003**: New ADRs start at 0028; `docs/adr/README.md` documents the
+  "when/how to add one" process.
+
+## References
+
+- **REF-001**: ADR-0024 (PRD §7.2.2 reconciliation example), ADR-0000 (template),
+  `docs/adr/README.md` (process)
+- **REF-002**: `.github/copilot-instructions.md`; `CLAUDE.md`; issues #73, #127
+- **REF-003**: Conventional ADR / decision-log practice

--- a/docs/adr/adr-0027-upstream-spec-bug-protocol.md
+++ b/docs/adr/adr-0027-upstream-spec-bug-protocol.md
@@ -6,6 +6,8 @@ authors: "Time Traveler engineering (reconstructed retroactively)"
 tags: ["architecture", "decision", "process", "governance"]
 supersedes: ""
 superseded_by: ""
+amends: ""
+amended_by: ""
 ---
 
 # ADR-0027: Upstream Spec/Schema Bug Protocol and PRD Reconciliation

--- a/docs/adr/adr-0028-period-span-overlay-and-hierarchy-axes.md
+++ b/docs/adr/adr-0028-period-span-overlay-and-hierarchy-axes.md
@@ -1,0 +1,160 @@
+---
+title: "ADR-0028: Periods as Span-Overlays; Hierarchical Containment for Periods & Categories"
+status: "Accepted"
+date: "2026-05-30"
+authors: "Time Traveler engineering"
+tags:
+  ["architecture", "decision", "data-model", "periods", "categories", "stories"]
+supersedes: ""
+superseded_by: ""
+amends: ""
+amended_by: ""
+---
+
+# ADR-0028: Periods as Span-Overlays; Hierarchical Containment for Periods & Categories
+
+## Status
+
+**Accepted** — resolved while designing the Milestone 7 (Phase 6) stories /
+periods / categories surfaces (`docs/design/admin/02-wireframes/` screens 18–24,
+issues #58–#64). The structural model is the existing schema
+(`supabase/migrations/00001_initial_schema.sql`,
+`00002_relationships_junctions.sql`); this ADR records the semantics now made
+explicit in `docs/system-design.md` (`period_timelines` and `story_events`
+comments) and the screen 23 (period detail) wireframe.
+
+## Context
+
+Milestone 7 brings periods, categories, and stories into the admin UI. The
+tables and junctions already exist, but three load-bearing model questions had
+no recorded decision and would have been answered ad hoc by the UI:
+
+1. **How does a period relate to events?** A naive reading would add a
+   `period_events` junction mirroring `timeline_events`. But periods, timelines,
+   and `event_type='period'` events are three different things, and conflating
+   them duplicates membership and creates a second curation surface to keep in
+   sync.
+2. **Do periods and categories nest?** Both have self-referential parent FKs
+   (`parent_period_id`, `parent_category_id`) in `00001`. ADR-0006 tombstoned the
+   analogous `events.parent_event_id` (#180), so the bare existence of a parent
+   FK is not sufficient justification — the decision to keep these needs its own
+   rationale to avoid looking like the same anti-pattern.
+3. **What is publishable?** Periods and stories carry `published`/`published_at`
+   (ADR-0011); categories do not. The UI needs this settled to know which
+   surfaces get a publish control.
+
+## Decision
+
+**Periods are span-overlays, not event containers.** A period's only structural
+association is `period_timelines` (period ↔ timeline); there is **no**
+`period_events` junction (deliberately). Events fall "within" a period **by
+date** — `events.sort_order_years BETWEEN` the period's
+`sort_order_start`/`sort_order_end` — computed at read time, not linked. This
+fixes the information architecture as three distinct mechanisms
+(`docs/system-design.md`, `period_timelines` comment):
+
+| Mechanism                        | Relationship to events                      |
+| -------------------------------- | ------------------------------------------- |
+| Timeline (via `timeline_events`) | **Contains** curated events (membership)    |
+| Period (via `period_timelines`)  | **Bands** timelines; gathers events by date |
+| `event_type='period'` event      | A **discrete span event** on one timeline   |
+
+**Periods and categories keep hierarchical containment.** `parent_period_id`
+(Mesozoic ⊃ Jurassic) and `parent_category_id` (Science ⊃ Physics) are genuine
+single-axis containment trees and are retained — in deliberate contrast to the
+retired event `parent_event_id` (ADR-0006, #180), which conflated _containment_
+with _decomposition_. Cycle prevention is enforced in the service layer for
+both (no DB constraint), the same posture ADR-0006 takes for
+`detail_timeline_id`.
+
+**Categories are taxonomy, not publishable content.** Categories tag events only
+this pass (`event_categories`); they have no `published` column and get no
+publish control. Publication (`published`/`published_at`, ADR-0011) applies to
+periods and stories.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: One curation surface for event membership (timelines), not two; a
+  period's coverage updates automatically as event dates change, with no junction
+  to maintain or let drift.
+- **POS-002**: The timeline / period / `event_type='period'` distinction is
+  explicit, so the UI and future contributors don't re-add a `period_events`
+  junction by reflex.
+- **POS-003**: Keeping `parent_period_id`/`parent_category_id` matches the real
+  domain (geological and topical containment) without reintroducing the
+  cross-axis ambiguity that sank `parent_event_id`.
+- **POS-004**: Categories stay a lightweight taxonomy (no publish lifecycle,
+  RLS, or notification fan-out), reducing surface area.
+
+### Negative
+
+- **NEG-001**: "Events in this period" is a range query, not an index join, so it
+  depends on the `sort_order_years` generated columns and their indexes
+  (ADR-0005); a period cannot include or exclude an individual event against its
+  dates without an `event_type='period'` event or a timeline.
+- **NEG-002**: Hierarchy cycles for periods/categories are not DB-constrained;
+  the service layer must reject cycle-closing `parent_*_id` assignments, the same
+  caveat ADR-0006 NEG-001 carries for `detail_timeline_id`.
+- **NEG-003**: Promoting categories to publishable, or attaching them to
+  characters/timelines/periods/stories, later requires a migration (a `published`
+  column and/or new junctions) and a new ADR.
+
+## Alternatives Considered
+
+### A `period_events` junction (periods contain events directly)
+
+- **ALT-001**: **Description**: Mirror `timeline_events` with a
+  `period_events (period_id, event_id)` junction so events are explicitly linked
+  to periods.
+- **ALT-002**: **Rejection Reason**: Duplicates event membership across a second
+  curation surface, drifts from the timeline as date ranges change, and blurs the
+  period / timeline / `event_type='period'` distinction. The by-date computation
+  is always correct and needs no upkeep.
+
+### Drop the period/category parent FKs (flat, like events post-#180)
+
+- **ALT-003**: **Description**: Treat #180 as a blanket rejection of
+  self-referential hierarchy and flatten periods and categories too.
+- **ALT-004**: **Rejection Reason**: #180 rejected event nesting because it
+  conflated two axes and crossed timeline/RLS boundaries. Period and category
+  hierarchies are single-axis containment with no such conflict; flattening them
+  would lose genuine domain structure.
+
+### Make categories publishable for symmetry
+
+- **ALT-005**: **Description**: Add `published`/`published_at` to categories so
+  every content entity shares the publish model.
+- **ALT-006**: **Rejection Reason**: Categories are organizational metadata, not
+  audience-facing content; a publish lifecycle adds RLS and notification cost for
+  no product need. Revisit via a new ADR if categories ever become curated,
+  shareable content.
+
+## Implementation Notes
+
+- **IMP-001**: `period_timelines` and `story_events` junctions in `00002`;
+  `periods.parent_period_id` and `categories.parent_category_id` self-FKs
+  (`ON DELETE CASCADE`) in `00001`. No `period_events` table exists by design.
+- **IMP-002**: Period RLS derives from the timeline via `period_timelines`
+  (`00007`, `00011`); a period has no owner column of its own. Category writes
+  follow the standard owner-derived pattern (ADR-0014).
+- **IMP-003**: Events-in-period is a `sort_order_years BETWEEN
+sort_order_start AND sort_order_end` range scan over the period's bands
+  (ADR-0005 generated columns); surfaced on the period detail screen (23).
+- **IMP-004**: `story_events.sort_order` for **editorial** narrative ordering is
+  pending migration #183 (see ADR-0010); it is orthogonal to the by-date period
+  computation here.
+
+## References
+
+- **REF-001**: ADR-0005 (`sort_order_years` generated columns), ADR-0006
+  (event nesting via `detail_timeline_id`; `parent_event_id` retired), ADR-0010
+  (junction conventions; `story_events.sort_order`), ADR-0011 (publication model;
+  categories excluded), ADR-0014 (owner-derived RLS)
+- **REF-002**: `supabase/migrations/00001_initial_schema.sql`,
+  `00002_relationships_junctions.sql`, `00007_rls_policies.sql`;
+  `docs/system-design.md` (`period_timelines` / `story_events` comments)
+- **REF-003**: `docs/design/admin/00-screen-inventory.md` (Milestone 7
+  decisions), `docs/design/admin/02-wireframes/21`–`24`; issues #58–#64, #180,
+  #183

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -26,6 +26,32 @@
 
 ---
 
+> **Architecture Decision Records.** The decisions described throughout this
+> document are captured as ADRs in [`docs/adr/`](adr/README.md). Key mappings:
+> §1.3 → [ADR-0001](adr/adr-0001-supabase-backend-platform.md); §2.2 →
+> [ADR-0003](adr/adr-0003-nextjs-app-router-react19.md),
+> [ADR-0021](adr/adr-0021-tanstack-query-zustand.md); §3.2 →
+> [ADR-0005](adr/adr-0005-hybrid-temporal-system.md),
+> [ADR-0006](adr/adr-0006-fractal-timeline-detail-timeline.md),
+> [ADR-0007](adr/adr-0007-seven-character-types.md),
+> [ADR-0011](adr/adr-0011-publication-model.md); §3.3 →
+> [ADR-0008](adr/adr-0008-character-relationships-directed-pairs.md),
+> [ADR-0009](adr/adr-0009-relationship-sub-role-taxonomy.md); §3.4 →
+> [ADR-0010](adr/adr-0010-junction-table-conventions.md); §3.5/§9.1 →
+> [ADR-0017](adr/adr-0017-auth-bootstrap-supporting-tables.md); §4 →
+> [ADR-0005](adr/adr-0005-hybrid-temporal-system.md); §5 →
+> [ADR-0012](adr/adr-0012-postgrest-crud-thin-service-layer.md),
+> [ADR-0013](adr/adr-0013-db-functions-read-only.md); §5.7 →
+> [ADR-0016](adr/adr-0016-storage-buckets-graduated-access.md); §6/§11 →
+> [ADR-0019](adr/adr-0019-services-package.md); §9 →
+> [ADR-0014](adr/adr-0014-rls-single-source-of-authorization.md),
+> [ADR-0015](adr/adr-0015-rls-and-function-hardening.md); §12 →
+> [ADR-0018](adr/adr-0018-curated-content-library.md). Front-end/design-system
+> decisions (ADR-0020, 0022–0025) live against
+> [`docs/design/admin/`](design/admin/fidelity-2-plan.md).
+
+---
+
 ## 1. System Overview
 
 Time Traveler is a temporal content management system for storing, visualizing, and interacting with historical events and narratives across the full span of time — from the Big Bang (13.8 billion years ago) through the present and into the speculative future.


### PR DESCRIPTION
## Summary

Reconstructs and documents the load-bearing architectural decisions made during the greenfield build of Time Traveler as a numbered **Architecture Decision Record** series under `docs/adr/`, closing a knowledge gap: the decisions were implemented (migrations `00001`–`00015`, the fidelity-1/2 design passes, monorepo bootstrap) but never recorded as discrete records.

**Docs-only** — no code, schema, migration, or token changes.

## What's included

- **27 retroactive ADRs** (`adr-0001` … `adr-0027`), each dated to its evidence (migration/PR) and marked **Accepted (retroactively documented 2026-05-30)**, with concrete citations (migration file + section, or doc section).
- **`docs/adr/README.md`** — index table of all 27, format rules, and the **"When to write an ADR"** process (new decisions start at `0028`).
- **`docs/adr/adr-0000-template.md`** — the ADR template.
- **Process wiring** — added a "When to write an ADR" section to `CLAUDE.md` and `.github/copilot-instructions.md`, and an ADR cross-reference block to `docs/system-design.md` mapping sections → ADRs.

## ADR map

| Phase | ADRs |
| --- | --- |
| Foundation | 0001 Supabase · 0002 pnpm+Turborepo · 0003 Next.js/React 19 · 0004 engineering standards |
| Data model | 0005 hybrid temporal · 0006 fractal `detail_timeline_id` · 0007 seven character types · 0008 directed relationships · 0009 sub-role taxonomy · 0010 junction conventions · 0011 publication model |
| API & security | 0012 PostgREST CRUD · 0013 read-only DB functions · 0014 RLS authorization · 0015 RLS/function hardening · 0016 storage buckets · 0017 auth bootstrap · 0018 content library |
| Frontend & design | 0019 `@repo/services` · 0020 `@repo/ui` shadcn/Tailwind · 0021 TanStack Query + Zustand · 0022 design tokens · 0023 dark-mode-only · 0024 accessibility-first visual language · 0025 MediaPicker/Tree |
| Process | 0026 testing strategy · 0027 upstream-bug/PRD-reconciliation protocol |

## Cross-reference integrity

- `0006` documents the superseded event-to-event `parent_event_id` approach (tombstoned per #180).
- `0008` ↔ `0009` carry reciprocal amend links (`relationship_role`, #119).
- All ADR↔ADR, ADR↔migration, and ADR↔system-design references resolve.

## Validation

Pre-commit hooks passed: Prettier (clean), ESLint (`--max-warnings 0`), and `check-types`.
