### PR TITLE
fix(media): add source discriminator + nullable storage_path (#179)

### DIFF
--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -497,7 +497,9 @@ CREATE TABLE media (
   slug VARCHAR(100) NOT NULL,
   alt_text TEXT,
   caption TEXT,
-  storage_path TEXT NOT NULL,
+  source VARCHAR(20) NOT NULL DEFAULT 'upload'
+    CHECK (source IN ('upload', 'external')),
+  storage_path TEXT,
   url TEXT NOT NULL,
   media_type VARCHAR(50) CHECK (
     media_type IN ('image', 'video', 'audio', 'document')
@@ -508,13 +510,20 @@ CREATE TABLE media (
   mime_type VARCHAR(200),
   metadata JSONB DEFAULT '{}',
   created_at TIMESTAMPTZ DEFAULT now(),
-  updated_at TIMESTAMPTZ DEFAULT now()
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  -- Uploads carry a Storage object path; external embeds must not.
+  CONSTRAINT media_source_storage_ck CHECK (
+    (source = 'upload'   AND storage_path IS NOT NULL) OR
+    (source = 'external' AND storage_path IS NULL)
+  )
 );
 
 CREATE UNIQUE INDEX media_slug_idx ON media (user_id, slug);
 ```
 
 > **Changes from prior schema:** Added `storage_path` (Supabase Storage object path, separate from the public URL), `media_type` with CHECK constraint, `file_size_bytes`, and `mime_type`. Renamed `alternativetext` to `alt_text`. Replaced the `formats` TEXT column (unclear purpose) with `metadata JSONB`.
+>
+> **Migration `00018` (issue #179):** Added the `source` discriminator (`'upload' | 'external'`), made `storage_path` nullable, and added the `media_source_storage_ck` guard. This lets a media row represent an **external URL embed** — a publicly hosted resource (`url`) with no Storage object (`storage_path IS NULL`, `source = 'external'`) — which #49's External-URL tab requires. The distinction drives **delete semantics**: deleting an `upload` row must also remove its Storage object; deleting an `external` row must not. The service layer (`packages/services/src/modules/media-service.ts`) keys off `source`, replacing the earlier `storage_path = url` sentinel.
 
 ### 3.3 Relationship Tables
 
@@ -1261,6 +1270,8 @@ const channel = supabase
 | `media`   | Yes    | Event and character media            |
 | `avatars` | Yes    | User profile avatars                 |
 | `exports` | No     | Private timeline exports (PDF, JSON) |
+
+> Not every `media` row has an object in the `media` bucket: rows with `source = 'external'` (§3.2) are URL-only embeds (`storage_path IS NULL`) pointing at an externally hosted resource. Storage operations — signed-URL generation and delete-original — apply only to `source = 'upload'` rows; external rows resolve directly to their public `url` and never touch the bucket.
 
 ---
 

--- a/packages/services/src/modules/media-service.test.ts
+++ b/packages/services/src/modules/media-service.test.ts
@@ -10,6 +10,7 @@ import {
   deleteMedia,
   getSignedUrl,
 } from "./media-service.js";
+import { mediaInsertSchema } from "../schemas/media.js";
 
 // ---------------------------------------------------------------------------
 // Mock builder helpers
@@ -117,7 +118,7 @@ function makeUploadClient(opts: {
   } as unknown as SupabaseClient<Database>;
 }
 
-// deleteMedia: call 1 = select (fetch storage_path+url), call 2 = delete
+// deleteMedia: call 1 = select (fetch source+storage_path), call 2 = delete
 function makeDeleteClient(opts: {
   fetchResult: { data: unknown; error: unknown };
   deleteResult?: { data: unknown; error: unknown };
@@ -156,6 +157,7 @@ const sampleMedia = {
   slug: "sample-image",
   alt_text: "A sample image",
   caption: null,
+  source: "upload",
   storage_path: "user-123/sample.jpg",
   url: "https://example.com/media/user-123/sample.jpg",
   media_type: "image",
@@ -171,7 +173,8 @@ const sampleMedia = {
 const externalMedia = {
   ...sampleMedia,
   id: "media-2",
-  storage_path: "https://external.com/image.jpg",
+  source: "external",
+  storage_path: null,
   url: "https://external.com/image.jpg",
 };
 
@@ -206,6 +209,14 @@ describe("getMedia", () => {
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
     expect(builder.eq).toHaveBeenCalledWith("media_type", "video");
+  });
+
+  it("applies source filter", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getMedia(client, { source: "external" });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("source", "external");
   });
 
   it("throws on query error", async () => {
@@ -303,7 +314,7 @@ describe("uploadMedia", () => {
 // ---------------------------------------------------------------------------
 
 describe("createExternalMedia", () => {
-  it("creates a media record with the external URL as storage_path", async () => {
+  it("creates an external-source record with a null storage_path", async () => {
     const client = makeUploadClient({
       insertResult: { data: externalMedia, error: null },
     });
@@ -311,6 +322,13 @@ describe("createExternalMedia", () => {
       url: "https://external.com/image.jpg",
     });
     expect(result).toEqual(externalMedia);
+
+    // The insert (second from() call) must mark the row external with no path.
+    const insertBuilder = (client.from as ReturnType<typeof vi.fn>).mock
+      .results[1]?.value as ReturnType<typeof makeBuilder>;
+    expect(insertBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "external", storage_path: null }),
+    );
   });
 
   it("uses an explicit slug when provided", async () => {
@@ -381,8 +399,8 @@ describe("deleteMedia", () => {
     const client = makeDeleteClient({
       fetchResult: {
         data: {
+          source: "upload",
           storage_path: "user-123/photo.jpg",
-          url: "https://cdn.example.com/photo.jpg",
         },
         error: null,
       },
@@ -392,12 +410,11 @@ describe("deleteMedia", () => {
     expect(bucket.remove).toHaveBeenCalledWith(["user-123/photo.jpg"]);
   });
 
-  it("skips Storage removal for external media (storage_path === url)", async () => {
+  it("skips Storage removal for external media (source = external)", async () => {
     const bucket = makeStorageBucket({});
-    const externalUrl = "https://external.com/image.jpg";
     const client = makeDeleteClient({
       fetchResult: {
-        data: { storage_path: externalUrl, url: externalUrl },
+        data: { source: "external", storage_path: null },
         error: null,
       },
       storageBucket: bucket,
@@ -422,8 +439,8 @@ describe("deleteMedia", () => {
     const client = makeDeleteClient({
       fetchResult: {
         data: {
+          source: "upload",
           storage_path: "user-123/photo.jpg",
-          url: "https://cdn.example.com/photo.jpg",
         },
         error: null,
       },
@@ -437,10 +454,7 @@ describe("deleteMedia", () => {
   it("throws when DB delete fails", async () => {
     const client = makeDeleteClient({
       fetchResult: {
-        data: {
-          storage_path: "https://ext.com/img.jpg",
-          url: "https://ext.com/img.jpg",
-        },
+        data: { source: "external", storage_path: null },
         error: null,
       },
       deleteResult: { data: null, error: { message: "delete failed" } },
@@ -460,6 +474,7 @@ describe("getSignedUrl", () => {
     // Call 1: fetch storage_path via .select().eq().single()
     const fetchBuilder = makeBuilder({
       data: {
+        source: "upload",
         storage_path: "user-123/private.jpg",
         url: "https://cdn.example.com/private.jpg",
       },
@@ -493,6 +508,7 @@ describe("getSignedUrl", () => {
   it("respects a custom expiresIn value", async () => {
     const fetchBuilder = makeBuilder({
       data: {
+        source: "upload",
         storage_path: "user-123/private.jpg",
         url: "https://cdn.example.com/private.jpg",
       },
@@ -529,6 +545,7 @@ describe("getSignedUrl", () => {
   it("throws when createSignedUrl fails", async () => {
     const fetchBuilder = makeBuilder({
       data: {
+        source: "upload",
         storage_path: "user-123/private.jpg",
         url: "https://cdn.example.com/private.jpg",
       },
@@ -556,7 +573,7 @@ describe("getSignedUrl", () => {
   it("returns the public URL directly for external media", async () => {
     const externalUrl = "https://external.com/image.jpg";
     const fetchBuilder = makeBuilder({
-      data: { storage_path: externalUrl, url: externalUrl },
+      data: { source: "external", storage_path: null, url: externalUrl },
       error: null,
     });
     const bucket = makeStorageBucket({});
@@ -574,5 +591,45 @@ describe("getSignedUrl", () => {
     const url = await getSignedUrl(client, "media-2");
     expect(url).toBe(externalUrl);
     expect(bucket.createSignedUrl).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mediaInsertSchema — guard mirrors the DB media_source_storage_ck constraint
+// ---------------------------------------------------------------------------
+
+describe("mediaInsertSchema", () => {
+  const base = { slug: "x", url: "https://example.com/x.jpg" };
+
+  it("accepts an upload with a storage_path", () => {
+    expect(
+      mediaInsertSchema.safeParse({
+        ...base,
+        source: "upload",
+        storage_path: "user-123/x.jpg",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts an external embed with no storage_path", () => {
+    expect(
+      mediaInsertSchema.safeParse({ ...base, source: "external" }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an upload missing a storage_path", () => {
+    expect(
+      mediaInsertSchema.safeParse({ ...base, source: "upload" }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an external embed carrying a storage_path", () => {
+    expect(
+      mediaInsertSchema.safeParse({
+        ...base,
+        source: "external",
+        storage_path: "user-123/x.jpg",
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/services/src/modules/media-service.ts
+++ b/packages/services/src/modules/media-service.ts
@@ -1,6 +1,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { z } from "zod";
-import { mediaSchema, mediaTypeEnum } from "../schemas/media.js";
+import {
+  mediaInsertSchema,
+  mediaSchema,
+  mediaSourceEnum,
+  mediaTypeEnum,
+} from "../schemas/media.js";
 import type { MediaInput } from "../schemas/media.js";
 import { generateSlug, resolveCollision } from "../utils/slug.js";
 import { MAX_SLUG_LENGTH } from "../schemas/slug.js";
@@ -14,6 +19,7 @@ const MEDIA_BUCKET = "media";
 export interface MediaFilters {
   userId?: string;
   mediaType?: z.infer<typeof mediaTypeEnum>;
+  source?: z.infer<typeof mediaSourceEnum>;
   page?: number;
   pageSize?: number;
 }
@@ -69,7 +75,7 @@ export async function getMedia(
   client: SupabaseClient<Database>,
   filters: MediaFilters = {},
 ): Promise<MediaRow[]> {
-  const { userId, mediaType, page, pageSize } = filters;
+  const { userId, mediaType, source, page, pageSize } = filters;
 
   const safePage = Math.max(1, Math.floor(page ?? 1));
   const safePageSize = Math.min(100, Math.max(1, Math.floor(pageSize ?? 20)));
@@ -87,6 +93,9 @@ export async function getMedia(
   }
   if (mediaType !== undefined) {
     query = query.eq("media_type", mediaType);
+  }
+  if (source !== undefined) {
+    query = query.eq("source", source);
   }
 
   const { data, error } = await query;
@@ -168,8 +177,9 @@ export async function uploadMedia(
   let attemptSlug = slug;
 
   for (let attempt = 0; attempt < MAX_SLUG_RETRIES; attempt++) {
-    const validated = mediaSchema.parse({
+    const validated = mediaInsertSchema.parse({
       slug: attemptSlug,
+      source: "upload",
       storage_path: storagePath,
       url: publicUrl,
       alt_text: input.altText,
@@ -210,7 +220,8 @@ export async function uploadMedia(
 
 /**
  * Create a media record for an externally hosted resource (no Storage upload).
- * `storage_path` is set to the URL itself since there is no hosted object.
+ * The row is marked `source = 'external'` with a NULL `storage_path` — there is
+ * no hosted object — which the DB guard (media_source_storage_ck) enforces.
  *
  * @param client - Supabase client instance
  * @param data - External media data including the public URL
@@ -253,10 +264,11 @@ export async function createExternalMedia(
   let attemptSlug = slug;
 
   for (let attempt = 0; attempt < MAX_SLUG_RETRIES; attempt++) {
-    // For external media, storage_path mirrors url — satisfies schema min(1)
-    const validated = mediaSchema.parse({
+    // External media has no Storage object: source='external', storage_path=null
+    const validated = mediaInsertSchema.parse({
       slug: attemptSlug,
-      storage_path: data.url,
+      source: "external",
+      storage_path: null,
       url: data.url,
       alt_text: data.altText,
       caption: data.caption,
@@ -320,9 +332,9 @@ export async function updateMedia(
 }
 
 /**
- * Delete a media record and, if it has a hosted storage object, remove it
- * from Supabase Storage too. External media records (where `storage_path`
- * equals the public URL) only have the DB row deleted.
+ * Delete a media record and, if it is an uploaded asset, remove its object
+ * from Supabase Storage too. External media records (`source = 'external'`,
+ * no `storage_path`) only have the DB row deleted.
  *
  * @param client - Supabase client instance
  * @param id - Media UUID
@@ -331,17 +343,17 @@ export async function deleteMedia(
   client: SupabaseClient<Database>,
   id: string,
 ): Promise<void> {
-  // Fetch the row first to get storage_path
+  // Fetch the row first to learn its source + storage_path
   const { data: row, error: fetchError } = await client
     .from("media")
-    .select("storage_path, url")
+    .select("source, storage_path")
     .eq("id", id)
     .single();
   assertNoError(fetchError, "deleteMedia.fetch");
 
-  // Remove the Storage object only when storage_path differs from url,
-  // indicating a hosted (non-external) file.
-  if (row.storage_path !== row.url) {
+  // Remove the Storage object only for uploaded media (external embeds have no
+  // hosted object — storage_path is NULL).
+  if (row.source === "upload" && row.storage_path !== null) {
     const { error: storageError } = await client.storage
       .from(MEDIA_BUCKET)
       .remove([row.storage_path]);
@@ -367,14 +379,14 @@ export async function getSignedUrl(
 ): Promise<string> {
   const { data: row, error: fetchError } = await client
     .from("media")
-    .select("storage_path, url")
+    .select("source, storage_path, url")
     .eq("id", mediaId)
     .single();
   assertNoError(fetchError, "getSignedUrl.fetch");
 
-  // External media records have storage_path === url (no hosted object).
-  // Return the public URL directly rather than attempting a signed URL.
-  if (row.storage_path === row.url) {
+  // External media has no hosted object (storage_path is NULL): return the
+  // public URL directly rather than attempting a signed URL.
+  if (row.source === "external" || row.storage_path === null) {
     return row.url;
   }
 

--- a/packages/services/src/schemas/media.ts
+++ b/packages/services/src/schemas/media.ts
@@ -3,11 +3,17 @@ import { slugSchema } from "./slug.js";
 
 export const mediaTypeEnum = z.enum(["image", "video", "audio", "document"]);
 
+/** Discriminates an uploaded asset (backed by a Storage object) from an
+ * externally-hosted URL embed (no stored object). See migration 00018 / #179. */
+export const mediaSourceEnum = z.enum(["upload", "external"]);
+
 export const mediaSchema = z.object({
   slug: slugSchema,
   alt_text: z.string().optional(),
   caption: z.string().optional(),
-  storage_path: z.string().min(1),
+  source: mediaSourceEnum,
+  // Uploads carry a Storage object path; external embeds have none (null).
+  storage_path: z.string().min(1).nullable().optional(),
   url: z.string().url(),
   media_type: mediaTypeEnum.optional(),
   width: z.number().int().positive().optional(),
@@ -16,5 +22,23 @@ export const mediaSchema = z.object({
   mime_type: z.string().max(200).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
+
+/**
+ * Insert-time schema that mirrors the DB guard (media_source_storage_ck):
+ * uploads must carry a storage_path; external embeds must not. Use this for
+ * create paths; `mediaSchema.partial()` remains available for partial updates
+ * (where the DB constraint still enforces the invariant).
+ */
+export const mediaInsertSchema = mediaSchema.refine(
+  (m) =>
+    m.source === "upload"
+      ? m.storage_path != null && m.storage_path.length > 0
+      : m.storage_path == null,
+  {
+    message:
+      "upload media requires a storage_path; external media must not have one",
+    path: ["storage_path"],
+  },
+);
 
 export type MediaInput = z.infer<typeof mediaSchema>;

--- a/packages/services/src/supabase/types.ts
+++ b/packages/services/src/supabase/types.ts
@@ -651,7 +651,8 @@ export type Database = {
           metadata: Json | null;
           mime_type: string | null;
           slug: string;
-          storage_path: string;
+          source: string;
+          storage_path: string | null;
           updated_at: string | null;
           url: string;
           user_id: string;
@@ -668,7 +669,8 @@ export type Database = {
           metadata?: Json | null;
           mime_type?: string | null;
           slug: string;
-          storage_path: string;
+          source?: string;
+          storage_path?: string | null;
           updated_at?: string | null;
           url: string;
           user_id: string;
@@ -685,7 +687,8 @@ export type Database = {
           metadata?: Json | null;
           mime_type?: string | null;
           slug?: string;
-          storage_path?: string;
+          source?: string;
+          storage_path?: string | null;
           updated_at?: string | null;
           url?: string;
           user_id?: string;

--- a/supabase/migrations/00018_media_source_discriminator.sql
+++ b/supabase/migrations/00018_media_source_discriminator.sql
@@ -1,0 +1,41 @@
+-- ============================================================================
+-- 00018_media_source_discriminator.sql
+--
+-- Adds an upload-vs-external discriminator to the media table (issue #179).
+--
+-- The original media table (00001) declared storage_path NOT NULL and offered
+-- no way to distinguish an uploaded asset (backed by a Supabase Storage object)
+-- from an externally-hosted URL embed (a url with no stored object). Issue #49
+-- requires registering external URL-based media, and the External-URL tab of
+-- the attach dialog was hard-blocked on this. The service layer
+-- (packages/services/src/modules/media-service.ts) had worked around the
+-- NOT NULL constraint with a sentinel hack (storage_path = url), inferring the
+-- kind from storage_path != url; this migration replaces that with a first-class
+-- discriminator.
+--
+-- Three changes:
+--   1. storage_path becomes nullable — external embeds have no object path.
+--   2. A `source` column ('upload' | 'external') makes the kind explicit for
+--      queries, UI labels, and delete semantics (uploaded media must also drop
+--      its Storage object; external media must not). DEFAULT 'upload' keeps the
+--      add-column backfill-safe.
+--   3. A guard CHECK ties the two together: uploads must carry a storage_path;
+--      external embeds must not.
+--
+-- The local DB is rebuilt via `pnpm run db:reset` (validation is local-only,
+-- no production data), so pre-existing sentinel rows are not a concern. RLS
+-- (read_media/write_media in 00007), the updated_at trigger, media_slug_idx,
+-- and the Storage buckets/policies (00009) are all untouched: this migration
+-- only widens the media table's shape.
+-- ============================================================================
+
+ALTER TABLE media ALTER COLUMN storage_path DROP NOT NULL;
+
+ALTER TABLE media ADD COLUMN source VARCHAR(20) NOT NULL DEFAULT 'upload'
+  CHECK (source IN ('upload', 'external'));
+
+-- Integrity guard: uploads must have a storage_path; external embeds must not.
+ALTER TABLE media ADD CONSTRAINT media_source_storage_ck CHECK (
+  (source = 'upload'   AND storage_path IS NOT NULL) OR
+  (source = 'external' AND storage_path IS NULL)
+);

--- a/supabase/tests/database/00018_media_source_discriminator_test.sql
+++ b/supabase/tests/database/00018_media_source_discriminator_test.sql
@@ -1,0 +1,96 @@
+-- pgTAP tests for 00018_media_source_discriminator.sql (issue #179 — add the
+-- media.source upload/external discriminator, make storage_path nullable, and
+-- guard the two with a CHECK constraint).
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(10);
+
+-- ============================================================================
+-- Column presence, type, nullability, default
+-- ============================================================================
+select has_column(
+  'public', 'media', 'source',
+  'media.source column exists'
+);
+
+select col_type_is(
+  'public', 'media', 'source', 'character varying(20)',
+  'media.source is varchar(20)'
+);
+
+select col_not_null(
+  'public', 'media', 'source',
+  'media.source is NOT NULL'
+);
+
+select col_default_is(
+  'public', 'media', 'source', 'upload',
+  'media.source defaults to upload'
+);
+
+select col_is_null(
+  'public', 'media', 'storage_path',
+  'media.storage_path is now nullable'
+);
+
+-- ============================================================================
+-- Test fixtures
+-- ============================================================================
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('bb000000-0000-0000-0000-000000000001'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'media-source@local', '', now(), now(), now(),
+          'authenticated', 'authenticated');
+
+-- ============================================================================
+-- Happy paths: upload with a storage_path; external with NULL storage_path
+-- ============================================================================
+select lives_ok(
+  $$insert into media (user_id, slug, source, storage_path, url, media_type)
+    values ('bb000000-0000-0000-0000-000000000001', 'ms-upload',
+            'upload', 'bb000000-0000-0000-0000-000000000001/file.jpg',
+            'http://x/file.jpg', 'image')$$,
+  'upload media with a storage_path is accepted'
+);
+
+select lives_ok(
+  $$insert into media (user_id, slug, source, storage_path, url, media_type)
+    values ('bb000000-0000-0000-0000-000000000001', 'ms-external',
+            'external', null, 'https://archive.org/img.jpg', 'image')$$,
+  'external media with NULL storage_path is accepted'
+);
+
+-- ============================================================================
+-- Guard CHECK: upload without a storage_path, external with one, both rejected
+-- ============================================================================
+select throws_ok(
+  $$insert into media (user_id, slug, source, storage_path, url, media_type)
+    values ('bb000000-0000-0000-0000-000000000001', 'ms-bad-upload',
+            'upload', null, 'http://x/y.jpg', 'image')$$,
+  '23514', null,
+  'media_source_storage_ck rejects upload with NULL storage_path'
+);
+
+select throws_ok(
+  $$insert into media (user_id, slug, source, storage_path, url, media_type)
+    values ('bb000000-0000-0000-0000-000000000001', 'ms-bad-external',
+            'external', '/some/path', 'https://x/y.jpg', 'image')$$,
+  '23514', null,
+  'media_source_storage_ck rejects external with non-NULL storage_path'
+);
+
+-- ============================================================================
+-- Enum CHECK: an unknown source value is rejected
+-- ============================================================================
+select throws_ok(
+  $$insert into media (user_id, slug, source, storage_path, url, media_type)
+    values ('bb000000-0000-0000-0000-000000000001', 'ms-bogus',
+            'bogus', '/some/path', 'http://x/z.jpg', 'image')$$,
+  '23514', null,
+  'source CHECK rejects values outside (upload, external)'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Closes #179. The `media` table declared `storage_path TEXT NOT NULL` with no way to distinguish an uploaded asset from an externally-hosted URL embed (a `url` with no Storage object). This blocked #49's External-URL tab, and the services layer had been working around it with a `storage_path = url` **sentinel hack** (inferring kind from `storage_path != url`).

This PR replaces the sentinel with a first-class discriminator:

- **Migration `00018`** — `storage_path` becomes nullable; new `source VARCHAR(20) NOT NULL DEFAULT 'upload' CHECK (source IN ('upload','external'))`; guard `media_source_storage_ck` (`upload ⇒ storage_path NOT NULL`, `external ⇒ storage_path NULL`). RLS, triggers, indexes, and Storage buckets untouched.
- **Service** (`media-service.ts`) — `uploadMedia` sets `source='upload'`; `createExternalMedia` sets `source='external'` / `storage_path=null`; `deleteMedia` and `getSignedUrl` branch on `source` (uploaded media removes its Storage object, external never touches the bucket); optional `source` filter added to `getMedia`.
- **Zod** (`schemas/media.ts`) — `mediaSourceEnum`, nullable `storage_path`, and a new `mediaInsertSchema` refine mirroring the DB guard so create paths fail fast. `mediaSchema` stays a plain object so `.partial()` still works for updates.
- **Types** regenerated (`source: string`, `storage_path: string | null`).
- **Docs** — `system-design.md` §3.2 (media table + change note) and §5.7 (Storage) document the upload-vs-external distinction and its delete semantics.

This lifts the #49 external-embed block at the schema + service layer; the remaining #49 work is the admin External-URL tab UI.

## Test plan

All local validation passes:

- [x] `pnpm run db:reset` — migration 00018 applies cleanly
- [x] `pnpm run db:test` — **366/366** pgTAP tests pass (new `00018` test: 10 assertions covering column/type/default/nullability, both happy paths, all three CHECK violations)
- [x] `pnpm run db:gen:types` — `media` block regenerated, diff scoped to `source`/`storage_path`
- [x] `pnpm run check-types`
- [x] `pnpm run lint` (zero warnings)
- [x] services unit tests — **649/649** pass (updated delete/signed-url/external fixtures + new `mediaInsertSchema` guard cases)
- [x] `pnpm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)