### PR TITLE
docs: refresh README, CLAUDE.md, and copilot-instructions to current state

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ Trust these instructions. Only search the codebase if information here is incomp
 
 **Time Traveler** is a temporal content management system for storing, visualizing, and interacting with historical events and narratives across the full span of time. Key features include fractal zoomable timelines, multi-dimensional character modeling (7 types: Human, Animal, Mythological, Fictional, Organization, Divine, Artifact), and a hybrid temporal system supporting dates from the Big Bang to the far future. The planned stack is **Next.js 16+ (App Router), React 19, TypeScript, Supabase (PostgreSQL + JSONB, Auth, Realtime, RLS), TanStack Query, Zustand, shadcn/ui, Tailwind CSS, D3.js**. Target hosting is **Vercel** (frontend) + **Supabase** (backend/database).
 
-**Current state:** `apps/admin` and `apps/docs` still contain Turborepo boilerplate pages, while the Supabase layer already has nine schema/policy/function/storage migrations plus pgTAP database tests.
+**Current state:** `apps/admin` is under active feature development — auth, the app shell, dashboard, list pages (timelines, characters, events, periods, stories, categories, media), the timeline create/edit editor, and a public reader — backed by `@repo/services` (nine service modules + Zod schemas) and `@repo/ui` (TanStack Query hooks, a Zustand store, shadcn/ui primitives). `apps/docs` is still Turborepo boilerplate. The Supabase layer has 19 numbered migrations plus pgTAP database tests.
 
 ## Repository Layout
 
@@ -18,7 +18,7 @@ This is a **pnpm monorepo** orchestrated by **Turborepo**.
 │   ├── admin/          # Next.js 16 administration app (port 3000) — package name: "admin"
 │   └── docs/           # Next.js 16 docs app (port 3001) — package name: "docs"
 ├── packages/
-│   ├── ui/             # @repo/ui — shared React components (button, card, code)
+│   ├── ui/             # @repo/ui — shared React components (shadcn/ui-based), TanStack Query hooks, Zustand store
 │   ├── services/       # @repo/services — shared Supabase clients, schemas, and service modules
 │   ├── eslint-config/  # @repo/eslint-config — shared ESLint configs (base, next, react-internal)
 │   └── typescript-config/ # @repo/typescript-config — shared tsconfig (base, nextjs, react-library)
@@ -39,16 +39,16 @@ This is a **pnpm monorepo** orchestrated by **Turborepo**.
 - `packages/ui/tsconfig.json` — extends `@repo/typescript-config/react-library.json`
 - `packages/services/eslint.config.mjs` — extends `@repo/eslint-config/base`
 - `packages/services/tsconfig.json` — extends `@repo/typescript-config/base.json`
-- `packages/ui/package.json` — exports via `"./*": "./src/*.tsx"`
+- `packages/ui/package.json` — subpath exports: components via `"./components/*"`, hooks via `"./hooks/*"`, store via `"./stores"`, styles via `"./styles/*"`
 - `packages/services/package.json` — exports via `"./*": "./src/*.ts"`
 
 ## Runtime & Tool Versions
 
 - **Node.js:** ≥24 (`.nvmrc` specifies v24; run `nvm use` if using nvm)
-- **pnpm:** 9.0.0 (specified in `package.json` `packageManager` field)
-- **Turborepo:** 2.8.20
-- **TypeScript:** 5.9.2 (all packages)
-- **Next.js:** 16.2.0 (both apps)
+- **pnpm:** 11.2.2 (specified in `package.json` `packageManager` field)
+- **Turborepo:** 2.9.16
+- **TypeScript:** 6.0.3 (all packages)
+- **Next.js:** 16.2.x (both apps)
 - **React:** 19.2.x (both apps)
 
 ## Build & Validation Commands
@@ -133,7 +133,7 @@ Or run steps 2–6 at once (minus db:test) via `pnpm verify`.
 - **TypeScript strict mode** is enabled (`strict: true`, `strictNullChecks: true`, `noUncheckedIndexedAccess: true`). All types must be explicit and correct.
 - **ESLint zero-warnings policy**: `--max-warnings 0` is enforced in every app and package. Any warning is treated as an error.
 - **ESM modules**: Both app `package.json` files have `"type": "module"`. Use ESM import/export syntax everywhere.
