### PR TITLE
feat(services): add events.detail_timeline_id for fractal drill-down (#177)

### DIFF
--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -344,7 +344,7 @@ CREATE TABLE events (
   importance INTEGER DEFAULT 5 CHECK (importance BETWEEN 1 AND 10),
   parent_event_id UUID REFERENCES events(id) ON DELETE CASCADE,  -- DEPRECATED (#180): event-to-event nesting; superseded by detail_timeline_id
   timeline_id UUID REFERENCES timelines(id) ON DELETE SET NULL,  -- primary containing timeline (RLS source)
-  detail_timeline_id UUID REFERENCES timelines(id) ON DELETE SET NULL,  -- PENDING (#177): the sub-timeline this event expands into (forward fractal drill-down)
+  detail_timeline_id UUID REFERENCES timelines(id) ON DELETE SET NULL,  -- #177 (migration 00017): the sub-timeline this event expands into (forward fractal drill-down)
   metadata JSONB DEFAULT '{}',
   search_vector TSVECTOR GENERATED ALWAYS AS (
     to_tsvector('english'::regconfig,
@@ -378,7 +378,7 @@ CREATE UNIQUE INDEX events_slug_idx ON events (user_id, slug);
 | ---------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `events.timeline_id`         | containment       | The event's **primary / home** timeline. **This is the RLS source** — `read_events` / `update_events` derive collaborator access from it (§9), and `idx_events_timeline_sort` is built on it. One event → one home timeline. |
 | `timeline_events` junction   | containment       | **Additional** "also appears in" timelines (e.g. an event surfaced in a comparative timeline). Many-to-many; carries `sort_order` for editorial arrangement (§3.4). Does **not** affect RLS.                                 |
-| `events.detail_timeline_id`  | decomposition     | The **sub-timeline this event expands into** — the forward fractal drill-down. One event → one sub-timeline. `ON DELETE SET NULL`. Pending migration #177.                                                                   |
+| `events.detail_timeline_id`  | decomposition     | The **sub-timeline this event expands into** — the forward fractal drill-down. One event → one sub-timeline. `ON DELETE SET NULL`. Migration 00017 (#177).                                                                   |
 | ~~`events.parent_event_id`~~ | ~~decomposition~~ | **Deprecated (#180).** Event-to-event nesting — redundant with, and weaker than, `detail_timeline_id`. Being tombstoned and dropped.                                                                                         |
 
 **Nesting is forward-only.** The hierarchy is `timeline → events → (event expands into) sub-timeline → events`, recursing on the timeline — not a backward `parent_event_id` tree. This preserves the committed event RLS untouched (access is keyed on the _containing_ `timeline_id`, never on the _child_ `detail_timeline_id`), eliminates the cross-timeline parent-link integrity holes `parent_event_id` permits, and keeps reads to one bounded query per zoom level. The forward model is the IA spec across the admin wireframes (`docs/design/admin/`).
@@ -567,7 +567,7 @@ All junction tables use composite primary keys, no surrogate `id`, no `user_id`.
 
 > **Self-referential FK cycles:** `parent_period_id` and `parent_category_id` are unconstrained at the database level — cycles (A → B → A) are accepted by PostgreSQL. Cycle prevention is enforced in the service layer during create/update operations (#31, #59, #60); the database intentionally does not attempt to detect cycles via constraints. (`parent_event_id` formerly belonged to this set but is deprecated — #180.)
 >
-> **Fractal-decomposition cycles:** the forward fractal mechanism `events.detail_timeline_id` → timeline can also form a cycle (an event expands into a timeline that, transitively, contains the event itself). Like the self-FK cases, this is **not** DB-constrained — the service layer rejects an `detail_timeline_id` assignment that would close such a loop (#177). The `detail_timeline_id` FK is `ON DELETE SET NULL`, so deleting a sub-timeline detaches the drill-down rather than cascading into the parent event.
+> **Fractal-decomposition cycles:** the forward fractal mechanism `events.detail_timeline_id` → timeline can also form a cycle (an event expands into a timeline that, transitively, contains the event itself). Like the self-FK cases, this is **not** DB-constrained — the service layer (`assertNoDetailTimelineCycle` in the event service) rejects a `detail_timeline_id` assignment that would close such a loop (#177). The `detail_timeline_id` FK is `ON DELETE SET NULL`, so deleting a sub-timeline detaches the drill-down rather than cascading into the parent event.
 
 ```sql
 -- Events ↔ Categories

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -598,6 +598,37 @@ describe("updateEvent", () => {
       updateEvent(client, "event-1", { detail_timeline_id: targetTimeline }),
     ).rejects.toThrow("fractal cycle");
   });
+
+  it("rejects update when detail_timeline_id equals timeline_id", async () => {
+    const timelineId = "11111111-1111-4111-8111-111111111111";
+    const client = makeClient({
+      fromResult: { data: sampleEvent, error: null },
+    });
+
+    await expect(
+      updateEvent(client, "event-1", {
+        timeline_id: timelineId,
+        detail_timeline_id: timelineId,
+      }),
+    ).rejects.toThrow("detail_timeline_id cannot equal timeline_id");
+  });
+
+  it("rejects when detail_timeline_id transitively reaches the new timeline_id", async () => {
+    const newHomeTimeline = "22222222-2222-4222-8222-222222222222";
+    const detailTimeline = "11111111-1111-4111-8111-111111111111";
+    const client = makeSequencedClient([
+      { data: [], error: null },
+      { data: [{ event_id: "event-2" }], error: null },
+      { data: [{ detail_timeline_id: newHomeTimeline }], error: null },
+    ]);
+
+    await expect(
+      updateEvent(client, "event-1", {
+        timeline_id: newHomeTimeline,
+        detail_timeline_id: detailTimeline,
+      }),
+    ).rejects.toThrow("detail_timeline_id cannot reach timeline_id");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -761,6 +792,17 @@ describe("setEventDetailTimeline", () => {
     await expect(
       setEventDetailTimeline(client, "event-1", "tl-sub"),
     ).rejects.toThrow("EventService.setEventDetailTimeline: update failed");
+  });
+
+  it("uses caller-neutral cycle error prefix", async () => {
+    const client = makeSequencedClient([
+      { data: [{ id: "event-1", detail_timeline_id: null }], error: null },
+      { data: [], error: null },
+    ]);
+
+    await expect(
+      setEventDetailTimeline(client, "event-1", "tl-sub"),
+    ).rejects.toThrow("EventService.assertNoDetailTimelineCycle");
   });
 });
 

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -629,6 +629,44 @@ describe("updateEvent", () => {
       }),
     ).rejects.toThrow("detail_timeline_id cannot reach timeline_id");
   });
+
+  it("guards a timeline_id-only update against an existing drill-down (#5)", async () => {
+    const newHome = "22222222-2222-4222-8222-222222222222";
+    // The event already expands into `newHome`; moving it there closes a cycle.
+    const client = makeSequencedClient([
+      { data: { detail_timeline_id: newHome }, error: null }, // current detail fetch
+    ]);
+    await expect(
+      updateEvent(client, "event-1", { timeline_id: newHome }),
+    ).rejects.toThrow("fractal cycle");
+  });
+
+  it("detects a transitive cycle on a timeline_id-only update (#5)", async () => {
+    const newHome = "22222222-2222-4222-8222-222222222222";
+    const detail = "11111111-1111-4111-8111-111111111111";
+    // Existing drill-down `detail` reaches `newHome` two hops out.
+    const client = makeSequencedClient([
+      { data: { detail_timeline_id: detail }, error: null }, // current detail fetch
+      { data: [{ detail_timeline_id: newHome }], error: null }, // home events of `detail`
+      { data: [], error: null }, // guest junction of `detail`
+    ]);
+    await expect(
+      updateEvent(client, "event-1", { timeline_id: newHome }),
+    ).rejects.toThrow("fractal cycle");
+  });
+
+  it("allows a timeline_id-only update when the event has no drill-down (#5)", async () => {
+    const newHome = "22222222-2222-4222-8222-222222222222";
+    const updated = { ...sampleEvent, timeline_id: newHome };
+    const client = makeSequencedClient([
+      { data: { detail_timeline_id: null }, error: null }, // current detail = none
+      { data: updated, error: null }, // the update
+    ]);
+    const result = await updateEvent(client, "event-1", {
+      timeline_id: newHome,
+    });
+    expect(result).toEqual(updated);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -12,6 +12,8 @@ import {
   unpublishEvent,
   getChildEvents,
   setParentEvent,
+  setEventDetailTimeline,
+  getEventsDetailedBy,
   getEventsInTemporalRange,
   addCategoryToEvent,
   removeCategoryFromEvent,
@@ -34,6 +36,7 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
     update: vi.fn().mockReturnThis(),
     delete: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
     gte: vi.fn().mockReturnThis(),
     lte: vi.fn().mockReturnThis(),
     textSearch: vi.fn().mockReturnThis(),
@@ -60,6 +63,35 @@ function makeClient(overrides: {
         .mockResolvedValue(
           authUser ?? { data: { user: { id: "user-123" } }, error: null },
         ),
+    },
+  };
+  return client as unknown as SupabaseClient<Database>;
+}
+
+/**
+ * Builds a client whose `from()` returns a fresh builder per call, drawn in
+ * order from `results`. Once the sequence is exhausted the last result repeats.
+ * Used for the cycle-guard tests, which issue several queries per call.
+ */
+function makeSequencedClient(
+  results: { data: unknown; error: unknown }[],
+): SupabaseClient<Database> {
+  const builders = results.map((r) => makeBuilder(r));
+  let i = 0;
+  const from = vi.fn(() => {
+    const builder = builders[Math.min(i, builders.length - 1)];
+    i += 1;
+    if (builder === undefined) {
+      throw new Error("makeSequencedClient: no builders configured");
+    }
+    return builder;
+  });
+  const client = {
+    from,
+    auth: {
+      getUser: vi
+        .fn()
+        .mockResolvedValue({ data: { user: { id: "user-123" } }, error: null }),
     },
   };
   return client as unknown as SupabaseClient<Database>;
@@ -94,6 +126,7 @@ const sampleEvent = {
   importance: 10,
   parent_event_id: null,
   timeline_id: null,
+  detail_timeline_id: null,
   metadata: null,
   search_vector: null,
   published: false,
@@ -552,6 +585,19 @@ describe("updateEvent", () => {
       updateEvent(client, "event-1", { title: "x" }),
     ).rejects.toThrow("EventService.updateEvent: update failed");
   });
+
+  it("runs the fractal-cycle guard when detail_timeline_id is set", async () => {
+    // The target timeline already contains event-1 → updating its drill-down to
+    // it cycles. (Zod requires a real UUID, unlike the setEventDetailTimeline path.)
+    const targetTimeline = "11111111-1111-4111-8111-111111111111";
+    const client = makeSequencedClient([
+      { data: [{ id: "event-1", detail_timeline_id: null }], error: null },
+      { data: [], error: null },
+    ]);
+    await expect(
+      updateEvent(client, "event-1", { detail_timeline_id: targetTimeline }),
+    ).rejects.toThrow("fractal cycle");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -640,6 +686,115 @@ describe("setParentEvent", () => {
     });
     await expect(setParentEvent(client, "event-1", "parent-1")).rejects.toThrow(
       "EventService.setParentEvent: update failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setEventDetailTimeline
+// ---------------------------------------------------------------------------
+
+describe("setEventDetailTimeline", () => {
+  it("sets the drill-down timeline when there is no cycle", async () => {
+    const updated = { ...sampleEvent, detail_timeline_id: "tl-sub" };
+    // 1: home events of tl-sub (none) · 2: guest junction (none) · 3: update
+    const client = makeSequencedClient([
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: updated, error: null },
+    ]);
+    const result = await setEventDetailTimeline(client, "event-1", "tl-sub");
+    expect(result).toEqual(updated);
+    const updateBuilder = (client.from as ReturnType<typeof vi.fn>).mock
+      .results[2]?.value as ReturnType<typeof makeBuilder>;
+    expect(updateBuilder.update).toHaveBeenCalledWith({
+      detail_timeline_id: "tl-sub",
+    });
+  });
+
+  it("clears the drill-down with null and skips the cycle check", async () => {
+    const updated = { ...sampleEvent, detail_timeline_id: null };
+    const client = makeClient({ fromResult: { data: updated, error: null } });
+    const result = await setEventDetailTimeline(client, "event-1", null);
+    expect(result).toEqual(updated);
+    // Only the update query runs — no BFS.
+    expect((client.from as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(
+      1,
+    );
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.update).toHaveBeenCalledWith({ detail_timeline_id: null });
+  });
+
+  it("rejects an assignment that would close a fractal cycle", async () => {
+    // tl-sub already contains event-1 (its home timeline) → cycle.
+    const client = makeSequencedClient([
+      { data: [{ id: "event-1", detail_timeline_id: null }], error: null },
+      { data: [], error: null },
+    ]);
+    await expect(
+      setEventDetailTimeline(client, "event-1", "tl-sub"),
+    ).rejects.toThrow("fractal cycle");
+  });
+
+  it("detects a cycle reached transitively through a guest appearance", async () => {
+    // tl-sub contains event-2 (guest); event-2 expands into tl-deep; tl-deep
+    // contains event-1 → cycle two hops out.
+    const client = makeSequencedClient([
+      { data: [], error: null }, // tl-sub home events
+      { data: [{ event_id: "event-2" }], error: null }, // tl-sub guest junction
+      { data: [{ id: "event-2", detail_timeline_id: "tl-deep" }], error: null }, // guest events
+      { data: [{ id: "event-1", detail_timeline_id: null }], error: null }, // tl-deep home events
+      { data: [], error: null }, // tl-deep guest junction
+    ]);
+    await expect(
+      setEventDetailTimeline(client, "event-1", "tl-sub"),
+    ).rejects.toThrow("fractal cycle");
+  });
+
+  it("throws on Supabase error during update", async () => {
+    const client = makeSequencedClient([
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: null, error: { message: "update failed" } },
+    ]);
+    await expect(
+      setEventDetailTimeline(client, "event-1", "tl-sub"),
+    ).rejects.toThrow("EventService.setEventDetailTimeline: update failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEventsDetailedBy
+// ---------------------------------------------------------------------------
+
+describe("getEventsDetailedBy", () => {
+  it("returns events that expand into the given timeline", async () => {
+    const detailing = { ...sampleEvent, detail_timeline_id: "tl-sub" };
+    const client = makeClient({
+      fromResult: { data: [detailing], error: null },
+    });
+    const result = await getEventsDetailedBy(client, "tl-sub");
+    expect(result).toEqual([detailing]);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("detail_timeline_id", "tl-sub");
+    expect(builder.order).toHaveBeenCalledWith("sort_order_years", {
+      ascending: true,
+    });
+  });
+
+  it("returns empty array when data is null", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    expect(await getEventsDetailedBy(client, "tl-sub")).toEqual([]);
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "DB error" } },
+    });
+    await expect(getEventsDetailedBy(client, "tl-sub")).rejects.toThrow(
+      "EventService.getEventsDetailedBy: DB error",
     );
   });
 });

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -280,19 +280,39 @@ export async function updateEvent(
   // The "expands into" drill-down can be set through a plain update, so the
   // fractal-cycle guard that setEventDetailTimeline applies must also run here
   // (an event must not expand into a timeline that transitively contains it).
-  if (
-    validated.detail_timeline_id !== undefined &&
-    validated.detail_timeline_id !== null
-  ) {
+  // Both fields are Zod `string | undefined` after parsing — never null — so a
+  // `!== undefined` check is sufficient.
+  if (validated.detail_timeline_id !== undefined) {
     await assertNoDetailTimelineCycle(client, id, validated.detail_timeline_id);
 
     // When `timeline_id` and `detail_timeline_id` are updated together, also
     // ensure the detail root cannot reach the new home timeline. Otherwise the
-    // check above can miss a cycle that only appears after the update lands.
-    if (validated.timeline_id !== undefined && validated.timeline_id !== null) {
+    // check above can miss a cycle that only appears after the update lands —
+    // the new home is not yet reflected in the DB.
+    if (validated.timeline_id !== undefined) {
       await assertNoTimelineReachableFromDetailRoot(
         client,
         validated.detail_timeline_id,
+        validated.timeline_id,
+      );
+    }
+  } else if (validated.timeline_id !== undefined) {
+    // Only the home timeline is changing. If the event already expands into a
+    // sub-timeline, that existing drill-down must not reach the new home (which
+    // would then contain the event). The drill-down itself is unchanged, so its
+    // prior containment was already validated when it was assigned; only the new
+    // home — not yet in the DB — needs checking.
+    const { data: current, error: currentError } = await client
+      .from("events")
+      .select("detail_timeline_id")
+      .eq("id", id)
+      .single();
+    assertNoError(currentError, "updateEvent(fetchCurrentDetail)");
+    const currentDetail = current?.detail_timeline_id ?? null;
+    if (currentDetail !== null) {
+      await assertNoTimelineReachableFromDetailRoot(
+        client,
+        currentDetail,
         validated.timeline_id,
       );
     }

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -267,6 +267,13 @@ export async function updateEvent(
 ): Promise<EventRow> {
   const validated = eventSchema.partial().parse(data);
 
+  // The "expands into" drill-down can be set through a plain update, so the
+  // fractal-cycle guard that setEventDetailTimeline applies must also run here
+  // (an event must not expand into a timeline that transitively contains it).
+  if (validated.detail_timeline_id !== undefined) {
+    await assertNoDetailTimelineCycle(client, id, validated.detail_timeline_id);
+  }
+
   type EventUpdate = Database["public"]["Tables"]["events"]["Update"];
   const { data: row, error } = await client
     .from("events")
@@ -372,6 +379,131 @@ export async function setParentEvent(
 
   assertNoError(error, "setParentEvent");
   return data as EventRow;
+}
+
+// ---------------------------------------------------------------------------
+// Fractal decomposition (forward drill-down)
+// ---------------------------------------------------------------------------
+
+/**
+ * Throws if assigning `timelineId` as the drill-down sub-timeline
+ * (`detail_timeline_id`) of `eventId` would close a fractal cycle — i.e. if
+ * `timelineId` already (transitively) contains `eventId`.
+ *
+ * The forward fractal graph is `timeline → contained events → (each event's
+ * detail_timeline_id) → sub-timeline → …`. "Contained" spans both containment
+ * axes: an event's primary/home timeline (`events.timeline_id`) and its guest
+ * appearances (`timeline_events` junction). Starting from `timelineId`, we walk
+ * this graph breadth-first; if `eventId` is reached, the assignment would make
+ * the event expand into a timeline that contains it, which is rejected.
+ *
+ * Detection is service-layer by design — the database does not constrain it
+ * (docs/system-design.md §3.4), consistent with the other self-referential FK
+ * cycle guards.
+ */
+export async function assertNoDetailTimelineCycle(
+  client: SupabaseClient<Database>,
+  eventId: string,
+  timelineId: string,
+): Promise<void> {
+  const visited = new Set<string>();
+  const frontier: string[] = [timelineId];
+
+  while (frontier.length > 0) {
+    const tl = frontier.shift();
+    if (tl === undefined || visited.has(tl)) {
+      continue;
+    }
+    visited.add(tl);
+
+    // Events whose primary/home timeline is `tl`.
+    const { data: homeEvents, error: homeError } = await client
+      .from("events")
+      .select("id, detail_timeline_id")
+      .eq("timeline_id", tl);
+    assertNoError(homeError, "assertNoDetailTimelineCycle(home)");
+
+    // Events linked to `tl` as guest appearances via the junction.
+    const { data: guestRows, error: guestError } = await client
+      .from("timeline_events")
+      .select("event_id")
+      .eq("timeline_id", tl);
+    assertNoError(guestError, "assertNoDetailTimelineCycle(guest)");
+
+    const guestEventIds = (guestRows ?? []).map((r) => r.event_id);
+    let guestEvents: { id: string; detail_timeline_id: string | null }[] = [];
+    if (guestEventIds.length > 0) {
+      const { data, error } = await client
+        .from("events")
+        .select("id, detail_timeline_id")
+        .in("id", guestEventIds);
+      assertNoError(error, "assertNoDetailTimelineCycle(guestEvents)");
+      guestEvents = data ?? [];
+    }
+
+    for (const ev of [...(homeEvents ?? []), ...guestEvents]) {
+      if (ev.id === eventId) {
+        throw new Error(
+          "EventService.setEventDetailTimeline: an event cannot expand into a " +
+            "timeline that contains it (fractal cycle)",
+        );
+      }
+      if (
+        ev.detail_timeline_id !== null &&
+        !visited.has(ev.detail_timeline_id)
+      ) {
+        frontier.push(ev.detail_timeline_id);
+      }
+    }
+  }
+}
+
+/**
+ * Sets (or clears, with `null`) the fractal drill-down sub-timeline an event
+ * expands into. When a non-null timeline is given, `assertNoDetailTimelineCycle`
+ * runs first to reject an assignment that would close a fractal cycle.
+ */
+export async function setEventDetailTimeline(
+  client: SupabaseClient<Database>,
+  eventId: string,
+  timelineId: string | null,
+): Promise<EventRow> {
+  if (timelineId !== null) {
+    await assertNoDetailTimelineCycle(client, eventId, timelineId);
+  }
+
+  const { data, error } = await client
+    .from("events")
+    .update({ detail_timeline_id: timelineId })
+    .eq("id", eventId)
+    .select()
+    .single();
+
+  assertNoError(error, "setEventDetailTimeline");
+  return data as EventRow;
+}
+
+/**
+ * Reverse lookup: returns the events that expand into the given timeline —
+ * i.e. the events whose `detail_timeline_id` is `timelineId`. Ordered by
+ * `sort_order_years` ascending.
+ *
+ * Returns an array because no DB uniqueness is imposed on `detail_timeline_id`
+ * (a timeline could conceivably detail more than one event, #177); the
+ * timeline-detail "Details the event" header uses the first.
+ */
+export async function getEventsDetailedBy(
+  client: SupabaseClient<Database>,
+  timelineId: string,
+): Promise<EventRow[]> {
+  const { data, error } = await client
+    .from("events")
+    .select("*")
+    .eq("detail_timeline_id", timelineId)
+    .order("sort_order_years", { ascending: true });
+
+  assertNoError(error, "getEventsDetailedBy");
+  return data ?? [];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -270,8 +270,6 @@ export async function updateEvent(
   if (
     validated.detail_timeline_id !== undefined &&
     validated.timeline_id !== undefined &&
-    validated.detail_timeline_id !== null &&
-    validated.timeline_id !== null &&
     validated.detail_timeline_id === validated.timeline_id
   ) {
     throw new Error(

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -267,11 +267,37 @@ export async function updateEvent(
 ): Promise<EventRow> {
   const validated = eventSchema.partial().parse(data);
 
+  if (
+    validated.detail_timeline_id !== undefined &&
+    validated.timeline_id !== undefined &&
+    validated.detail_timeline_id !== null &&
+    validated.timeline_id !== null &&
+    validated.detail_timeline_id === validated.timeline_id
+  ) {
+    throw new Error(
+      "EventService.updateEvent: detail_timeline_id cannot equal timeline_id (fractal cycle)",
+    );
+  }
+
   // The "expands into" drill-down can be set through a plain update, so the
   // fractal-cycle guard that setEventDetailTimeline applies must also run here
   // (an event must not expand into a timeline that transitively contains it).
-  if (validated.detail_timeline_id !== undefined) {
+  if (
+    validated.detail_timeline_id !== undefined &&
+    validated.detail_timeline_id !== null
+  ) {
     await assertNoDetailTimelineCycle(client, id, validated.detail_timeline_id);
+
+    // When `timeline_id` and `detail_timeline_id` are updated together, also
+    // ensure the detail root cannot reach the new home timeline. Otherwise the
+    // check above can miss a cycle that only appears after the update lands.
+    if (validated.timeline_id !== undefined && validated.timeline_id !== null) {
+      await assertNoTimelineReachableFromDetailRoot(
+        client,
+        validated.detail_timeline_id,
+        validated.timeline_id,
+      );
+    }
   }
 
   type EventUpdate = Database["public"]["Tables"]["events"]["Update"];
@@ -408,9 +434,11 @@ export async function assertNoDetailTimelineCycle(
 ): Promise<void> {
   const visited = new Set<string>();
   const frontier: string[] = [timelineId];
+  let cursor = 0;
 
-  while (frontier.length > 0) {
-    const tl = frontier.shift();
+  while (cursor < frontier.length) {
+    const tl = frontier[cursor];
+    cursor += 1;
     if (tl === undefined || visited.has(tl)) {
       continue;
     }
@@ -444,10 +472,74 @@ export async function assertNoDetailTimelineCycle(
     for (const ev of [...(homeEvents ?? []), ...guestEvents]) {
       if (ev.id === eventId) {
         throw new Error(
-          "EventService.setEventDetailTimeline: an event cannot expand into a " +
+          "EventService.assertNoDetailTimelineCycle: an event cannot expand into a " +
             "timeline that contains it (fractal cycle)",
         );
       }
+      if (
+        ev.detail_timeline_id !== null &&
+        !visited.has(ev.detail_timeline_id)
+      ) {
+        frontier.push(ev.detail_timeline_id);
+      }
+    }
+  }
+}
+
+/**
+ * Throws if a detail root timeline can (transitively) reach `timelineId` via
+ * `event.detail_timeline_id` links. Used by `updateEvent` when both
+ * `timeline_id` and `detail_timeline_id` are set in the same payload.
+ */
+async function assertNoTimelineReachableFromDetailRoot(
+  client: SupabaseClient<Database>,
+  detailRootTimelineId: string,
+  timelineId: string,
+): Promise<void> {
+  const visited = new Set<string>();
+  const frontier: string[] = [detailRootTimelineId];
+  let cursor = 0;
+
+  while (cursor < frontier.length) {
+    const tl = frontier[cursor];
+    cursor += 1;
+    if (tl === undefined || visited.has(tl)) {
+      continue;
+    }
+    if (tl === timelineId) {
+      throw new Error(
+        "EventService.updateEvent: detail_timeline_id cannot reach timeline_id (fractal cycle)",
+      );
+    }
+    visited.add(tl);
+
+    const { data: homeEvents, error: homeError } = await client
+      .from("events")
+      .select("detail_timeline_id")
+      .eq("timeline_id", tl);
+    assertNoError(homeError, "assertNoTimelineReachableFromDetailRoot(home)");
+
+    const { data: guestRows, error: guestError } = await client
+      .from("timeline_events")
+      .select("event_id")
+      .eq("timeline_id", tl);
+    assertNoError(guestError, "assertNoTimelineReachableFromDetailRoot(guest)");
+
+    const guestEventIds = (guestRows ?? []).map((r) => r.event_id);
+    let guestEvents: { detail_timeline_id: string | null }[] = [];
+    if (guestEventIds.length > 0) {
+      const { data, error } = await client
+        .from("events")
+        .select("detail_timeline_id")
+        .in("id", guestEventIds);
+      assertNoError(
+        error,
+        "assertNoTimelineReachableFromDetailRoot(guestEvents)",
+      );
+      guestEvents = data ?? [];
+    }
+
+    for (const ev of [...(homeEvents ?? []), ...guestEvents]) {
       if (
         ev.detail_timeline_id !== null &&
         !visited.has(ev.detail_timeline_id)

--- a/packages/services/src/schemas/event.ts
+++ b/packages/services/src/schemas/event.ts
@@ -28,6 +28,7 @@ export const eventSchema = z.object({
   importance: z.number().int().min(1).max(10).default(5),
   parent_event_id: z.string().uuid().optional(),
   timeline_id: z.string().uuid().optional(),
+  detail_timeline_id: z.string().uuid().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/packages/services/src/supabase/types.ts
+++ b/packages/services/src/supabase/types.ts
@@ -525,6 +525,7 @@ export type Database = {
           computed_start_date: string | null;
           created_at: string | null;
           detail: string | null;
+          detail_timeline_id: string | null;
           end_temporal_data: Json | null;
           event_type: string | null;
           id: string;
@@ -551,6 +552,7 @@ export type Database = {
           computed_start_date?: string | null;
           created_at?: string | null;
           detail?: string | null;
+          detail_timeline_id?: string | null;
           end_temporal_data?: Json | null;
           event_type?: string | null;
           id?: string;
@@ -577,6 +579,7 @@ export type Database = {
           computed_start_date?: string | null;
           created_at?: string | null;
           detail?: string | null;
+          detail_timeline_id?: string | null;
           end_temporal_data?: Json | null;
           event_type?: string | null;
           id?: string;
@@ -599,6 +602,13 @@ export type Database = {
           user_id?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: "events_detail_timeline_id_fkey";
+            columns: ["detail_timeline_id"];
+            isOneToOne: false;
+            referencedRelation: "timelines";
+            referencedColumns: ["id"];
+          },
           {
             foreignKeyName: "events_parent_event_id_fkey";
             columns: ["parent_event_id"];
@@ -1348,6 +1358,7 @@ export type Database = {
           computed_start_date: string | null;
           created_at: string | null;
           detail: string | null;
+          detail_timeline_id: string | null;
           end_temporal_data: Json | null;
           event_type: string | null;
           id: string;
@@ -1383,6 +1394,7 @@ export type Database = {
           computed_start_date: string | null;
           created_at: string | null;
           detail: string | null;
+          detail_timeline_id: string | null;
           end_temporal_data: Json | null;
           event_type: string | null;
           id: string;

--- a/supabase/migrations/00017_events_detail_timeline_id.sql
+++ b/supabase/migrations/00017_events_detail_timeline_id.sql
@@ -1,0 +1,31 @@
+-- ============================================================================
+-- 00017_events_detail_timeline_id.sql
+--
+-- Adds detail_timeline_id to the events table (issue #177).
+--
+-- This is the forward fractal "drill-down" link: the sub-timeline an event
+-- expands into (e.g. the "Earth forms" event opens into an "evolution of life"
+-- timeline). It is the DECOMPOSITION axis of the event<->timeline model and is
+-- distinct from CONTAINMENT (events.timeline_id = primary/home timeline, the
+-- RLS source; timeline_events junction = secondary "also appears in"). See the
+-- canonical event<->timeline model in docs/system-design.md §3.
+--
+-- ON DELETE SET NULL mirrors the existing events.timeline_id FK: deleting the
+-- sub-timeline detaches the drill-down rather than cascading into (deleting)
+-- the parent event. Access is never derived from this column — a sub-timeline's
+-- collaborators do not gain access to the parent event through the fractal link
+-- (see §9). The committed event RLS, idx_events_timeline_sort, and reporting
+-- views are all untouched: they key on the containing timeline_id only.
+--
+-- Cycle prevention (an event must not expand into a timeline that transitively
+-- contains it) is enforced in the service layer, consistent with the other
+-- self-referential FK cycle guards (§3.4); the database intentionally does not
+-- constrain it. The partial index supports the reverse lookup "which event does
+-- this timeline detail?" (timeline-detail header, #177).
+-- ============================================================================
+
+ALTER TABLE events
+  ADD COLUMN detail_timeline_id UUID REFERENCES timelines(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_events_detail_timeline
+  ON events (detail_timeline_id) WHERE detail_timeline_id IS NOT NULL;

--- a/supabase/tests/database/00017_events_detail_timeline_id_test.sql
+++ b/supabase/tests/database/00017_events_detail_timeline_id_test.sql
@@ -1,0 +1,67 @@
+-- pgTAP tests for 00017_events_detail_timeline_id.sql (issue #177 — add
+-- events.detail_timeline_id fractal drill-down link).
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(6);
+
+-- ============================================================================
+-- Column presence + type
+-- ============================================================================
+
+select has_column(
+  'public', 'events', 'detail_timeline_id',
+  'events.detail_timeline_id column exists'
+);
+
+select col_type_is(
+  'public', 'events', 'detail_timeline_id', 'uuid',
+  'events.detail_timeline_id is uuid'
+);
+
+select col_is_null(
+  'public', 'events', 'detail_timeline_id',
+  'events.detail_timeline_id is nullable'
+);
+
+-- ============================================================================
+-- FK target + ON DELETE behavior
+-- ============================================================================
+
+select ok(
+  exists (
+    select 1
+    from pg_constraint c
+    join pg_class t on t.oid = c.conrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = 'public'
+      and t.relname = 'events'
+      and c.contype = 'f'
+      and c.conname = 'events_detail_timeline_id_fkey'
+      and c.confrelid = 'public.timelines'::regclass
+  ),
+  'events.detail_timeline_id FK targets public.timelines(id)'
+);
+
+select is(
+  (
+    select c.confdeltype
+    from pg_constraint c
+    where c.conname = 'events_detail_timeline_id_fkey'
+      and c.conrelid = 'public.events'::regclass
+  ),
+  'n',
+  'events.detail_timeline_id FK uses ON DELETE SET NULL'
+);
+
+-- ============================================================================
+-- Reverse-lookup partial index exists
+-- ============================================================================
+
+select has_index(
+  'public', 'events', 'idx_events_detail_timeline',
+  'idx_events_detail_timeline exists'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Adds `events.detail_timeline_id` — the forward fractal **drill-down** link: the sub-timeline an event expands into (e.g. the "Earth forms" event opens into an "evolution of life" timeline). This is the **decomposition** axis of the event↔timeline model, distinct from **containment** (`events.timeline_id` = primary/home timeline + RLS source; `timeline_events` junction = secondary "also appears in"). Purely additive — the committed event RLS, `idx_events_timeline_sort`, and reporting views are untouched.

Resolves #177. Unblocks #180 (the `parent_event_id` deprecation depends on this forward mechanism existing).

## Changes

- **Migration `00017`** — `detail_timeline_id UUID REFERENCES timelines(id) ON DELETE SET NULL` + partial index `idx_events_detail_timeline` for the reverse lookup. `ON DELETE SET NULL` mirrors `timeline_id`: deleting the sub-timeline detaches the drill-down rather than cascading into the event.
- **Zod** — `detail_timeline_id` on the event schema.
- **Service layer** (`event-service.ts`):
  - `assertNoDetailTimelineCycle` — transitive BFS guard over the forward fractal graph (home `timeline_id` ∪ `timeline_events` guest appearances), rejecting any assignment where the target timeline already (transitively) contains the event. Service-layer by design, per system-design §3.4.
  - `setEventDetailTimeline(eventId, timelineId | null)` — sets/clears the drill-down (cycle-checked when non-null).
  - `getEventsDetailedBy(timelineId)` — reverse lookup; returns an **array** (no DB uniqueness imposed; the timeline-detail header uses the first).
  - Cycle-guard call wired into `updateEvent` so the field can't bypass the check.
- **Types** — regenerated `supabase/types.ts`.
- **Docs** — `system-design.md`: flipped the `PENDING (#177)` markers to landed (migration 00017) and named the guard function.

## Scope

Service-layer only, per design discussion — admin editor/hooks for the "Expands into" picker are deferred to #46/#47 (the event editor isn't built yet). `parent_event_id` deprecation is **out of scope** here (#180).

## Verification

- `pnpm run db:reset` (applies 00017) + `pnpm run db:gen:types`
- `format:check`, `lint`, `check-types`, `build` — all pass
- services unit tests — 638 passing (new cases: direct + transitive-via-guest cycle rejection, clear-with-null skips the BFS, reverse lookup, `updateEvent` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)