### PR TITLE
fix: make end_temporal_data nullable and persistable

### DIFF
--- a/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
+++ b/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
@@ -190,11 +190,9 @@ export function mapRowToFormValues(
     summary: row.summary ?? "",
     detail: row.detail ?? "",
     scale: row.scale ?? "",
-    // `temporal_data`/`end_temporal_data` default to `'{}'::jsonb` in the DB
-    // (migration 00001), so an absent end date reads back as `{}` rather than
-    // null. Validate the JSON and treat anything that isn't a real TemporalData
-    // as null, so the editor doesn't render a garbage "undefined …" value
-    // (#215 tracks fixing the underlying DB default / nullable contract).
+    // Legacy rows may still contain '{}' JSON from migration 00001 defaults.
+    // Validate the JSON and treat anything that isn't a real TemporalData as
+    // null, so the editor doesn't render a garbage "undefined …" value.
     temporal_data: toTemporalOrNull(row.temporal_data),
     end_temporal_data: toTemporalOrNull(row.end_temporal_data),
     timeline_type: (row.timeline_type as TimelineType | null) ?? "general",
@@ -213,12 +211,7 @@ function toPersistedFields(values: TimelineFormValues) {
     detail: values.detail || undefined,
     scale: values.scale || undefined,
     temporal_data: values.temporal_data as TemporalData,
-    // LIMITATION (#215): `timelineSchema.end_temporal_data` is `.optional()`,
-    // not `.nullable()`, and the column defaults to `'{}'::jsonb`. A cleared end
-    // date maps to `undefined` and is dropped from the PATCH, so it can't be
-    // unset on an existing row until the schema accepts null and the DB default
-    // becomes NULL. Send `null` here once #215 lands.
-    end_temporal_data: values.end_temporal_data ?? undefined,
+    end_temporal_data: values.end_temporal_data ?? null,
     timeline_type: values.timeline_type,
     subject_character_id: values.subject_character_id || undefined,
     visibility: values.visibility,

--- a/packages/services/src/schemas/event.test.ts
+++ b/packages/services/src/schemas/event.test.ts
@@ -46,6 +46,14 @@ describe("eventSchema — valid inputs", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts null for end_temporal_data", () => {
+    const result = eventSchema.safeParse({
+      ...validBase,
+      end_temporal_data: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts importance within range [1..10]", () => {
     const lo = eventSchema.safeParse({ ...validBase, importance: 1 });
     const hi = eventSchema.safeParse({ ...validBase, importance: 10 });

--- a/packages/services/src/schemas/event.ts
+++ b/packages/services/src/schemas/event.ts
@@ -22,7 +22,7 @@ export const eventSchema = z.object({
   detail: z.string().optional(),
   event_type: eventTypeEnum.default("milestone"),
   temporal_data: temporalDataSchema,
-  end_temporal_data: temporalDataSchema.optional(),
+  end_temporal_data: temporalDataSchema.nullable().optional(),
   location: z.string().max(2000).optional(),
   spatial_data: z.record(z.string(), z.unknown()).optional(),
   importance: z.number().int().min(1).max(10).default(5),

--- a/packages/services/src/schemas/period.test.ts
+++ b/packages/services/src/schemas/period.test.ts
@@ -33,6 +33,14 @@ describe("periodSchema — valid inputs", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts null for end_temporal_data", () => {
+    const result = periodSchema.safeParse({
+      ...validBase,
+      end_temporal_data: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts characteristics array", () => {
     const result = periodSchema.safeParse({
       ...validBase,

--- a/packages/services/src/schemas/period.ts
+++ b/packages/services/src/schemas/period.ts
@@ -9,7 +9,7 @@ export const periodSchema = z.object({
   summary: z.string().optional(),
   detail: z.string().optional(),
   temporal_data: temporalDataSchema,
-  end_temporal_data: temporalDataSchema.optional(),
+  end_temporal_data: temporalDataSchema.nullable().optional(),
   parent_period_id: z.string().uuid().optional(),
   significance: significanceEnum.default("medium"),
   characteristics: z.array(z.string()).optional(),

--- a/packages/services/src/schemas/timeline.test.ts
+++ b/packages/services/src/schemas/timeline.test.ts
@@ -67,6 +67,14 @@ describe("timelineSchema — valid inputs", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts null for end_temporal_data", () => {
+    const result = timelineSchema.safeParse({
+      ...validBase,
+      end_temporal_data: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts subject_character_id as a UUID", () => {
     const result = timelineSchema.safeParse({
       ...validBase,

--- a/packages/services/src/schemas/timeline.ts
+++ b/packages/services/src/schemas/timeline.ts
@@ -17,7 +17,7 @@ export const timelineSchema = z.object({
   detail: z.string().optional(),
   scale: z.string().max(2000).optional(),
   temporal_data: temporalDataSchema,
-  end_temporal_data: temporalDataSchema.optional(),
+  end_temporal_data: temporalDataSchema.nullable().optional(),
   timeline_type: timelineTypeEnum.default("general"),
   subject_character_id: z.string().uuid().nullable().optional(),
   visibility: timelineVisibilityEnum.default("private"),

--- a/supabase/migrations/00020_end_temporal_data_nullable.sql
+++ b/supabase/migrations/00020_end_temporal_data_nullable.sql
@@ -1,0 +1,32 @@
+-- ============================================================================
+-- 00020_end_temporal_data_nullable.sql
+--
+-- Fixes issue #215 by making "no end date" representable as SQL NULL instead
+-- of an empty JSON object.
+--
+-- Changes:
+--   1) Drop end_temporal_data defaults on timelines/events/periods so creates
+--      without an end value persist NULL.
+--   2) Backfill legacy '{}'::jsonb values to NULL.
+-- ============================================================================
+
+ALTER TABLE timelines
+  ALTER COLUMN end_temporal_data DROP DEFAULT;
+
+ALTER TABLE events
+  ALTER COLUMN end_temporal_data DROP DEFAULT;
+
+ALTER TABLE periods
+  ALTER COLUMN end_temporal_data DROP DEFAULT;
+
+UPDATE timelines
+SET end_temporal_data = NULL
+WHERE end_temporal_data = '{}'::jsonb;
+
+UPDATE events
+SET end_temporal_data = NULL
+WHERE end_temporal_data = '{}'::jsonb;
+
+UPDATE periods
+SET end_temporal_data = NULL
+WHERE end_temporal_data = '{}'::jsonb;

--- a/supabase/tests/database/00020_end_temporal_data_nullable_test.sql
+++ b/supabase/tests/database/00020_end_temporal_data_nullable_test.sql
@@ -1,0 +1,112 @@
+-- pgTAP tests for 00020_end_temporal_data_nullable.sql (issue #215)
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(7);
+
+-- ============================================================================
+-- end_temporal_data defaults are removed (NULL-by-default)
+-- ============================================================================
+
+select ok(
+  not exists (
+    select 1
+    from pg_attrdef d
+    join pg_class c on c.oid = d.adrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    join pg_attribute a on a.attrelid = c.oid and a.attnum = d.adnum
+    where n.nspname = 'public'
+      and c.relname = 'timelines'
+      and a.attname = 'end_temporal_data'
+  ),
+  'timelines.end_temporal_data has no default'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_attrdef d
+    join pg_class c on c.oid = d.adrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    join pg_attribute a on a.attrelid = c.oid and a.attnum = d.adnum
+    where n.nspname = 'public'
+      and c.relname = 'events'
+      and a.attname = 'end_temporal_data'
+  ),
+  'events.end_temporal_data has no default'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_attrdef d
+    join pg_class c on c.oid = d.adrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    join pg_attribute a on a.attrelid = c.oid and a.attnum = d.adnum
+    where n.nspname = 'public'
+      and c.relname = 'periods'
+      and a.attname = 'end_temporal_data'
+  ),
+  'periods.end_temporal_data has no default'
+);
+
+-- ============================================================================
+-- Inserts without end_temporal_data persist NULL for all three entities
+-- ============================================================================
+
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'end-null@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+insert into timelines (user_id, slug, title, temporal_data)
+  values ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'tl-end-null', 'Timeline End Null',
+          '{"year":2000,"era":"CE","precision":"exact"}'::jsonb);
+
+insert into events (user_id, slug, title, temporal_data)
+  values ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'ev-end-null', 'Event End Null',
+          '{"year":2001,"era":"CE","precision":"exact"}'::jsonb);
+
+insert into periods (user_id, slug, title, temporal_data)
+  values ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'pd-end-null', 'Period End Null',
+          '{"year":2002,"era":"CE","precision":"exact"}'::jsonb);
+
+select is(
+  (select end_temporal_data from timelines where slug = 'tl-end-null'),
+  null::jsonb,
+  'timeline insert without end_temporal_data stores NULL'
+);
+
+select is(
+  (select end_temporal_data from events where slug = 'ev-end-null'),
+  null::jsonb,
+  'event insert without end_temporal_data stores NULL'
+);
+
+select is(
+  (select end_temporal_data from periods where slug = 'pd-end-null'),
+  null::jsonb,
+  'period insert without end_temporal_data stores NULL'
+);
+
+-- ============================================================================
+-- Clearing end_temporal_data to NULL remains valid
+-- ============================================================================
+
+update timelines
+set end_temporal_data = '{"year":2010,"era":"CE","precision":"exact"}'::jsonb
+where slug = 'tl-end-null';
+
+update timelines
+set end_temporal_data = null
+where slug = 'tl-end-null';
+
+select is(
+  (select end_temporal_data from timelines where slug = 'tl-end-null'),
+  null::jsonb,
+  'timeline end_temporal_data can be cleared back to NULL'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

- fix issue #215 by making end temporal absence representable as NULL
- add migration 00020 to drop end_temporal_data defaults and backfill legacy '{}' JSON to NULL for timelines, events, and periods
- update service schemas to accept end_temporal_data as nullable optional
- update timeline form serialization so clearing end date persists NULL
- add schema tests and pgTAP coverage for the new contract

## Validation

- pnpm verify
- pnpm run db:reset
- pnpm run db:test

Closes #215