-- **Shared packages**: Import UI components as `@repo/ui/button`, `@repo/ui/card`, etc. (resolved via `packages/ui/src/*.tsx`). Import configs as `@repo/eslint-config/...` and `@repo/typescript-config/...`.
+- **Shared packages**: Import UI components as `@repo/ui/components/button`, `@repo/ui/components/card`, etc.; hooks via `@repo/ui/hooks/*`; the Zustand store via `@repo/ui/stores`. Import `@repo/services` schemas/modules as `@repo/services/schemas/*` and `@repo/services/<entity>-service`. Import configs as `@repo/eslint-config/...` and `@repo/typescript-config/...`.
 - **Turborepo task graph**: `build` depends on `^build` (packages build before apps). Do not run per-app builds in isolation unless you have already built the packages.
 - **GitHub Actions workflows**: CI runs Lint, Type Check, Build, and Test on every push/PR. All four jobs are required status checks on `main`.
 - **Documentation**: `docs/prd/PRD-0001-time-traveler-system.md` (product requirements) and `docs/system-design.md` (architecture, schema, API design) are the authoritative references for feature work. `docs/design/admin/` contains the fidelity-1 wireframes for the admin app (characters + events CRUD plus the relationships editor) — read these alongside PRD §7.11 when doing UI work in `apps/admin`. Divergences between the wireframes and PRD §7.11 are tracked in #127.
@@ -168,8 +168,8 @@ If implementing a task reveals a bug in the spec (`docs/system-design.md`, PRD),
 
 ## When to Write an ADR
 
-Architectural decisions are recorded as Architecture Decision Records in `docs/adr/`. The retroactive series ADR-0001 through ADR-0027 documents every load-bearing decision made to date; the index, format rules, and process live in `docs/adr/README.md`.
+Architectural decisions are recorded as Architecture Decision Records in `docs/adr/`. The series ADR-0001 through ADR-0032 documents every load-bearing decision made to date; the index, format rules, and process live in `docs/adr/README.md`.
 
 - Write a new ADR when a decision is **hard to reverse, cross-cutting, or precedent-setting** — e.g., a new platform/dependency, a schema or RLS pattern, an API boundary, a state/data-flow choice, or a design-system rule. Routine, local, easily-reversible changes do not need one.
-- **Number new ADRs from 0029 onward** (0028 records the Milestone 7 period/category model). Copy `docs/adr/adr-0000-template.md`, fill in every section, cite concrete evidence (a migration file/section or a doc section), and add a row to the `docs/adr/README.md` index.
+- **Number new ADRs from the next free number** — the series currently runs through ADR-0032, so check `docs/adr/README.md` for the latest before numbering. Copy `docs/adr/adr-0000-template.md`, fill in every section, cite concrete evidence (a migration file/section or a doc section), and add a row to the `docs/adr/README.md` index.
 - If a new decision **supersedes or amends** an existing ADR, set the `supersedes`/`superseded_by` front matter on both ADRs and update the index status accordingly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Hybrid temporal system** — JSONB-encoded dates extend beyond SQL date limits to handle prehistoric/geological/cosmological dates, with precision metadata and uncertainty ranges. See `docs/system-design.md` §4 for the era conversion formula used by all `sort_order` generated columns.
 - **Seven character types** — Human, Animal, Mythological, Fictional, Organization, Divine, Artifact — with temporally-scoped relationships and event participation.
 
-**Current state:** Database schema migrations exist (`supabase/migrations/`), but `apps/admin` and `apps/docs` are still Turborepo boilerplate — the product features are not yet implemented.
+**Current state:** The Supabase layer is mature (19 numbered migrations + pgTAP tests). `apps/admin` is under active feature development — auth, the app shell, dashboard, list pages (timelines, characters, events, periods, stories, categories, media), the timeline create/edit editor, and a public reader all exist — backed by `@repo/services` (nine service modules + Zod schemas) and `@repo/ui` (TanStack Query hooks, a Zustand store, shadcn/ui primitives). `apps/docs` is still Turborepo boilerplate.
 
 ## Repository Layout
 
