### PR TITLE
fix(timeline): allow clearing subject character on update

### DIFF
--- a/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
+++ b/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
@@ -237,14 +237,9 @@ export function toCreateInput(values: TimelineFormValues): CreateTimelineInput {
 export function toUpdateData(
   values: TimelineFormValues,
 ): Partial<TimelineInput> {
-  // LIMITATION (#209): `timelineSchema.subject_character_id` is `.optional()`,
-  // not `.nullable()`, so an emptied subject maps to `undefined` here and is
-  // dropped from the PATCH rather than written as NULL. The form clears the
-  // field on a biographical→other type switch (the UI AC), but persisting that
-  // clear on an existing row needs the schema to accept null. Once #209 makes
-  // the field nullable, send `null` here when the subject is empty in edit mode.
   return {
     ...toPersistedFields(values),
+    subject_character_id: values.subject_character_id ?? null,
     slug: values.slug,
   };
 }

--- a/packages/services/src/modules/timeline-service.test.ts
+++ b/packages/services/src/modules/timeline-service.test.ts
@@ -591,6 +591,22 @@ describe("updateTimeline", () => {
       updateTimeline(client, "timeline-1", { fractal_depth: 0 }),
     ).rejects.toThrow();
   });
+
+  it("allows clearing subject_character_id with null", async () => {
+    const updated = { ...sampleTimeline, subject_character_id: null };
+    const client = makeClient({ fromResult: { data: updated, error: null } });
+
+    const result = await updateTimeline(client, "timeline-1", {
+      subject_character_id: null,
+    });
+
+    expect(result.subject_character_id).toBeNull();
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ subject_character_id: null }),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/services/src/schemas/timeline.test.ts
+++ b/packages/services/src/schemas/timeline.test.ts
@@ -75,6 +75,14 @@ describe("timelineSchema — valid inputs", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("accepts subject_character_id as null", () => {
+    const result = timelineSchema.safeParse({
+      ...validBase,
+      subject_character_id: null,
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe("timelineSchema — invalid inputs", () => {

--- a/packages/services/src/schemas/timeline.ts
+++ b/packages/services/src/schemas/timeline.ts
@@ -19,7 +19,7 @@ export const timelineSchema = z.object({
   temporal_data: temporalDataSchema,
   end_temporal_data: temporalDataSchema.optional(),
   timeline_type: timelineTypeEnum.default("general"),
-  subject_character_id: z.string().uuid().optional(),
+  subject_character_id: z.string().uuid().nullable().optional(),
   visibility: timelineVisibilityEnum.default("private"),
   fractal_depth: z.number().int().min(1).default(5),
   metadata: z.record(z.string(), z.unknown()).optional(),


### PR DESCRIPTION
Closes #209 by allowing timeline subject_character_id to be cleared on update.

Changes:
- Make subject_character_id nullable in the timeline schema
- Persist null from the edit form when the subject is cleared
- Add regression coverage for null-clearing in service and schema tests

Validation:
- pnpm exec vitest run packages/services/src/modules/timeline-service.test.ts packages/services/src/schemas/timeline.test.ts