### PR TITLE
feat(admin): Timeline create/edit form with temporal inputs and validation (#43)

### DIFF
--- a/apps/admin/app/(protected)/timelines/[slug]/edit/page.tsx
+++ b/apps/admin/app/(protected)/timelines/[slug]/edit/page.tsx
@@ -1,20 +1,23 @@
-import { PlaceholderPage } from "../../../../../components/placeholder-page";
+import { redirect } from "next/navigation";
+import { getUser } from "../../../../../lib/auth";
+import { getServerSupabaseClient } from "../../../../auth/_lib/server-supabase";
+import { TimelineFormClient } from "../../_components/timeline-form-client";
 
-interface TimelineDetailPageProps {
+interface EditTimelinePageProps {
   params: Promise<{ slug: string }>;
 }
 
-export default async function TimelineDetailPage({
+export default async function EditTimelinePage({
   params,
-}: TimelineDetailPageProps) {
+}: EditTimelinePageProps) {
   const { slug } = await params;
 
-  return (
-    <PlaceholderPage
-      title={`Edit timeline: ${slug}`}
-      description="Timeline editor surface scaffolded for dashboard deep-link flows."
-      trackedIn="a later batch (TBD)"
-      rows={3}
-    />
-  );
+  // Resolve the owner id server-side (session already validated by the
+  // protected layout) so the client hook can build its (userId, slug) query
+  // key on first render without an auth round-trip / loading flash.
+  const client = await getServerSupabaseClient();
+  const user = await getUser(client);
+  if (!user) redirect("/auth/login");
+
+  return <TimelineFormClient mode="edit" userId={user.id} slug={slug} />;
 }

--- a/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
+++ b/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
@@ -22,6 +22,7 @@ import {
   compareTemporal,
 } from "@repo/services/schemas/temporal";
 import type { TemporalData } from "@repo/services/schemas/temporal";
+import { generateSlug } from "@repo/services/utils/slug";
 
 import {
   useTimelineBySlug,
@@ -174,6 +175,12 @@ const BLANK_VALUES: TimelineFormValues = {
   metadata: undefined,
 };
 
+/** Coerce stored JSON to TemporalData, treating invalid/empty (`{}`) as null. */
+export function toTemporalOrNull(json: unknown): TemporalData | null {
+  const result = temporalDataSchema.safeParse(json);
+  return result.success ? result.data : null;
+}
+
 export function mapRowToFormValues(
   row: TimelineWithRelations,
 ): TimelineFormValues {
@@ -183,8 +190,13 @@ export function mapRowToFormValues(
     summary: row.summary ?? "",
     detail: row.detail ?? "",
     scale: row.scale ?? "",
-    temporal_data: (row.temporal_data as TemporalData | null) ?? null,
-    end_temporal_data: (row.end_temporal_data as TemporalData | null) ?? null,
+    // `temporal_data`/`end_temporal_data` default to `'{}'::jsonb` in the DB
+    // (migration 00001), so an absent end date reads back as `{}` rather than
+    // null. Validate the JSON and treat anything that isn't a real TemporalData
+    // as null, so the editor doesn't render a garbage "undefined …" value
+    // (#215 tracks fixing the underlying DB default / nullable contract).
+    temporal_data: toTemporalOrNull(row.temporal_data),
+    end_temporal_data: toTemporalOrNull(row.end_temporal_data),
     timeline_type: (row.timeline_type as TimelineType | null) ?? "general",
     subject_character_id: row.subject_character_id ?? undefined,
     visibility: (row.visibility as Visibility | null) ?? "private",
@@ -201,6 +213,11 @@ function toPersistedFields(values: TimelineFormValues) {
     detail: values.detail || undefined,
     scale: values.scale || undefined,
     temporal_data: values.temporal_data as TemporalData,
+    // LIMITATION (#215): `timelineSchema.end_temporal_data` is `.optional()`,
+    // not `.nullable()`, and the column defaults to `'{}'::jsonb`. A cleared end
+    // date maps to `undefined` and is dropped from the PATCH, so it can't be
+    // unset on an existing row until the schema accepts null and the DB default
+    // becomes NULL. Send `null` here once #215 lands.
     end_temporal_data: values.end_temporal_data ?? undefined,
     timeline_type: values.timeline_type,
     subject_character_id: values.subject_character_id || undefined,
@@ -455,6 +472,18 @@ export function TimelineFormClient(props: Props) {
 
   const submit = React.useCallback(
     (opts?: { addAnother?: boolean }) => {
+      // SlugField generates the slug from the title on a debounce, so a quick
+      // title→Save can fire before it lands and trip the schema's min-length
+      // slug rule. Flush it synchronously here (mirroring the service's own
+      // title→slug fallback) so a quick-save never hard-fails on that timing.
+      const { slug, title } = form.getValues();
+      if (slug.trim().length === 0 && title.trim().length > 0) {
+        try {
+          form.setValue("slug", generateSlug(title), { shouldValidate: false });
+        } catch {
+          // Non-sluggable title (e.g. emoji-only) — let validation surface it.
+        }
+      }
       addAnotherRef.current = opts?.addAnother ?? false;
       void form.handleSubmit(onValid)();
     },

--- a/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
+++ b/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
@@ -1,0 +1,950 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useForm, useWatch, Controller, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import {
+  timelineSchema,
+  timelineTypeEnum,
+  timelineVisibilityEnum,
+} from "@repo/services/schemas/timeline";
+import type { TimelineInput } from "@repo/services/schemas/timeline";
+import type {
+  CreateTimelineInput,
+  TimelineWithRelations,
+} from "@repo/services/timeline-service";
+import {
+  temporalDataSchema,
+  compareTemporal,
+} from "@repo/services/schemas/temporal";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+
+import {
+  useTimelineBySlug,
+  useCreateTimeline,
+  useUpdateTimeline,
+} from "@repo/ui/hooks/use-timelines";
+import { useCharacters } from "@repo/ui/hooks/use-characters";
+import { useUiStore } from "@repo/ui/stores";
+
+import { Alert, AlertDescription, AlertTitle } from "@repo/ui/components/alert";
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/form";
+import { Label } from "@repo/ui/components/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import { RadioGroup, RadioGroupItem } from "@repo/ui/components/radio-group";
+import { Separator } from "@repo/ui/components/separator";
+import { SaveDropdown } from "@repo/ui/components/save-dropdown";
+import { SlugField } from "@repo/ui/components/slug-field";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { TemporalInput } from "@repo/ui/components/temporal-input";
+import { Textarea } from "@repo/ui/components/textarea";
+import { cn } from "@repo/ui/lib/utils";
+
+import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import { useUnsavedChangesGuard } from "./use-unsaved-changes-guard";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type TimelineType = z.infer<typeof timelineTypeEnum>;
+type Visibility = z.infer<typeof timelineVisibilityEnum>;
+
+/**
+ * The form's working value type. Uses the schema's snake_case field names so
+ * `zodResolver` validates directly. Temporal fields are nullable here (the
+ * empty state) even though the persisted schema requires a start — the
+ * required check lives in `timelineFormSchema` below for a clean message.
+ *
+ * Publication (`published`/`published_at`) is intentionally NOT editable here.
+ * A timeline isn't publishable until it has linked events, and event-linking
+ * plus the publish control both live on the detail page (#44). The editor only
+ * ever writes draft content; new timelines are always created as drafts and
+ * editing never changes an existing row's live state.
+ */
+export interface TimelineFormValues {
+  title: string;
+  slug: string;
+  summary: string;
+  detail: string;
+  scale: string;
+  temporal_data: TemporalData | null;
+  end_temporal_data: TemporalData | null;
+  timeline_type: TimelineType;
+  subject_character_id: string | undefined;
+  visibility: Visibility;
+  fractal_depth: number;
+  metadata: Record<string, unknown> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Validation — wrap the canonical schema (do not mutate it)
+// ---------------------------------------------------------------------------
+
+/**
+ * Form-only schema: reuses `timelineSchema` for every field, but
+ *  - makes the temporal fields nullable (the empty UI state), then requires a
+ *    start via superRefine with a friendly message;
+ *  - enforces the two cross-field rules from issue #43:
+ *    biographical-requires-subject and end-not-before-start.
+ * These refinements are validation-only and never reach the service.
+ */
+const timelineFormSchema = timelineSchema
+  .extend({
+    temporal_data: temporalDataSchema.nullable(),
+    end_temporal_data: temporalDataSchema.nullable().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.temporal_data === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["temporal_data"],
+        message: "A start date is required.",
+      });
+    }
+    if (data.timeline_type === "biographical" && !data.subject_character_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["subject_character_id"],
+        message: "Biographical timelines require a subject character.",
+      });
+    }
+    if (
+      data.temporal_data &&
+      data.end_temporal_data &&
+      compareTemporal(data.end_temporal_data, data.temporal_data) < 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["end_temporal_data"],
+        message: "End must be the same as or later than the start.",
+      });
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Pure mappers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+const BLANK_VALUES: TimelineFormValues = {
+  title: "",
+  slug: "",
+  summary: "",
+  detail: "",
+  scale: "",
+  temporal_data: null,
+  end_temporal_data: null,
+  timeline_type: "general",
+  subject_character_id: undefined,
+  visibility: "private",
+  fractal_depth: 5,
+  metadata: undefined,
+};
+
+export function mapRowToFormValues(
+  row: TimelineWithRelations,
+): TimelineFormValues {
+  return {
+    title: row.title,
+    slug: row.slug,
+    summary: row.summary ?? "",
+    detail: row.detail ?? "",
+    scale: row.scale ?? "",
+    temporal_data: (row.temporal_data as TemporalData | null) ?? null,
+    end_temporal_data: (row.end_temporal_data as TemporalData | null) ?? null,
+    timeline_type: (row.timeline_type as TimelineType | null) ?? "general",
+    subject_character_id: row.subject_character_id ?? undefined,
+    visibility: (row.visibility as Visibility | null) ?? "private",
+    fractal_depth: row.fractal_depth ?? 5,
+    metadata: (row.metadata as Record<string, unknown> | null) ?? undefined,
+  };
+}
+
+/** Drops empty-string optionals so we never persist "" for nullable text. */
+function toPersistedFields(values: TimelineFormValues) {
+  return {
+    title: values.title,
+    summary: values.summary || undefined,
+    detail: values.detail || undefined,
+    scale: values.scale || undefined,
+    temporal_data: values.temporal_data as TemporalData,
+    end_temporal_data: values.end_temporal_data ?? undefined,
+    timeline_type: values.timeline_type,
+    subject_character_id: values.subject_character_id || undefined,
+    visibility: values.visibility,
+    fractal_depth: values.fractal_depth,
+    metadata: values.metadata,
+  };
+}
+
+export function toCreateInput(values: TimelineFormValues): CreateTimelineInput {
+  return {
+    ...toPersistedFields(values),
+    slug: values.slug || undefined,
+  };
+}
+
+export function toUpdateData(
+  values: TimelineFormValues,
+): Partial<TimelineInput> {
+  // LIMITATION (#209): `timelineSchema.subject_character_id` is `.optional()`,
+  // not `.nullable()`, so an emptied subject maps to `undefined` here and is
+  // dropped from the PATCH rather than written as NULL. The form clears the
+  // field on a biographical→other type switch (the UI AC), but persisting that
+  // clear on an existing row needs the schema to accept null. Once #209 makes
+  // the field nullable, send `null` here when the subject is empty in edit mode.
+  return {
+    ...toPersistedFields(values),
+    slug: values.slug,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------------------
+
+const LABEL_CLASS = "mb-1.5 block text-sm font-medium text-foreground";
+const INPUT_CLASS =
+  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-4">
+      <h2 className="mb-1.5 font-display text-sm font-normal text-foreground">
+        {children}
+      </h2>
+      <Separator />
+    </div>
+  );
+}
+
+const VISIBILITY_HINTS: Record<Visibility, string> = {
+  private: "Only you can see this.",
+  public: "Anyone with the link.",
+  shared: "Named collaborators only.",
+};
+
+// ---------------------------------------------------------------------------
+// Subject character picker
+// ---------------------------------------------------------------------------
+
+type ServiceClient = Parameters<typeof useCharacters>[0];
+
+function SubjectCharacterPicker({
+  client,
+  value,
+  onChange,
+  error,
+}: {
+  client: ServiceClient;
+  value: string | undefined;
+  onChange: (id: string | undefined) => void;
+  error?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const { data: characters, isPending } = useCharacters(client, {});
+
+  const selected = characters?.find((c) => c.id === value);
+  const selectedLabel = selected?.name ?? (value ? "Selected character" : "");
+
+  return (
+    <div>
+      <Label className={LABEL_CLASS}>
+        Subject character{" "}
+        <span aria-label="required" className="text-destructive">
+          *
+        </span>
+      </Label>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="secondary"
+            role="combobox"
+            aria-expanded={open}
+            className={cn(
+              "w-full justify-between font-normal",
+              !value && "text-muted-foreground",
+            )}
+          >
+            {selectedLabel || "Search for a character…"}
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+          <Command>
+            <CommandInput placeholder="Search characters…" />
+            <CommandList>
+              <CommandEmpty>
+                {isPending ? "Loading…" : "No characters found."}
+              </CommandEmpty>
+              <CommandGroup>
+                {characters?.map((character) => (
+                  <CommandItem
+                    key={character.id}
+                    value={character.name}
+                    onSelect={() => {
+                      onChange(
+                        character.id === value ? undefined : character.id,
+                      );
+                      setOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        value === character.id ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {character.name}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      <p className="mt-1 text-xs text-foreground-muted">
+        Biographical timelines are about one character.
+      </p>
+      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+type Props =
+  | { mode: "create" }
+  | { mode: "edit"; userId: string; slug: string };
+
+export function TimelineFormClient(props: Props) {
+  const router = useRouter();
+  const addToast = useUiStore((s) => s.addToast);
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+
+  const createTimeline = useCreateTimeline(client);
+  const updateTimeline = useUpdateTimeline(client);
+
+  // Edit mode: fetch the existing row (userId resolved server-side).
+  const isEdit = props.mode === "edit";
+  const editQuery = useTimelineBySlug(
+    client,
+    isEdit ? props.userId : "",
+    isEdit ? props.slug : "",
+    { enabled: isEdit },
+  );
+
+  const form = useForm<TimelineFormValues>({
+    resolver: zodResolver(timelineFormSchema) as Resolver<TimelineFormValues>,
+    defaultValues: BLANK_VALUES,
+    mode: "onTouched",
+  });
+
+  // Hydrate the form once from the fetched row (guard against re-hydration on
+  // background refetch wiping user edits).
+  const hydratedRef = React.useRef(false);
+  const editRow = editQuery.data;
+  React.useEffect(() => {
+    if (!isEdit || hydratedRef.current || editRow === undefined) return;
+    form.reset(mapRowToFormValues(editRow));
+    hydratedRef.current = true;
+  }, [isEdit, editRow, form]);
+
+  const isDirty = form.formState.isDirty;
+  const guard = useUnsavedChangesGuard(isDirty);
+
+  // Confirm dialog state for switching timeline_type away from biographical.
+  const [pendingType, setPendingType] = React.useState<TimelineType | null>(
+    null,
+  );
+
+  const addAnotherRef = React.useRef(false);
+
+  // -------------------------------------------------------------------------
+  // Save flow
+  //
+  // The editor only writes draft content. Publication lives on the timeline
+  // detail page (#44), gated on having at least one linked event — neither is
+  // available or meaningful here, so there is no publish path in this form.
+  // -------------------------------------------------------------------------
+
+  const finalize = React.useCallback(
+    (slug: string, addAnother: boolean) => {
+      // Mark the form clean so the unsaved-changes guard won't fire on redirect.
+      if (addAnother) {
+        form.reset(BLANK_VALUES);
+        return;
+      }
+      // TODO(#44): redirect to the protected timeline detail page once it
+      // exists. Until then `/timelines/[slug]` resolves to the public reader.
+      router.push(`/timelines/${slug}`);
+    },
+    [form, router],
+  );
+
+  const onValid = React.useCallback(
+    async (values: TimelineFormValues) => {
+      const addAnother = addAnotherRef.current;
+      addAnotherRef.current = false;
+
+      try {
+        let savedSlug: string;
+
+        if (isEdit) {
+          const row = await updateTimeline.mutateAsync({
+            id: editRow!.id,
+            data: toUpdateData(values),
+          });
+          savedSlug = row.slug;
+        } else {
+          const row = await createTimeline.mutateAsync(toCreateInput(values));
+          savedSlug = row.slug;
+        }
+
+        // Reset to the saved values so isDirty clears before any redirect.
+        form.reset(values);
+        addToast({
+          id: `timeline-saved-${Date.now()}`,
+          message: isEdit ? "Timeline updated." : "Timeline created.",
+          variant: "success",
+        });
+
+        finalize(savedSlug, addAnother);
+      } catch {
+        // Mutation errors surface via the form-level Alert below.
+      }
+    },
+    [isEdit, editRow, updateTimeline, createTimeline, form, addToast, finalize],
+  );
+
+  const submit = React.useCallback(
+    (opts?: { addAnother?: boolean }) => {
+      addAnotherRef.current = opts?.addAnother ?? false;
+      void form.handleSubmit(onValid)();
+    },
+    [form, onValid],
+  );
+
+  // -------------------------------------------------------------------------
+  // timeline_type change (clear subject when leaving biographical)
+  // -------------------------------------------------------------------------
+
+  const handleTypeChange = React.useCallback(
+    (next: TimelineType) => {
+      const current = form.getValues("timeline_type");
+      const hasSubject = Boolean(form.getValues("subject_character_id"));
+      if (current === "biographical" && next !== "biographical" && hasSubject) {
+        setPendingType(next);
+        return;
+      }
+      form.setValue("timeline_type", next, { shouldDirty: true });
+    },
+    [form],
+  );
+
+  const confirmTypeChange = React.useCallback(() => {
+    if (pendingType === null) return;
+    form.setValue("subject_character_id", undefined, { shouldDirty: true });
+    form.setValue("timeline_type", pendingType, { shouldDirty: true });
+    setPendingType(null);
+  }, [pendingType, form]);
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  const watchedTitle = useWatch({ control: form.control, name: "title" });
+  const watchedType = useWatch({
+    control: form.control,
+    name: "timeline_type",
+  });
+  const slugMode = isEdit ? "edit" : "create";
+  const isSaving = createTimeline.isPending || updateTimeline.isPending;
+
+  const mutationError = createTimeline.error ?? updateTimeline.error ?? null;
+  const hasFieldErrors = Object.keys(form.formState.errors).length > 0;
+
+  if (isEdit && editQuery.isPending) {
+    return (
+      <div className="space-y-4 p-6">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (isEdit && editQuery.isError) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive" role="alert">
+          <AlertTitle>Couldn’t load this timeline</AlertTitle>
+          <AlertDescription>
+            {editQuery.error instanceof Error
+              ? editQuery.error.message
+              : "Unknown error."}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const breadcrumbs = isEdit
+    ? [
+        { label: "Timelines", href: "/timelines" },
+        { label: watchedTitle || "Edit timeline" },
+      ]
+    : [{ label: "Timelines", href: "/timelines" }, { label: "New timeline" }];
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex h-full flex-col overflow-hidden"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        {/* ── Toolbar ──────────────────────────────────────────────────── */}
+        <div className="flex shrink-0 items-center justify-between border-b border-border px-6 py-3">
+          <nav className="flex items-center gap-1 text-sm text-foreground-muted">
+            {breadcrumbs.map((crumb, i) => (
+              <React.Fragment key={crumb.label}>
+                {i > 0 && (
+                  <span aria-hidden className="mx-1">
+                    ▸
+                  </span>
+                )}
+                {crumb.href ? (
+                  <button
+                    type="button"
+                    className="hover:text-foreground"
+                    onClick={() => guard.requestNavigate(crumb.href!)}
+                  >
+                    {crumb.label}
+                  </button>
+                ) : (
+                  <span className="text-foreground">{crumb.label}</span>
+                )}
+              </React.Fragment>
+            ))}
+          </nav>
+
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => guard.requestNavigate("/timelines")}
+            >
+              Cancel
+            </Button>
+            <SaveDropdown
+              onSave={() => submit()}
+              disabled={isSaving}
+              onSaveAndAddAnother={
+                isEdit ? undefined : () => submit({ addAnother: true })
+              }
+            />
+          </div>
+        </div>
+
+        {/* ── Body ─────────────────────────────────────────────────────── */}
+        <div className="flex flex-1 overflow-auto">
+          {/* Left column — main form */}
+          <div className="flex-1 space-y-8 overflow-auto px-6 py-6">
+            {(hasFieldErrors || mutationError) && (
+              <Alert variant="destructive" role="alert">
+                <AlertTitle>
+                  {mutationError
+                    ? "Couldn’t save this timeline"
+                    : "Please fix the highlighted fields"}
+                </AlertTitle>
+                <AlertDescription>
+                  {mutationError instanceof Error
+                    ? mutationError.message
+                    : "Some fields need your attention before saving."}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {/* Identity */}
+            <section>
+              <SectionHeading>Identity</SectionHeading>
+              <div className="space-y-5">
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>
+                        Title{" "}
+                        <span
+                          aria-label="required"
+                          className="text-destructive"
+                        >
+                          *
+                        </span>
+                      </FormLabel>
+                      <FormControl>
+                        <input
+                          {...field}
+                          className={INPUT_CLASS}
+                          placeholder="Timeline title"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <div>
+                  <Label htmlFor="timeline-type" className={LABEL_CLASS}>
+                    Type{" "}
+                    <span aria-label="required" className="text-destructive">
+                      *
+                    </span>
+                  </Label>
+                  <select
+                    id="timeline-type"
+                    className={INPUT_CLASS}
+                    value={watchedType}
+                    onChange={(e) =>
+                      handleTypeChange(e.target.value as TimelineType)
+                    }
+                  >
+                    {timelineTypeEnum.options.map((value) => (
+                      <option key={value} value={value}>
+                        {value.charAt(0).toUpperCase() + value.slice(1)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {watchedType === "biographical" && (
+                  <Controller
+                    control={form.control}
+                    name="subject_character_id"
+                    render={({ field, fieldState }) => (
+                      <SubjectCharacterPicker
+                        client={client}
+                        value={field.value}
+                        onChange={field.onChange}
+                        error={fieldState.error?.message}
+                      />
+                    )}
+                  />
+                )}
+
+                <FormField
+                  control={form.control}
+                  name="summary"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>Summary</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          placeholder="One-paragraph summary…"
+                          className="min-h-[80px]"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="detail"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>Detail</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          placeholder="Long-form description…"
+                          className="min-h-[140px]"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </section>
+
+            {/* Span */}
+            <section>
+              <SectionHeading>Span</SectionHeading>
+              <div className="space-y-4">
+                <Controller
+                  control={form.control}
+                  name="temporal_data"
+                  render={({ field, fieldState }) => (
+                    <TemporalInput
+                      label="Start"
+                      required
+                      value={field.value}
+                      onChange={field.onChange}
+                      error={fieldState.error?.message}
+                    />
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name="end_temporal_data"
+                  render={({ field, fieldState }) => (
+                    <TemporalInput
+                      label="End"
+                      value={field.value}
+                      onChange={field.onChange}
+                      error={fieldState.error?.message}
+                    />
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="scale"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>Scale</FormLabel>
+                      <FormControl>
+                        <input
+                          {...field}
+                          className={INPUT_CLASS}
+                          placeholder="e.g. a single lifetime, an epoch…"
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Free-text label describing the temporal grain.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </section>
+
+            {/* Advanced */}
+            <section>
+              <details>
+                <summary className="cursor-pointer select-none text-sm text-foreground-muted hover:text-foreground">
+                  ▸ Advanced (fractal depth, metadata)
+                </summary>
+                <div className="mt-3 space-y-4 rounded-md border border-border bg-surface/30 px-4 py-3">
+                  <FormField
+                    control={form.control}
+                    name="fractal_depth"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={LABEL_CLASS}>
+                          Fractal depth
+                        </FormLabel>
+                        <FormControl>
+                          <input
+                            type="number"
+                            min={1}
+                            max={10}
+                            className={`${INPUT_CLASS} max-w-[120px]`}
+                            value={
+                              Number.isFinite(field.value) ? field.value : ""
+                            }
+                            onChange={(e) =>
+                              field.onChange(e.target.valueAsNumber)
+                            }
+                            onBlur={field.onBlur}
+                            name={field.name}
+                            ref={field.ref}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          How many zoom levels this timeline supports (default
+                          5).
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <p className="text-xs text-foreground-muted">
+                    A <code>metadata</code> JSON editor is a later, power-user
+                    enhancement.
+                  </p>
+                </div>
+              </details>
+            </section>
+          </div>
+
+          {/* Right column — metadata rail */}
+          <aside className="w-72 shrink-0 space-y-6 border-l border-border px-5 py-6">
+            <Controller
+              control={form.control}
+              name="slug"
+              render={({ field }) => (
+                <SlugField
+                  label="Slug"
+                  value={field.value}
+                  onChange={field.onChange}
+                  sourceValue={watchedTitle}
+                  mode={slugMode}
+                  warning={
+                    isEdit
+                      ? "Changing the slug will break existing links to this timeline."
+                      : undefined
+                  }
+                  description="Auto-generated from title."
+                />
+              )}
+            />
+
+            {/* Visibility (who can reach this) — distinct from publication,
+                which is managed on the timeline detail page (#44). */}
+            <Controller
+              control={form.control}
+              name="visibility"
+              render={({ field }) => (
+                <div>
+                  <Label className={LABEL_CLASS}>Visibility</Label>
+                  <RadioGroup
+                    value={field.value}
+                    onValueChange={(v) => field.onChange(v as Visibility)}
+                  >
+                    {timelineVisibilityEnum.options.map((value) => (
+                      <label
+                        key={value}
+                        htmlFor={`vis-${value}`}
+                        className="flex cursor-pointer items-start gap-2.5"
+                      >
+                        <RadioGroupItem
+                          id={`vis-${value}`}
+                          value={value}
+                          className="mt-0.5"
+                        />
+                        <span className="flex flex-col">
+                          <span className="text-sm capitalize text-foreground">
+                            {value}
+                          </span>
+                          <span className="text-xs text-foreground-muted">
+                            {VISIBILITY_HINTS[value]}
+                          </span>
+                        </span>
+                      </label>
+                    ))}
+                  </RadioGroup>
+                </div>
+              )}
+            />
+
+            <p className="border-t border-border pt-4 text-xs text-foreground-muted">
+              New timelines are saved as drafts. You can publish from the
+              timeline’s page once it has at least one event.
+            </p>
+          </aside>
+        </div>
+      </form>
+
+      {/* ── Confirm: switching away from biographical ─────────────────── */}
+      <Dialog
+        open={pendingType !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingType(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove the subject character?</DialogTitle>
+            <DialogDescription>
+              Only biographical timelines have a subject character. Switching
+              the type will clear the one you selected.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setPendingType(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={confirmTypeChange}
+            >
+              Switch &amp; clear
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Confirm: discard unsaved changes ──────────────────────────── */}
+      <Dialog
+        open={guard.isConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) guard.cancelNavigation();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Discard unsaved changes?</DialogTitle>
+            <DialogDescription>
+              You have unsaved changes. If you leave now, they’ll be lost.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={guard.cancelNavigation}
+            >
+              Keep editing
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={guard.confirmNavigation}
+            >
+              Discard
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Form>
+  );
+}

--- a/apps/admin/app/(protected)/timelines/_components/use-unsaved-changes-guard.ts
+++ b/apps/admin/app/(protected)/timelines/_components/use-unsaved-changes-guard.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Guards a dirty form against accidental navigation loss.
+ *
+ * Two surfaces are covered:
+ *  - **Hard navigation** (reload / tab close / external link): a `beforeunload`
+ *    listener triggers the browser's native confirmation while `isDirty`.
+ *  - **In-app navigation** the form controls (Cancel button, breadcrumbs):
+ *    call `requestNavigate(href)` instead of `router.push`. When dirty it
+ *    defers the push and exposes `isConfirmOpen` so the caller can render a
+ *    confirm dialog; on confirm it completes the navigation.
+ *
+ * NOTE: the App Router has no stable API to intercept arbitrary in-app
+ * navigation (e.g. clicking a sidebar link), so only the surfaces routed
+ * through `requestNavigate` are guarded in-app; `beforeunload` is the
+ * backstop for everything else.
+ */
+export function useUnsavedChangesGuard(isDirty: boolean) {
+  const router = useRouter();
+  const [pendingHref, setPendingHref] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!isDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // Required for Chrome to show the native prompt.
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+
+  const requestNavigate = React.useCallback(
+    (href: string) => {
+      if (isDirty) {
+        setPendingHref(href);
+      } else {
+        router.push(href);
+      }
+    },
+    [isDirty, router],
+  );
+
+  const confirmNavigation = React.useCallback(() => {
+    setPendingHref((href) => {
+      if (href !== null) router.push(href);
+      return null;
+    });
+  }, [router]);
+
+  const cancelNavigation = React.useCallback(() => setPendingHref(null), []);
+
+  return {
+    requestNavigate,
+    isConfirmOpen: pendingHref !== null,
+    confirmNavigation,
+    cancelNavigation,
+  };
+}

--- a/apps/admin/app/(protected)/timelines/new/page.tsx
+++ b/apps/admin/app/(protected)/timelines/new/page.tsx
@@ -1,0 +1,9 @@
+import { TimelineFormClient } from "../_components/timeline-form-client";
+
+export const metadata = {
+  title: "New timeline",
+};
+
+export default function NewTimelinePage() {
+  return <TimelineFormClient mode="create" />;
+}

--- a/packages/ui/src/components/temporal-input.tsx
+++ b/packages/ui/src/components/temporal-input.tsx
@@ -500,7 +500,12 @@ export function TemporalInput({
       <div className="flex items-center justify-between gap-3">
         <label className="text-sm font-medium text-foreground">
           {label}
-          {required ? <span className="text-foreground-muted"> *</span> : null}
+          {required ? (
+            <span aria-label="required" className="text-destructive">
+              {" "}
+              *
+            </span>
+          ) : null}
         </label>
         <div className="flex items-center gap-2">
           {value && (
@@ -516,7 +521,15 @@ export function TemporalInput({
           )}
           <Popover open={open} onOpenChange={handleOpenChange}>
             <PopoverTrigger asChild>
-              <Button type="button" variant="secondary" disabled={disabled}>
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={disabled}
+                aria-invalid={error ? true : undefined}
+                className={cn(
+                  error && "border border-destructive ring-1 ring-destructive",
+                )}
+              >
                 {previewValue ? (
                   <TemporalDisplay value={previewValue} format="compact" />
                 ) : (
@@ -779,14 +792,16 @@ export function TemporalInput({
               )}
 
               {/* Catch-all error — surfaces the first non-year/era schema
-                  issue so users can recover (e.g. "day: ... invalid for month"). */}
+                  issue in the current draft so users can recover (e.g.
+                  "day: ... invalid for month"). The parent-supplied `error`
+                  prop is shown in its own slot below the field, not here, to
+                  avoid duplicating it while the popover is open. */}
               {hasInteracted &&
                 candidate == null &&
                 !fieldErrors.year &&
                 !fieldErrors.era && (
                   <p className="text-sm text-destructive">
-                    {error ??
-                      genericError ??
+                    {genericError ??
                       "Complete the required fields to save this temporal value."}
                   </p>
                 )}
@@ -820,6 +835,10 @@ export function TemporalInput({
           {required ? "Required temporal value." : "Optional temporal value."}
         </p>
       )}
+
+      {/* Field-level error surfaced by the parent form (e.g. a cross-field rule
+          like end-before-start), shown even while the popover is closed. */}
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
     </div>
   );
 }


### PR DESCRIPTION
Closes #43.

## What

First real CRUD form in the admin app: timeline **create** (`/timelines/new`) and **edit** (`/timelines/[slug]/edit`) routes sharing one client form, ported from the fidelity-1 `timeline-editor` Storybook spec to a real react-hook-form + zod + TanStack Query implementation.

## Highlights

- **Shared form** ([timeline-form-client.tsx](apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx)) for both modes. Edit resolves the owner id **server-side** in the RSC so `useTimelineBySlug` has its `(userId, slug)` key on first render (no auth flash).
- **Validation** via `zodResolver` over a form-only wrapper of `timelineSchema` (the canonical schema is reused, not mutated): required start, **biographical-requires-subject**, and **end-not-before-start** (`compareTemporal`) cross-field rules. Field-level (`FormMessage`) + form-level (`Alert`) errors.
- **Reuses** `TemporalInput`, `SlugField`, `SaveDropdown`, the timeline/character hooks, and a cmdk **subject-character combobox**.
- **Conditional subject** picker for biographical timelines; switching type away clears it via a confirm dialog.
- **Unsaved-changes guard** ([use-unsaved-changes-guard.ts](apps/admin/app/(protected)/timelines/_components/use-unsaved-changes-guard.ts)): `beforeunload` + a Cancel/breadcrumb confirm dialog.
- **Visibility** stays distinct from publication.

## Publication: deferred to the detail page (by design)

After dogfooding, the editor's publish-on-save toggle was removed entirely. A timeline isn't publishable until it has linked events, and both event-linking and the publish control live on the timeline **detail page (#44)**. So the editor only ever writes **draft** content — new timelines are always drafts, and editing never changes an existing row's live state.

- The "no events ⇒ not publishable" **hard rule** (detail-page UI gate + `publishTimeline` service guard) is tracked in **#211**.
- The corresponding wireframe-16 spec update is tracked in **#212**.

## Shared TemporalInput fix

Fixed the shared `TemporalInput` so the required marker is **red** and the `error` prop renders **inline with a field highlight even while the popover is closed** — previously cross-field errors (like end-before-start) never surfaced on the field. Catch-all in-popover validation now shows only the internal draft error to avoid duplication. All 285 `@repo/ui` tests pass.

## Known limitation

**#209** — clearing `subject_character_id` on an existing row can't persist NULL until the service schema makes the field `.nullable()`. The form clears the field (UI behavior correct); persistence of the cleared value awaits #209.

## Validation

`pnpm format` / `check-types` / `lint` (zero-warnings) / `build` all pass; `@repo/ui` `test:coverage` green (pre-push hook enforced).

## Test plan

- [x] Create: title → slug auto-gen; manual slug override breaks link.
- [x] Required start blocks save with inline + form-level errors.
- [x] End-before-start: red-highlighted End field + inline message, blocks save.
- [x] Biographical reveals required subject; switching away confirms + clears.
- [x] Save → redirect to `/timelines/[slug]`; edit pre-populates and updates.
- [x] Cancel/breadcrumb with unsaved edits prompts; reload triggers `beforeunload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)