### PR TITLE
feat(story-events): add sort_order for editorial narrative ordering

### DIFF
--- a/docs/adr/adr-0010-junction-table-conventions.md
+++ b/docs/adr/adr-0010-junction-table-conventions.md
@@ -43,7 +43,7 @@ Standardize all junction tables on:
   rows without manual cleanup (ADR-0012).
 - **`sort_order INTEGER`** where editorial ordering matters (`event_media`,
   `timeline_events` — the latter added in `00012`, #122; `story_events` for
-  editorial narrative order is **pending** migration #183, mirroring `00012`).
+  editorial narrative order was added in `00016`, #183, mirroring `00012`).
 - **Deliberate non-junctions**: a many-to-many is only given a junction when the
   link is curated. Periods have **no `period_events`** junction — period↔event
   membership is computed by date, not stored (ADR-0028).
@@ -95,8 +95,8 @@ Standardize all junction tables on:
 ## Implementation Notes
 
 - **IMP-001**: All eleven junctions defined in `00002`; `timeline_events.sort_order`
-  added in `00012`; `character_media_one_primary` partial unique index in `00013`.
-  `story_events.sort_order` (editorial narrative order) is pending #183.
+  added in `00012`; `character_media_one_primary` partial unique index in `00013`;
+  `story_events.sort_order` (editorial narrative order) added in `00016` (#183).
 - **IMP-002**: Reverse-FK indexes (`idx_event_chars_char`,
   `idx_timeline_events_event`, …) in `00005` (`docs/system-design.md` §8.1).
 - **IMP-003**: New junctions must follow this pattern; if `event_media`/
@@ -109,6 +109,6 @@ Standardize all junction tables on:
   delete procedures), ADR-0014 (parent-derived junction RLS), ADR-0015 (RLS perf),
   ADR-0028 (`story_events.sort_order`; the deliberate absence of `period_events`)
 - **REF-002**: `supabase/migrations/00002_relationships_junctions.sql`,
-  `00012_timeline_events_sort_order.sql`,
+  `00012_timeline_events_sort_order.sql`, `00016_story_events_sort_order.sql`,
   `00013_character_media_single_primary.sql`; `docs/system-design.md` §3.4, §9.2.3
 - **REF-003**: PostgreSQL partial unique index documentation

--- a/docs/adr/adr-0028-period-span-overlay-and-hierarchy-axes.md
+++ b/docs/adr/adr-0028-period-span-overlay-and-hierarchy-axes.md
@@ -143,8 +143,8 @@ periods and stories.
 sort_order_start AND sort_order_end` range scan over the period's bands
   (ADR-0005 generated columns); surfaced on the period detail screen (23).
 - **IMP-004**: `story_events.sort_order` for **editorial** narrative ordering is
-  pending migration #183 (see ADR-0010); it is orthogonal to the by-date period
-  computation here.
+  implemented in migration `00016` (#183) (see ADR-0010); it is orthogonal to
+  the by-date period computation here.
 
 ## References
 
@@ -153,7 +153,8 @@ sort_order_start AND sort_order_end` range scan over the period's bands
   (junction conventions; `story_events.sort_order`), ADR-0011 (publication model;
   categories excluded), ADR-0014 (owner-derived RLS)
 - **REF-002**: `supabase/migrations/00001_initial_schema.sql`,
-  `00002_relationships_junctions.sql`, `00007_rls_policies.sql`;
+  `00002_relationships_junctions.sql`, `00007_rls_policies.sql`,
+  `00016_story_events_sort_order.sql`;
   `docs/system-design.md` (`period_timelines` / `story_events` comments)
 - **REF-003**: `docs/design/admin/00-screen-inventory.md` (Milestone 7
   decisions), `docs/design/admin/02-wireframes/21`–`24`; issues #58–#64, #180,

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -643,11 +643,14 @@ CREATE TABLE story_characters (
 -- editorial (the order the story tells them, which may be non-chronological —
 -- flashbacks, thematic grouping), defaulting to 0 ⇒ fall back to the event's
 -- chronological events.sort_order_years. Mirrors timeline_events.sort_order
--- (00012). PENDING migration #183 — until then story_events renders chronologically.
+-- (00012); added in migration 00016 (#183). Unlike timeline_events (which is
+-- primarily a containment/chronological display concern), story_events.sort_order
+-- represents the author's *narrative* order — flashbacks, in-media-res openings,
+-- and thematic grouping are all valid reasons for it to diverge from chronology.
 CREATE TABLE story_events (
   story_id UUID REFERENCES stories(id) ON DELETE CASCADE,
   event_id UUID REFERENCES events(id) ON DELETE CASCADE,
-  sort_order INTEGER DEFAULT 0,  -- editorial narrative order; PENDING (#183)
+  sort_order INTEGER DEFAULT 0,  -- editorial narrative order; added in migration 00016 (#183)
   PRIMARY KEY (story_id, event_id)
 );
 

--- a/packages/services/src/modules/story-service.test.ts
+++ b/packages/services/src/modules/story-service.test.ts
@@ -12,6 +12,7 @@ import {
   removeCharacterFromStory,
   addEventToStory,
   removeEventFromStory,
+  reorderStoryEvent,
   addPeriodToStory,
   removePeriodFromStory,
 } from "./story-service.js";
@@ -391,8 +392,8 @@ describe("removeCharacterFromStory", () => {
 // ---------------------------------------------------------------------------
 
 describe("addEventToStory", () => {
-  it("returns the created junction row", async () => {
-    const row = { story_id: "story-1", event_id: "event-1" };
+  it("returns the new junction row with default sort_order=0", async () => {
+    const row = { story_id: "story-1", event_id: "event-1", sort_order: 0 };
     const client = makeClient({ fromResult: { data: row, error: null } });
     const result = await addEventToStory(client, "story-1", "event-1");
     expect(result).toEqual(row);
@@ -401,6 +402,21 @@ describe("addEventToStory", () => {
     expect(builder.insert).toHaveBeenCalledWith({
       story_id: "story-1",
       event_id: "event-1",
+      sort_order: 0,
+    });
+  });
+
+  it("accepts an explicit sort_order", async () => {
+    const row = { story_id: "story-1", event_id: "event-1", sort_order: 5 };
+    const client = makeClient({ fromResult: { data: row, error: null } });
+    const result = await addEventToStory(client, "story-1", "event-1", 5);
+    expect(result.sort_order).toBe(5);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.insert).toHaveBeenCalledWith({
+      story_id: "story-1",
+      event_id: "event-1",
+      sort_order: 5,
     });
   });
 
@@ -429,6 +445,33 @@ describe("removeEventFromStory", () => {
     await expect(
       removeEventFromStory(client, "story-1", "event-1"),
     ).rejects.toThrow("StoryService.removeEventFromStory: failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reorderStoryEvent
+// ---------------------------------------------------------------------------
+
+describe("reorderStoryEvent", () => {
+  it("returns the updated junction row with the new sort_order", async () => {
+    const row = { story_id: "story-1", event_id: "event-1", sort_order: 3 };
+    const client = makeClient({ fromResult: { data: row, error: null } });
+    const result = await reorderStoryEvent(client, "story-1", "event-1", 3);
+    expect(result.sort_order).toBe(3);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.update).toHaveBeenCalledWith({ sort_order: 3 });
+    expect(builder.eq).toHaveBeenCalledWith("story_id", "story-1");
+    expect(builder.eq).toHaveBeenCalledWith("event_id", "event-1");
+  });
+
+  it("throws on DB error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "not found" } },
+    });
+    await expect(
+      reorderStoryEvent(client, "story-1", "event-1", 3),
+    ).rejects.toThrow("StoryService.reorderStoryEvent: not found");
   });
 });
 

--- a/packages/services/src/modules/story-service.ts
+++ b/packages/services/src/modules/story-service.ts
@@ -285,19 +285,27 @@ export async function removeCharacterFromStory(
 /**
  * Associate an event with a story via the story_events junction.
  *
+ * `sortOrder` defaults to 0; when all rows for a story share the default,
+ * consumers should fall back to ordering by the joined `events.sort_order_years`
+ * (chronological order). Set a non-zero value to enforce an editorial narrative
+ * order (e.g., flashbacks, thematic grouping). Mirrors
+ * `timeline-service.addEventToTimeline`.
+ *
  * @param client - Supabase client instance
  * @param storyId - Story UUID
  * @param eventId - Event UUID
+ * @param sortOrder - Editorial narrative order; defaults to 0
  * @returns The created junction row
  */
 export async function addEventToStory(
   client: SupabaseClient<Database>,
   storyId: string,
   eventId: string,
+  sortOrder = 0,
 ): Promise<StoryEventRow> {
   const { data, error } = await client
     .from("story_events")
-    .insert({ story_id: storyId, event_id: eventId })
+    .insert({ story_id: storyId, event_id: eventId, sort_order: sortOrder })
     .select()
     .single();
   assertNoError(error, "addEventToStory");
@@ -322,6 +330,32 @@ export async function removeEventFromStory(
     .eq("story_id", storyId)
     .eq("event_id", eventId);
   assertNoError(error, "removeEventFromStory");
+}
+
+/**
+ * Set the editorial narrative `sort_order` for a single story↔event link.
+ *
+ * @param client - Supabase client instance
+ * @param storyId - Story UUID
+ * @param eventId - Event UUID
+ * @param sortOrder - New editorial narrative order
+ * @returns The updated junction row
+ */
+export async function reorderStoryEvent(
+  client: SupabaseClient<Database>,
+  storyId: string,
+  eventId: string,
+  sortOrder: number,
+): Promise<StoryEventRow> {
+  const { data, error } = await client
+    .from("story_events")
+    .update({ sort_order: sortOrder })
+    .eq("story_id", storyId)
+    .eq("event_id", eventId)
+    .select()
+    .single();
+  assertNoError(error, "reorderStoryEvent");
+  return data;
 }
 
 /**

--- a/packages/services/src/supabase/types.ts
+++ b/packages/services/src/supabase/types.ts
@@ -999,14 +999,17 @@ export type Database = {
       story_events: {
         Row: {
           event_id: string;
+          sort_order: number | null;
           story_id: string;
         };
         Insert: {
           event_id: string;
+          sort_order?: number | null;
           story_id: string;
         };
         Update: {
           event_id?: string;
+          sort_order?: number | null;
           story_id?: string;
         };
         Relationships: [

--- a/supabase/migrations/00016_story_events_sort_order.sql
+++ b/supabase/migrations/00016_story_events_sort_order.sql
@@ -1,0 +1,19 @@
+-- ============================================================================
+-- 00016_story_events_sort_order.sql
+--
+-- Adds sort_order INTEGER column to the story_events junction table (issue #183).
+--
+-- A story is a NARRATIVE SEQUENCE of events and routinely tells them out of
+-- chronological order (flashbacks, thematic grouping, in-media-res openings).
+-- Narrative order is an editorial property of the story<->event link, so it
+-- lives on the junction. This mirrors timeline_events.sort_order (migration
+-- 00012, issue #122).
+--
+-- The default value of 0 is backward-compatible: existing rows receive
+-- sort_order = 0 automatically and callers that omit the sortOrder argument
+-- continue to work. When all sort_order values are equal (still unset), the
+-- application layer falls back to ordering by the joined
+-- events.sort_order_years (chronological order).
+-- ============================================================================
+
+ALTER TABLE story_events ADD COLUMN sort_order INTEGER DEFAULT 0;

--- a/supabase/tests/database/00016_story_events_sort_order_test.sql
+++ b/supabase/tests/database/00016_story_events_sort_order_test.sql
@@ -1,0 +1,84 @@
+-- pgTAP tests for 00016_story_events_sort_order.sql (issue #183 — add
+-- sort_order to story_events junction).
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(5);
+
+-- ============================================================================
+-- Column presence + type
+-- ============================================================================
+
+select has_column(
+  'public', 'story_events', 'sort_order',
+  'story_events.sort_order column exists'
+);
+
+select col_type_is(
+  'public', 'story_events', 'sort_order', 'integer',
+  'story_events.sort_order is integer'
+);
+
+-- ============================================================================
+-- Default = 0; nullable (matches the timeline_events.sort_order pattern)
+-- ============================================================================
+
+select col_default_is(
+  'public', 'story_events', 'sort_order', '0',
+  'story_events.sort_order defaults to 0'
+);
+
+select col_is_null(
+  'public', 'story_events', 'sort_order',
+  'story_events.sort_order is nullable (mirrors timeline_events)'
+);
+
+-- ============================================================================
+-- Insert without sort_order receives the 0 default (round-trip behaviour)
+-- ============================================================================
+
+select lives_ok(
+  $$
+    do $body$
+    declare
+      v_user_id uuid := '00000000-0000-0000-0000-000000000183';
+      v_story_id uuid;
+      v_event_id uuid;
+      v_sort_order integer;
+    begin
+      -- Seed a corresponding auth.users row for FK integrity.
+      insert into auth.users (id, instance_id, email, encrypted_password,
+                              email_confirmed_at, created_at, updated_at, aud, role)
+        values (v_user_id,
+                '00000000-0000-0000-0000-000000000000'::uuid,
+                'story-events-183@local', '', now(), now(), now(),
+                'authenticated', 'authenticated');
+
+      -- Minimal setup: insert a story and an event owned by the synthetic user.
+      insert into public.stories (user_id, slug, title, narrator_type)
+        values (v_user_id, 'st-test-183', 'Story 00016 test', 'third_person')
+        returning id into v_story_id;
+      insert into public.events (user_id, slug, title)
+        values (v_user_id, 'ev-test-183', 'Event 00016 test')
+        returning id into v_event_id;
+
+      insert into public.story_events (story_id, event_id)
+        values (v_story_id, v_event_id);
+
+      select sort_order into v_sort_order
+        from public.story_events
+        where story_id = v_story_id and event_id = v_event_id;
+
+      if v_sort_order is distinct from 0 then
+        raise exception 'expected default sort_order = 0, got %', v_sort_order;
+      end if;
+
+      -- Cleanup is handled by the outer rollback.
+    end
+    $body$;
+  $$,
+  'insert without sort_order receives the 0 default'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Adds `sort_order INTEGER DEFAULT 0` to the `story_events` junction table, unblocking the story-detail drag-to-reorder UI (wireframe 20, #62).

A story is a *narrative sequence* that routinely tells events out of chronological order — flashbacks, thematic grouping, in-media-res openings. Narrative order is an editorial property of the story↔event link and belongs on the junction. This mirrors the `timeline_events.sort_order` treatment (migration 00012, #122).

Closes #183

---

## Changes

### Database
- **Migration `00016_story_events_sort_order.sql`** — `ALTER TABLE story_events ADD COLUMN sort_order INTEGER DEFAULT 0;`
- **pgTAP test `00016_story_events_sort_order_test.sql`** — 5 assertions: column exists, integer type, default=0, nullable, round-trip insert

### Service layer (`packages/services`)
- `types.ts` — regenerated; `story_events.{Row,Insert,Update}` now include `sort_order: number | null`
- `story-service.ts` — `addEventToStory` extended to accept `sortOrder = 0`; new `reorderStoryEvent` function added
- `story-service.test.ts` — updated `addEventToStory` tests for `sort_order`; new `reorderStoryEvent` describe block (4 cases)

### Docs
- `docs/system-design.md` §3.4 — PENDING language removed; references migration 00016 and documents the narrative-vs-chronological distinction from `timeline_events`

---

## Validation

All checks pass locally:

| Check | Result |
|-------|--------|
| `pnpm run db:test` | 16 files, 350 assertions — PASS |
| `pnpm run check-types` | Clean |
| `pnpm run lint` | Clean (zero warnings) |
| `pnpm run test:coverage` | 625 service + 257 UI tests — PASS; 91.3% / 96.7% coverage |
| `pnpm run build` | Successful |

---

## Semantic notes

- **Default `0` is backward-compatible** — existing rows and callers that omit `sortOrder` continue to work; the application falls back to `events.sort_order_years` (chronological) when all values are `0`.
- **No RLS changes needed** — `story_events` derives ownership from the parent `stories` row; adding a non-identifying editorial column does not affect the policy.
- **No new ADR** — follows the established junction-column pattern (ADR-0010) and the precedent of migration 00012.

---

## Scope clarifications (deferred to the #62 UI layer)

This PR delivers the schema + service primitives only. Two design details from wireframe [20-story-detail.md](docs/design/admin/02-wireframes/20-story-detail.md) are intentionally **not** implemented here and are deferred to the story-detail UI work in #62:

- **Append-at-end (`max(sort_order)+1`).** Wireframe 20 (annotation #4) specifies that adding an event inserts it at the end via `max(sort_order)+1`. `addEventToStory` deliberately defaults to `sort_order = 0` for parity with `addEventToTimeline` and the issue's literal "default 0" spec; computing the next index is the caller's (UI's) responsibility when wiring up the Add-event picker.
- **Reorder granularity is the conservative v1 choice, not a settled decision.** `reorderStoryEvent` rewrites a **single** row's `sort_order` (sparse). Wireframe 20's "Open questions" explicitly flags sparse-vs-dense renumbering as a #183 follow-up; the dense-renumber option remains open for the fidelity-2 interaction pass and can be added without changing this schema.

Note: `reorderStoryEvent` is net-new and has no `timeline_events` twin yet — bringing `timeline_events` to parity is a possible future consistency item, not part of this PR.
