### PR TITLE
test(ui): add phase 1-3 component unit coverage

### DIFF
--- a/packages/ui/src/components/auth-login-form.test.tsx
+++ b/packages/ui/src/components/auth-login-form.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthLoginForm } from "./auth-login-form";
+
+describe("AuthLoginForm", () => {
+  it("shows schema validation errors and blocks submit", async () => {
+    const action = vi.fn();
+    const user = userEvent.setup();
+
+    render(<AuthLoginForm action={action} />);
+
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(await screen.findByText("Enter a valid email")).toBeInTheDocument();
+    expect(screen.getByText("Password is required")).toBeInTheDocument();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("submits valid credentials and displays server errors", async () => {
+    const action = vi.fn().mockResolvedValue({
+      ok: false,
+      error: { message: "Invalid email or password." },
+    });
+    const user = userEvent.setup();
+
+    render(<AuthLoginForm action={action} initialError="Seeded error" />);
+
+    expect(screen.getByText("Seeded error")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Email"), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "secret");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(action).toHaveBeenCalledWith({
+        email: "user@example.com",
+        password: "secret",
+      });
+    });
+    expect(
+      await screen.findByText("Invalid email or password."),
+    ).toBeInTheDocument();
+  });
+
+  it("disables submit while request is pending", async () => {
+    let resolveAction: (result: {
+      ok: false;
+      error: { message: string };
+    }) => void = () => {};
+    const action = vi.fn(
+      () =>
+        new Promise<{ ok: false; error: { message: string } }>((resolve) => {
+          resolveAction = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+
+    render(<AuthLoginForm action={action} />);
+
+    await user.type(screen.getByLabelText("Email"), "pending@example.com");
+    await user.type(screen.getByLabelText("Password"), "secret");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    const submit = screen.getByRole("button", { name: /signing in/i });
+    expect(submit).toBeDisabled();
+
+    resolveAction({ ok: false, error: { message: "Later" } });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+  });
+});

--- a/packages/ui/src/components/auth-magic-link-form.test.tsx
+++ b/packages/ui/src/components/auth-magic-link-form.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthMagicLinkForm } from "./auth-magic-link-form";
+
+describe("AuthMagicLinkForm", () => {
+  it("shows email validation errors", async () => {
+    const action = vi.fn();
+    const user = userEvent.setup();
+
+    render(<AuthMagicLinkForm action={action} />);
+
+    await user.click(screen.getByRole("button", { name: "Send magic link" }));
+    expect(await screen.findByText("Enter a valid email")).toBeInTheDocument();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("submits email and shows success state", async () => {
+    const action = vi.fn().mockResolvedValue({ ok: true });
+    const user = userEvent.setup();
+
+    render(<AuthMagicLinkForm action={action} />);
+
+    await user.type(screen.getByLabelText("Email"), "magic@example.com");
+    await user.click(screen.getByRole("button", { name: "Send magic link" }));
+
+    await waitFor(() => {
+      expect(action).toHaveBeenCalledWith({ email: "magic@example.com" });
+    });
+    expect(await screen.findByText("Check your email")).toBeInTheDocument();
+  });
+
+  it("disables submit while request is pending", async () => {
+    let resolveAction: (result: { ok: true }) => void = () => {};
+    const action = vi.fn(
+      () =>
+        new Promise<{ ok: true }>((resolve) => {
+          resolveAction = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+
+    render(<AuthMagicLinkForm action={action} />);
+
+    await user.type(screen.getByLabelText("Email"), "wait@example.com");
+    await user.click(screen.getByRole("button", { name: "Send magic link" }));
+
+    const submit = screen.getByRole("button", { name: /sending link/i });
+    expect(submit).toBeDisabled();
+
+    resolveAction({ ok: true });
+    expect(await screen.findByText("Check your email")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/auth-register-form.test.tsx
+++ b/packages/ui/src/components/auth-register-form.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthRegisterForm } from "./auth-register-form";
+
+describe("AuthRegisterForm", () => {
+  it("validates password confirmation before submit", async () => {
+    const action = vi.fn();
+    const user = userEvent.setup();
+
+    render(<AuthRegisterForm action={action} />);
+
+    await user.type(screen.getByLabelText("First name"), "Ada");
+    await user.type(screen.getByLabelText("Last name"), "Lovelace");
+    await user.type(screen.getByLabelText("Email"), "ada@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+    await user.type(screen.getByLabelText("Confirm password"), "different");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    expect(
+      await screen.findByText("Passwords do not match"),
+    ).toBeInTheDocument();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("submits with expected payload and renders success state", async () => {
+    const action = vi.fn().mockResolvedValue({ ok: true });
+    const user = userEvent.setup();
+
+    render(<AuthRegisterForm action={action} />);
+
+    await user.type(screen.getByLabelText("First name"), "Ada");
+    await user.type(screen.getByLabelText("Last name"), "Lovelace");
+    await user.type(screen.getByLabelText("Email"), "ada@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+    await user.type(screen.getByLabelText("Confirm password"), "password123");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    await waitFor(() => {
+      expect(action).toHaveBeenCalledWith({
+        email: "ada@example.com",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        password: "password123",
+      });
+    });
+
+    expect(await screen.findByText("Check your email")).toBeInTheDocument();
+  });
+
+  it("renders initialSuccess immediately", () => {
+    const action = vi.fn();
+    render(<AuthRegisterForm action={action} initialSuccess />);
+    expect(screen.getByText("Check your email")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/auth-reset-password-form.test.tsx
+++ b/packages/ui/src/components/auth-reset-password-form.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthResetPasswordForm } from "./auth-reset-password-form";
+
+describe("AuthResetPasswordForm", () => {
+  it("shows email validation errors", async () => {
+    const action = vi.fn();
+    const user = userEvent.setup();
+
+    render(<AuthResetPasswordForm action={action} />);
+
+    await user.click(screen.getByRole("button", { name: "Send reset link" }));
+    expect(await screen.findByText("Enter a valid email")).toBeInTheDocument();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("submits email and renders server error responses", async () => {
+    const action = vi.fn().mockResolvedValue({
+      ok: false,
+      error: { message: "Unable to send reset email." },
+    });
+    const user = userEvent.setup();
+
+    render(
+      <AuthResetPasswordForm
+        action={action}
+        initialError="Seeded reset error"
+      />,
+    );
+
+    expect(screen.getByText("Seeded reset error")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Email"), "reset@example.com");
+    await user.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    await waitFor(() => {
+      expect(action).toHaveBeenCalledWith({ email: "reset@example.com" });
+    });
+    expect(
+      await screen.findByText("Unable to send reset email."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders initialSuccess immediately", () => {
+    const action = vi.fn();
+    render(<AuthResetPasswordForm action={action} initialSuccess />);
+    expect(screen.getByText("Check your email")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/auth-update-password-form.test.tsx
+++ b/packages/ui/src/components/auth-update-password-form.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthUpdatePasswordForm } from "./auth-update-password-form";
+
+describe("AuthUpdatePasswordForm", () => {
+  it("validates password confirmation before submit", async () => {
+    const action = vi.fn();
+    const user = userEvent.setup();
+
+    render(<AuthUpdatePasswordForm action={action} />);
+
+    await user.type(screen.getByLabelText("New password"), "password123");
+    await user.type(screen.getByLabelText("Confirm new password"), "different");
+    await user.click(screen.getByRole("button", { name: "Set new password" }));
+
+    expect(
+      await screen.findByText("Passwords do not match"),
+    ).toBeInTheDocument();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("submits only password and surfaces server errors", async () => {
+    const action = vi.fn().mockResolvedValue({
+      ok: false,
+      error: { message: "This link has expired." },
+    });
+    const user = userEvent.setup();
+
+    render(
+      <AuthUpdatePasswordForm action={action} initialError="Seeded error" />,
+    );
+
+    expect(screen.getByText("Seeded error")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("New password"), "password123");
+    await user.type(
+      screen.getByLabelText("Confirm new password"),
+      "password123",
+    );
+    await user.click(screen.getByRole("button", { name: "Set new password" }));
+
+    await waitFor(() => {
+      expect(action).toHaveBeenCalledWith({ password: "password123" });
+    });
+    expect(
+      await screen.findByText("This link has expired."),
+    ).toBeInTheDocument();
+  });
+
+  it("disables submit while request is pending", async () => {
+    let resolveAction: (result: {
+      ok: false;
+      error: { message: string };
+    }) => void = () => {};
+    const action = vi.fn(
+      () =>
+        new Promise<{ ok: false; error: { message: string } }>((resolve) => {
+          resolveAction = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+
+    render(<AuthUpdatePasswordForm action={action} />);
+
+    await user.type(screen.getByLabelText("New password"), "password123");
+    await user.type(
+      screen.getByLabelText("Confirm new password"),
+      "password123",
+    );
+    await user.click(screen.getByRole("button", { name: "Set new password" }));
+
+    const submit = screen.getByRole("button", { name: /saving/i });
+    expect(submit).toBeDisabled();
+
+    resolveAction({ ok: false, error: { message: "Later" } });
+    await waitFor(() => expect(submit).not.toBeDisabled());
+  });
+});

--- a/packages/ui/src/components/form.test.tsx
+++ b/packages/ui/src/components/form.test.tsx
@@ -1,0 +1,151 @@
+import type { ReactNode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { useForm } from "react-hook-form";
+
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
+} from "./form";
+
+type Values = {
+  email: string;
+};
+
+function HookProbe() {
+  useFormField();
+  return null;
+}
+
+function MissingFormFieldHarness() {
+  const form = useForm<Values>({ defaultValues: { email: "" } });
+
+  return (
+    <Form {...form}>
+      <HookProbe />
+    </Form>
+  );
+}
+
+function MissingFormItemHarness() {
+  const form = useForm<Values>({ defaultValues: { email: "" } });
+
+  return (
+    <Form {...form}>
+      <FormField
+        control={form.control}
+        name="email"
+        render={() => <HookProbe />}
+      />
+    </Form>
+  );
+}
+
+function FormHarness({ messageChildren }: { messageChildren?: ReactNode }) {
+  const form = useForm<Values>({ defaultValues: { email: "" } });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(() => {})}>
+        <FormField
+          control={form.control}
+          name="email"
+          rules={{ required: "Email is required" }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <input type="email" {...field} />
+              </FormControl>
+              <FormDescription>Helpful hint</FormDescription>
+              <FormMessage data-testid="message">{messageChildren}</FormMessage>
+            </FormItem>
+          )}
+        />
+        <button type="submit">Submit</button>
+      </form>
+    </Form>
+  );
+}
+
+describe("form primitives", () => {
+  it("throws when useFormField is used outside FormField", () => {
+    expect(() => render(<MissingFormFieldHarness />)).toThrow(
+      "useFormField should be used within <FormField>",
+    );
+  });
+
+  it("throws when useFormField is used outside FormItem", () => {
+    expect(() => render(<MissingFormItemHarness />)).toThrow(
+      "useFormField should be used within <FormItem>",
+    );
+  });
+
+  it("wires label, described-by, and empty message state when valid", () => {
+    render(<FormHarness />);
+
+    const input = screen.getByRole("textbox", { name: "Email" });
+    const label = screen.getByText("Email");
+
+    expect(label).toHaveAttribute("for", input.getAttribute("id"));
+    expect(input).toHaveAttribute("aria-invalid", "false");
+
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const describedByIds = (describedBy ?? "").split(" ");
+    expect(describedByIds).toHaveLength(1);
+    const firstDescribedById = describedByIds[0];
+    expect(firstDescribedById).toBeDefined();
+    if (!firstDescribedById) {
+      throw new Error("Expected aria-describedby to contain one id");
+    }
+    expect(document.getElementById(firstDescribedById)).toHaveTextContent(
+      "Helpful hint",
+    );
+
+    expect(screen.queryByTestId("message")).not.toBeInTheDocument();
+  });
+
+  it("renders custom message children when no error exists", () => {
+    render(<FormHarness messageChildren="Custom helper" />);
+
+    expect(screen.getByTestId("message")).toHaveTextContent("Custom helper");
+    expect(screen.getByRole("textbox", { name: "Email" })).toHaveAttribute(
+      "aria-invalid",
+      "false",
+    );
+  });
+
+  it("switches aria wiring to include error message on validation failure", async () => {
+    const user = userEvent.setup();
+    render(<FormHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    const errorText = await screen.findByText("Email is required");
+    const input = screen.getByRole("textbox", { name: "Email" });
+    const label = screen.getByText("Email");
+
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(label.className).toContain("text-destructive");
+
+    await waitFor(() => {
+      const ids = (input.getAttribute("aria-describedby") ?? "").split(" ");
+      expect(ids).toHaveLength(2);
+      const resolved = ids
+        .map((id) => document.getElementById(id)?.textContent ?? "")
+        .join(" ");
+      expect(resolved).toContain("Helpful hint");
+      expect(resolved).toContain("Email is required");
+    });
+
+    expect(errorText).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/sonner.test.tsx
+++ b/packages/ui/src/components/sonner.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockUseTheme = vi.fn();
+const mockSonner = vi.fn();
+
+vi.mock("next-themes", () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+vi.mock("sonner", () => ({
+  Toaster: (props: unknown) => {
+    mockSonner(props);
+    return <div data-testid="sonner-root" />;
+  },
+}));
+
+import { Toaster } from "./sonner";
+
+function getFirstSonnerCallProps<T>(): T {
+  const firstCall = mockSonner.mock.calls[0];
+  if (!firstCall) {
+    throw new Error("Expected sonner Toaster mock to be called at least once");
+  }
+  return firstCall[0] as T;
+}
+
+describe("Toaster", () => {
+  beforeEach(() => {
+    mockUseTheme.mockReset();
+    mockSonner.mockReset();
+  });
+
+  it("passes the current theme through to sonner", () => {
+    mockUseTheme.mockReturnValue({ theme: "dark" });
+
+    render(<Toaster />);
+
+    expect(mockSonner).toHaveBeenCalledTimes(1);
+    const props = getFirstSonnerCallProps<Record<string, unknown>>();
+    expect(props.theme).toBe("dark");
+    expect(props.className).toBe("toaster group");
+  });
+
+  it("falls back to system theme when theme is missing", () => {
+    mockUseTheme.mockReturnValue({});
+
+    render(<Toaster />);
+
+    const props = getFirstSonnerCallProps<Record<string, unknown>>();
+    expect(props.theme).toBe("system");
+  });
+
+  it("provides icon slots and keeps caller props", () => {
+    mockUseTheme.mockReturnValue({ theme: "light" });
+
+    render(<Toaster richColors />);
+
+    const props = getFirstSonnerCallProps<{
+      richColors?: boolean;
+      icons?: Record<string, unknown>;
+      toastOptions?: {
+        classNames?: Record<string, string>;
+      };
+    }>();
+
+    expect(props.richColors).toBe(true);
+    expect(Object.keys(props.icons ?? {}).sort()).toEqual([
+      "error",
+      "info",
+      "loading",
+      "success",
+      "warning",
+    ]);
+    expect(props.toastOptions?.classNames?.toast).toContain("group toast");
+    expect(props.toastOptions?.classNames?.actionButton).toContain(
+      "text-primary-foreground",
+    );
+    expect(props.toastOptions?.classNames?.cancelButton).toContain(
+      "text-muted-foreground",
+    );
+  });
+});

--- a/packages/ui/src/components/status-badge.test.tsx
+++ b/packages/ui/src/components/status-badge.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StatusBadge } from "./status-badge";
+
+describe("StatusBadge", () => {
+  it("defaults to Draft when no status is provided", () => {
+    render(<StatusBadge data-testid="badge" />);
+
+    const badge = screen.getByTestId("badge");
+    expect(badge).toHaveTextContent("Draft");
+    expect(badge.className).toContain("bg-surface-2");
+    expect(badge.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders the published variant", () => {
+    render(<StatusBadge status="published" data-testid="badge" />);
+
+    const badge = screen.getByTestId("badge");
+    expect(badge).toHaveTextContent("Published");
+    expect(badge.className).toContain("bg-emerald-500/10");
+    expect(badge.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders the shared variant", () => {
+    render(<StatusBadge status="shared" data-testid="badge" />);
+
+    const badge = screen.getByTestId("badge");
+    expect(badge).toHaveTextContent("Shared");
+    expect(badge.className).toContain("bg-sky-500/10");
+    expect(badge.querySelector("svg")).not.toBeNull();
+  });
+
+  it("uses a custom label when provided", () => {
+    render(
+      <StatusBadge status="published" label="Live now" data-testid="badge" />,
+    );
+
+    const badge = screen.getByTestId("badge");
+    expect(badge).toHaveTextContent("Live now");
+    expect(badge).not.toHaveTextContent("Published");
+  });
+});

--- a/packages/ui/src/components/tree.test.tsx
+++ b/packages/ui/src/components/tree.test.tsx
@@ -50,7 +50,7 @@ describe("Tree", () => {
     render(<Tree aria-label="Hierarchy" nodes={NODES} />);
 
     const rootRow = rowFor("Root timeline");
-    rootRow.focus();
+    await user.click(rootRow);
     await user.keyboard("{ArrowLeft}");
 
     expect(rootRow).toHaveAttribute("aria-expanded", "false");
@@ -63,8 +63,7 @@ describe("Tree", () => {
     const user = userEvent.setup();
     render(<Tree aria-label="Hierarchy" nodes={nodes} />);
 
-    const row = rowFor("Leaf");
-    row.focus();
+    await user.tab();
     await user.keyboard("{Enter}");
     expect(onActivate).toHaveBeenCalledOnce();
   });
@@ -74,7 +73,7 @@ describe("Tree", () => {
     render(<Tree aria-label="Hierarchy" nodes={NODES} />);
 
     const rootRow = rowFor("Root timeline");
-    rootRow.focus();
+    await user.click(rootRow);
     await user.keyboard("{ArrowDown}");
 
     // Focus moved: Event A now has tabIndex 0 (roving focus), root has -1.
@@ -88,7 +87,7 @@ describe("Tree", () => {
 
     // Focus Event A (a leaf child of Root).
     const eventARow = rowFor("Event A");
-    eventARow.focus();
+    await user.click(eventARow);
     await user.keyboard("{ArrowLeft}");
 
     // Focus should move up to Root timeline.


### PR DESCRIPTION
## Summary
- add auth form unit tests for login, register, magic-link, reset-password, and update-password flows
- add shared form primitive contract tests for aria wiring, guardrails, and message behavior
- add status badge and toaster unit tests for variant/theme and prop contract coverage
- update tree keyboard tests to use user interactions for focus, removing React act warnings

## Validation
- pnpm test (packages/ui)
- pnpm run check-types
- pnpm verify

## Notes
- This PR is test-focused and does not change production component logic.