@@ -18,19 +18,20 @@ pnpm monorepo orchestrated by Turborepo. Workspaces: `apps/*`, `packages/*`.
 
 - `apps/admin` — Next.js 16 admin app (port 3000). Package name is `admin`.
 - `apps/docs` — Next.js 16 docs app (port 3001). Package name is `docs`.
-- `packages/ui` — `@repo/ui` shared React components. Import as `@repo/ui/button`, `@repo/ui/card`, etc. (resolved via `packages/ui/src/*.tsx`).
-- `packages/eslint-config` — `@repo/eslint-config` (`base`, `next`, `react-internal`).
+- `packages/ui` — `@repo/ui` shared React components (shadcn/ui-based). Import components as `@repo/ui/components/button`, `@repo/ui/components/card`, etc.; TanStack Query hooks via `@repo/ui/hooks/*`; the Zustand store via `@repo/ui/stores` (subpath exports — see `packages/ui/package.json`).
+- `packages/services` — `@repo/services` Supabase clients, Zod schemas (`@repo/services/schemas/*`), and service modules (`@repo/services/<entity>-service`). Wildcard subpath exports (`./*` → `src/*.ts`).
+- `packages/eslint-config` — `@repo/eslint-config` (`base`, `next-js`, `react-internal`).
 - `packages/typescript-config` — `@repo/typescript-config` (`base.json`, `nextjs.json`, `react-library.json`).
 - `supabase/migrations` — numbered SQL migrations. Migration `00001_initial_schema.sql` defines core tables (profiles, characters, …); `00002_relationships_junctions.sql` defines `character_relationships` and 11 junction tables.
 - `docs/prd/PRD-0001-time-traveler-system.md` and `docs/system-design.md` are the authoritative references for feature/schema work.
 - `docs/design/admin/` contains the fidelity-1 wireframes for the admin app (characters + events CRUD plus the relationships editor). When doing UI work in `apps/admin`, these are the IA + interaction spec — read alongside PRD §7.11 (some divergences are tracked in #127).
-- There is no CI build pipeline — **validation is local-only**.
+- CI runs on GitHub Actions (`.github/workflows/ci.yml`): format, lint, type-check, build, and test on every push/PR; these are required checks on `main`.
 
 ## Toolchain
 
 - **Node ≥24** (`.nvmrc` pins v24)
-- **pnpm 9.0.0** (declared in `package.json` `packageManager`)
-- **Turborepo 2.8.20**, **TypeScript 5.9.2**, **Next.js 16.2.0**, **React 19.2.x**
+- **pnpm 11.2.2** (declared in `package.json` `packageManager`)
+- **Turborepo 2.9.16**, **TypeScript 6.0.3**, **Next.js 16.2.x**, **React 19.2.x**
 - **Supabase CLI** ^2.101.0 — local stack runs Postgres 17
 
 ## Commands
@@ -39,7 +40,9 @@ pnpm monorepo orchestrated by Turborepo. Workspaces: `apps/*`, `packages/*`.
 pnpm install              # bootstrap; run after dependency changes
 pnpm run build            # turbo run build across all packages/apps
 pnpm run lint             # ESLint with --max-warnings 0 (warnings fail)
-pnpm run check-types      # next typegen && tsc --noEmit in each Next app, tsc --noEmit in packages/ui
+pnpm run check-types      # next typegen && tsc --noEmit in each Next app, tsc --noEmit in packages/ui and packages/services
+pnpm run test             # turbo run test (Vitest in packages/ui + packages/services)
+pnpm run test:coverage    # Vitest with an 80% coverage threshold
 pnpm run format           # prettier --write "**/*.{ts,tsx,md}"
 pnpm run dev              # admin on :3000, docs on :3001
 ```
@@ -58,7 +61,7 @@ pnpm run db:gen:migration <n>  # scaffold a new migration
 pnpm run db:gen:types          # regenerate ./packages/services/src/supabase/types.ts
 ```
 
-**No test framework is configured.** There is no `test` script in any `package.json`. Do not invent `pnpm test`.
+**Vitest** powers unit tests in `packages/ui` and `packages/services` (`pnpm test`, `pnpm test:coverage` — the latter enforces an 80% threshold). Tests live next to source as `*.test.ts(x)`. `apps/*` have no tests yet. The husky **pre-push** hook runs `test:coverage`, so a push fails if tests fail or coverage drops.
 
 ### Validation before submitting changes
 
@@ -68,7 +71,8 @@ Run in order — all must pass:
 2. **`pnpm run format`** — run this **before** `git add`; the husky pre-commit hook runs `format:check` and will block the commit if any file is not formatted. One write-pass here prevents all hook-related thrashing.
 3. `pnpm run check-types`
 4. `pnpm run lint`
-5. `pnpm run build`
+5. `pnpm run test:coverage` (also enforced by the pre-push hook)
+6. `pnpm run build`
 
 Or run the full suite at once: `pnpm verify` (`format:check && lint && check-types && test:coverage && build`).
 
@@ -95,8 +99,8 @@ If implementing a task reveals a bug in the spec (`docs/system-design.md`, PRD),
 
 ## When to write an ADR
 
-Architectural decisions are recorded as ADRs in [`docs/adr/`](docs/adr/). The retroactive series ADR-0001…0027 documents every load-bearing decision made to date; the index and process live in [`docs/adr/README.md`](docs/adr/README.md).
+Architectural decisions are recorded as ADRs in [`docs/adr/`](docs/adr/). The series ADR-0001…0032 documents every load-bearing decision made to date; the index and process live in [`docs/adr/README.md`](docs/adr/README.md).
 
 - Write a new ADR when you make a decision that is **hard to reverse, cross-cutting, or sets a precedent** — a new dependency/platform, a schema/RLS pattern, an API boundary, a state/data-flow choice, or a design-system rule. Routine, local, easily-reversible changes do not need one.
-- **Number new ADRs from 0029 onward** (0028 records the Milestone 7 period/category model). Copy [`docs/adr/adr-0000-template.md`](docs/adr/adr-0000-template.md), fill it in, cite concrete evidence (migration file/section or doc section), and add a row to the README index.
+- **Number new ADRs from the next free number** — the series currently runs through ADR-0032, so check [`docs/adr/README.md`](docs/adr/README.md) for the latest before numbering. Copy [`docs/adr/adr-0000-template.md`](docs/adr/adr-0000-template.md), fill it in, cite concrete evidence (migration file/section or doc section), and add a row to the README index.
 - If a new decision **supersedes or amends** an existing ADR, set the `supersedes`/`superseded_by` front matter on both sides and update the index status.

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ For the product specification, see [`docs/prd/PRD-0001-time-traveler-system.md`]
 
 ## Status
 
-**Greenfield, mid-development.** The Supabase layer is largely complete: 13 numbered migrations cover schema, RLS, indexes, views, functions, storage, and follow-up data integrity fixes, with pgTAP tests for the database surface. The two Next.js apps under `apps/` are currently Turborepo boilerplate — the admin app's fidelity-1 IA + interaction wireframes are documented in [`docs/design/admin/`](docs/design/admin/) and ready for implementation.
+**Greenfield, mid-development.** The Supabase layer is largely complete: 19 numbered migrations cover schema, RLS, indexes, views, functions, storage, and follow-up data-integrity fixes, with pgTAP tests for the database surface. `apps/admin` is under active development against the fidelity-1 wireframes in [`docs/design/admin/`](docs/design/admin/) — auth, the app shell, dashboard, entity list pages, the timeline create/edit editor, and a public reader are in place. `apps/docs` is still Turborepo boilerplate.
 
 ## Stack
 
 | Layer         | Technology                                                                         |
 | ------------- | ---------------------------------------------------------------------------------- |
 | Frontend      | Next.js 16 (App Router), React 19, TypeScript 6.0                                  |
-| UI            | CSS Modules, global CSS, shared React components in `@repo/ui`                     |
-| Server state  | Planned: TanStack Query                                                            |
-| Client state  | Planned: Zustand                                                                   |
+| UI            | Tailwind CSS + shadcn/ui primitives in `@repo/ui`                                  |
+| Server state  | TanStack Query (`@repo/ui/hooks`)                                                  |
+| Client state  | Zustand (`@repo/ui/stores`)                                                        |
 | Backend / API | Supabase PostgREST (auto-generated REST), `@supabase/supabase-js`, `@supabase/ssr` |
 | Database      | Supabase PostgreSQL 17 with JSONB temporal storage and RLS                         |
 | Auth          | Supabase Auth (email, magic link, OAuth)                                           |
@@ -43,7 +43,7 @@ For the product specification, see [`docs/prd/PRD-0001-time-traveler-system.md`]
 | Storage       | Supabase Storage                                                                   |
 | Hosting       | Vercel (frontend) + Supabase Cloud (backend / database)                            |
 
-Toolchain: **Node ≥24** (pinned via `.nvmrc`), **pnpm 11.2.2**, **Turborepo 2.9.14**, **TypeScript 6.0.3**, **Supabase CLI ^2.101**.
+Toolchain: **Node ≥24** (pinned via `.nvmrc`), **pnpm 11.2.2**, **Turborepo 2.9.16**, **TypeScript 6.0.3**, **Supabase CLI ^2.101**.
 
 ## Repository layout
 
@@ -57,7 +57,7 @@ packages/
   eslint-config/               # @repo/eslint-config — shared ESLint configs
   typescript-config/           # @repo/typescript-config — shared tsconfig presets
 supabase/
-  migrations/                  # numbered SQL migrations (00001 → 00013)
+  migrations/                  # numbered SQL migrations (00001 → 00019)
   tests/database/              # pgTAP database tests
 docs/
   prd/                         # product requirements (authoritative)
@@ -89,7 +89,7 @@ pnpm run db:start      # boot local Supabase stack (Postgres 17 + Auth + Storage
 
 ### Validate before submitting changes
 
-Run all four; each must pass:
+Run all five; each must pass:
 
 ```bash
 pnpm run format:check     # Prettier format check
@@ -105,7 +105,7 @@ For database schema changes also run:
 pnpm run db:test          # pgTAP database tests
 ```
 
-The same four validations run in GitHub Actions on every push and pull request (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
+These validations run in GitHub Actions on every push and pull request (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
 
 ### Common tasks
 


### PR DESCRIPTION
The three agent/onboarding docs had drifted from the actual repo. This PR brings them current. Each correction is backed by evidence from `package.json`, the `supabase/migrations/` and `docs/adr/` directories, and `.github/workflows/`.

## Corrections

| Topic | Was | Now |
|---|---|---|
| pnpm | 9.0.0 | **11.2.2** |
| Turborepo | 2.8.20 / 2.9.14 | **2.9.16** |
| TypeScript | 5.9.2 | **6.0.3** |
| Migrations | "9" / "13" | **19** (→ `00019`) |
| ADR series | …0027, "number from 0029" | **…0032**, number from the next free (0028 = period-span-overlay) |
| CI (CLAUDE.md) | "no CI — validation is local-only" | **`ci.yml` runs format/lint/type-check/build/test** |
| Tests (CLAUDE.md) | "no test framework — don't invent `pnpm test`" | **Vitest in ui + services**; `pnpm test` / `test:coverage` (80%); enforced by pre-push |
| Apps state | "Turborepo boilerplate" | **admin implemented** (auth, shell, dashboard, list pages, timeline editor, public reader); only docs is boilerplate |
| `@repo/ui` imports | `@repo/ui/button` | **`@repo/ui/components/button`** (subpath exports) |
| README stack | TanStack/Zustand "Planned"; UI = CSS Modules | both **actual**; UI = **Tailwind + shadcn/ui** |

Also: added the missing `packages/services` entry to CLAUDE.md's layout, and fixed README's "four → five" validation count.

## Why these mattered
The two CLAUDE.md errors (no CI, no test framework) were actively misleading — an agent following them would skip `test:coverage` and be surprised when the pre-push hook rejects the push (which is exactly what happened while building #43).

## Scope
Docs only — no code changes. Surfaced while working on #43 (timeline editor); kept separate to avoid muddying that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)