### PR TITLE
docs: require pnpm format before commit in validation checklists

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,11 +119,14 @@ Coverage reports are written to `packages/*/coverage/`. Do not add apps to the t
 Run these in order — all must pass:
 
 1. `pnpm install` — if you added/changed dependencies
-2. `pnpm run check-types` — TypeScript must compile with no errors
-3. `pnpm run lint` — zero ESLint errors or warnings
-4. `pnpm run build` — must produce a successful Next.js build
-5. `pnpm run test:coverage` — all tests must pass with ≥80% coverage
-6. `pnpm run db:test` — if you made database schema changes
+2. **`pnpm run format`** — run this **before `git add`**; the husky pre-commit hook runs `format:check` and will block the commit if any `.ts`, `.tsx`, or `.md` file is not formatted. One write-pass here prevents hook-related commit failures.
+3. `pnpm run check-types` — TypeScript must compile with no errors
+4. `pnpm run lint` — zero ESLint errors or warnings
+5. `pnpm run build` — must produce a successful Next.js build
+6. `pnpm run test:coverage` — all tests must pass with ≥80% coverage
+7. `pnpm run db:test` — if you made database schema changes
+
+Or run steps 2–6 at once (minus db:test) via `pnpm verify`.
 
 ## Important Rules & Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,12 @@ pnpm run db:gen:types          # regenerate ./packages/services/src/supabase/typ
 Run in order — all must pass:
 
 1. `pnpm install` if deps changed
-2. `pnpm run check-types`
-3. `pnpm run lint`
-4. `pnpm run build`
+2. **`pnpm run format`** — run this **before** `git add`; the husky pre-commit hook runs `format:check` and will block the commit if any file is not formatted. One write-pass here prevents all hook-related thrashing.
+3. `pnpm run check-types`
+4. `pnpm run lint`
+5. `pnpm run build`
+
+Or run the full suite at once: `pnpm verify` (`format:check && lint && check-types && test:coverage && build`).
 
 ## Conventions and gotchas
 


### PR DESCRIPTION
## What

Adds `pnpm format` as the explicit first step in the validation checklists in both `CLAUDE.md` and `.github/copilot-instructions.md`.

## Why

The husky pre-commit hook runs `pnpm format:check` (read-only). If any `.ts`, `.tsx`, or `.md` file isn't formatted, the hook exits non-zero and the commit is aborted. Without this step explicitly called out in the checklist, it gets missed every time — causing commit failures, re-staging, and wasted iteration.

## Changes

- `CLAUDE.md` — adds step 2 (`pnpm run format`) with an explanation of the hook, and notes `pnpm verify` as the all-in-one shortcut
- `.github/copilot-instructions.md` — same addition to the validation checklist

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)