### PR TITLE
docs: reconcile README, CLAUDE.md, and copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,7 +136,7 @@ Or run steps 2–6 at once (minus db:test) via `pnpm verify`.
 - **Shared packages**: Import UI components as `@repo/ui/components/button`, `@repo/ui/components/card`, etc.; hooks via `@repo/ui/hooks/*`; the Zustand store via `@repo/ui/stores`. Import `@repo/services` schemas/modules as `@repo/services/schemas/*` and `@repo/services/<entity>-service`. Import configs as `@repo/eslint-config/...` and `@repo/typescript-config/...`.
 - **Turborepo task graph**: `build` depends on `^build` (packages build before apps). Do not run per-app builds in isolation unless you have already built the packages.
 - **GitHub Actions workflows**: CI runs Lint, Type Check, Build, and Test on every push/PR. All four jobs are required status checks on `main`.
-- **Documentation**: `docs/prd/PRD-0001-time-traveler-system.md` (product requirements) and `docs/system-design.md` (architecture, schema, API design) are the authoritative references for feature work. `docs/design/admin/` contains the fidelity-1 wireframes for the admin app (characters + events CRUD plus the relationships editor) — read these alongside PRD §7.11 when doing UI work in `apps/admin`. Divergences between the wireframes and PRD §7.11 are tracked in #127.
+- **Documentation**: `docs/prd/PRD-0001-time-traveler-system.md` (product requirements) and `docs/system-design.md` (architecture, schema, API design) are authoritative. `docs/design/admin/` has fidelity-1 wireframes for the admin app (IA + interaction spec for characters, events, relationships). `docs/design/public/` has comprehensive design for the public reader: UX principles, wireframes, mid-fidelity + motion + accessibility specs, interaction spec, and prototype validation. Read design alongside the PRD when doing UI work. Divergences in admin design are tracked in #127. Architectural decisions are in `docs/adr/` (index + 32 ADRs; 0001–0027 retroactively documented May 2026; 0028+ forward decisions).
 - **App package names**: The app package names are `admin` and `docs`; Turborepo references them as `admin:*` and `docs:*`.
 
 ## GitHub Tool Workarounds
@@ -168,7 +168,7 @@ If implementing a task reveals a bug in the spec (`docs/system-design.md`, PRD),
 
 ## When to Write an ADR
 
-Architectural decisions are recorded as Architecture Decision Records in `docs/adr/`. The series ADR-0001 through ADR-0032 documents every load-bearing decision made to date; the index, format rules, and process live in `docs/adr/README.md`.
+Architectural decisions are recorded as Architecture Decision Records in `docs/adr/`. The series ADR-0001 through ADR-0032 documents every load-bearing decision made to date. ADRs 0001–0027 were retroactively documented in May 2026 to close a knowledge gap; decisions 0028 onward are recorded forward as decisions are made. The index, format rules, and process live in `docs/adr/README.md`.
 
 - Write a new ADR when a decision is **hard to reverse, cross-cutting, or precedent-setting** — e.g., a new platform/dependency, a schema or RLS pattern, an API boundary, a state/data-flow choice, or a design-system rule. Routine, local, easily-reversible changes do not need one.
 - **Number new ADRs from the next free number** — the series currently runs through ADR-0032, so check `docs/adr/README.md` for the latest before numbering. Copy `docs/adr/adr-0000-template.md`, fill in every section, cite concrete evidence (a migration file/section or a doc section), and add a row to the `docs/adr/README.md` index.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Hybrid temporal system** — JSONB-encoded dates extend beyond SQL date limits to handle prehistoric/geological/cosmological dates, with precision metadata and uncertainty ranges. See `docs/system-design.md` §4 for the era conversion formula used by all `sort_order` generated columns.
 - **Seven character types** — Human, Animal, Mythological, Fictional, Organization, Divine, Artifact — with temporally-scoped relationships and event participation.
 
-**Current state:** The Supabase layer is mature (19 numbered migrations + pgTAP tests). `apps/admin` is under active feature development — auth, the app shell, dashboard, list pages (timelines, characters, events, periods, stories, categories, media), the timeline create/edit editor, and a public reader all exist — backed by `@repo/services` (nine service modules + Zod schemas) and `@repo/ui` (TanStack Query hooks, a Zustand store, shadcn/ui primitives). `apps/docs` is still Turborepo boilerplate.
+**Current state:** The Supabase layer is mature (19 numbered migrations + pgTAP tests). `apps/admin` is under active feature development — auth, the app shell, dashboard, list pages (timelines, characters, events, periods, stories, categories, media), and the timeline create/edit editor — backed by `@repo/services` (nine service modules + Zod schemas) and `@repo/ui` (TanStack Query hooks, a Zustand store, shadcn/ui primitives). The public-facing reader is comprehensively designed (UX/IA/motion/accessibility specs in `docs/design/public/`) and will live in a dedicated `apps/reader` Next.js app per [ADR-0030](docs/adr/adr-0030-public-reader-app-placement.md). All 32 load-bearing architectural decisions are documented in `docs/adr/` (retroactive 0001–0027 recorded May 2026; forward decisions 0028 onward). `apps/docs` is still Turborepo boilerplate.
 
 ## Repository Layout
 
@@ -24,7 +24,9 @@ pnpm monorepo orchestrated by Turborepo. Workspaces: `apps/*`, `packages/*`.
 - `packages/typescript-config` — `@repo/typescript-config` (`base.json`, `nextjs.json`, `react-library.json`).
 - `supabase/migrations` — numbered SQL migrations. Migration `00001_initial_schema.sql` defines core tables (profiles, characters, …); `00002_relationships_junctions.sql` defines `character_relationships` and 11 junction tables.
 - `docs/prd/PRD-0001-time-traveler-system.md` and `docs/system-design.md` are the authoritative references for feature/schema work.
-- `docs/design/admin/` contains the fidelity-1 wireframes for the admin app (characters + events CRUD plus the relationships editor). When doing UI work in `apps/admin`, these are the IA + interaction spec — read alongside PRD §7.11 (some divergences are tracked in #127).
+- `docs/design/admin/` contains the fidelity-1 wireframes for the admin app (IA + interaction spec for characters, events, and relationships editor). When doing UI work in `apps/admin`, read alongside PRD §7.11 (divergences tracked in #127).
+- `docs/design/public/` contains the complete design spec for the public-facing reader: UX principles, wireframes, mid-fidelity designs, interaction spec, motion tokens, and accessibility spec. This design gates implementation tickets #65–#69.
+- `docs/adr/` contains all 32 load-bearing architectural decisions. See [`docs/adr/README.md`](docs/adr/README.md) for the index; decisions 0001–0027 were retroactively documented in May 2026, and forward decisions (0028 onward) are added as decisions are made.
 - CI runs on GitHub Actions (`.github/workflows/ci.yml`): format, lint, type-check, build, and test on every push/PR; these are required checks on `main`.
 
 ## Toolchain

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For the product specification, see [`docs/prd/PRD-0001-time-traveler-system.md`]
 
 ## Status
 
-**Greenfield, mid-development.** The Supabase layer is largely complete: 19 numbered migrations cover schema, RLS, indexes, views, functions, storage, and follow-up data-integrity fixes, with pgTAP tests for the database surface. `apps/admin` is under active development against the fidelity-1 wireframes in [`docs/design/admin/`](docs/design/admin/) — auth, the app shell, dashboard, entity list pages, the timeline create/edit editor, and a public reader are in place. `apps/docs` is still Turborepo boilerplate.
+**Greenfield, mid-development.** The Supabase layer is largely complete: 19 numbered migrations cover schema, RLS, indexes, views, functions, storage, and follow-up data-integrity fixes, with pgTAP tests for the database surface. `apps/admin` is under active development against fidelity-1 wireframes in [`docs/design/admin/`](docs/design/admin/) — auth, the app shell, dashboard, entity list pages, and the timeline create/edit editor are in place. The public-facing reader is designed (comprehensive UX artifacts in [`docs/design/public/`](docs/design/public/)) but not yet implemented; it will live in a dedicated `apps/reader` per [ADR-0030](docs/adr/adr-0030-public-reader-app-placement.md). All 32 load-bearing architectural decisions are documented in [`docs/adr/`](docs/adr/) — the first 27 were retroactively recorded in May 2026; the series continues with forward decisions (0028 onward). `apps/docs` is still Turborepo boilerplate.
 
 ## Stack
 
@@ -95,8 +95,8 @@ Run all five; each must pass:
 pnpm run format:check     # Prettier format check
 pnpm run check-types      # TypeScript: next typegen + tsc --noEmit
 pnpm run lint             # ESLint with --max-warnings 0 (warnings fail)
-pnpm run build            # Turborepo: build all packages and apps
 pnpm run test:coverage    # Vitest with 80% coverage threshold
+pnpm run build            # Turborepo: build all packages and apps
 ```
 
 For database schema changes also run:
@@ -122,12 +122,36 @@ Manual dataset seeding docs: [docs/seeding-discovery.md](docs/seeding-discovery.
 
 ## Documentation
 
+### Product & System
+
 | Document                                         | Purpose                                                        |
 | ------------------------------------------------ | -------------------------------------------------------------- |
 | [PRD](docs/prd/PRD-0001-time-traveler-system.md) | Product requirements and functional specs (authoritative)      |
 | [System Design](docs/system-design.md)           | Architecture, schema, RLS policies, API design (authoritative) |
-| [Admin Design Wireframes](docs/design/admin/)    | Fidelity-1 IA + interaction spec for the admin app             |
-| [Historical Papers](docs/historical-papers/)     | Reference material                                             |
+
+### Design Artifacts
+
+| Document                                                                                | Purpose                                                                  |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [Admin Design](docs/design/admin/)                                                      | Fidelity-1 wireframes, IA, interaction spec, and aesthetic notes         |
+| [Public Reader Design](docs/design/public/)                                             | Complete UX design for public-facing timeline explorer and story browser |
+| [Public Reader Motion Spec](docs/design/public/06-mid-fidelity/motion-spec.md)          | Animation durations, easing, reduced-motion contract                     |
+| [Public Reader Accessibility](docs/design/public/06-mid-fidelity/accessibility-spec.md) | WCAG compliance + keyboard navigation spec                               |
+
+### Architecture & Decisions
+
+| Document                        | Purpose                                                                                |
+| ------------------------------- | -------------------------------------------------------------------------------------- |
+| [ADR Index](docs/adr/README.md) | All 32 load-bearing architectural decisions (retroactive 0001–0027, forward 0028–0032) |
+
+**Notable ADRs:** [0001 Supabase](docs/adr/adr-0001-supabase-backend-platform.md) • [0005 Temporal system](docs/adr/adr-0005-hybrid-temporal-system.md) • [0014 RLS](docs/adr/adr-0014-rls-single-source-of-authorization.md) • [0030 Public reader placement](docs/adr/adr-0030-public-reader-app-placement.md)
+
+### Reference
+
+| Document                                       | Purpose                   |
+| ---------------------------------------------- | ------------------------- |
+| [Historical Papers](docs/historical-papers/)   | Domain research material  |
+| [Seeding Discovery](docs/seeding-discovery.md) | Manual dataset seed guide |
 
 For working in the codebase, see also [`CLAUDE.md`](CLAUDE.md) (guidance for Claude Code agents) and [`.github/copilot-instructions.md`](.github/copilot-instructions.md) (guidance for GitHub Copilot).
 


### PR DESCRIPTION
## Summary

Reconciled documentation across three key files to accurately reflect the current state of the Time Traveler repository, particularly:

- Addition of 32 Architecture Decision Records (ADRs) covering all load-bearing decisions (retroactive 0001–0027, forward 0028–0032)
- Comprehensive public reader design (UX, IA, motion, accessibility specs) and planned implementation in dedicated `apps/reader`
- Enhanced clarity on what is implemented (admin app) vs. designed-but-not-yet-built (public reader)

## Changes

### README.md
- **Status section**: Now clarifies public reader design completion and ADR system
- **Documentation section**: Reorganized into four subsections (Product & System, Design Artifacts, Architecture & Decisions, Reference) with comprehensive cross-links

### CLAUDE.md
- **Current state**: Separated implemented work from designed-but-not-built, clarified ADR status
- **Repository Layout**: Added full context on public reader design and ADR documentation

### .github/copilot-instructions.md
- **Documentation note**: Expanded to cover both admin and public reader design artifacts with fidelity levels
- **ADR section**: Made retroactive vs. forward distinction explicit

## Testing

- ✅ All files pass `pnpm format:check`
- ✅ All files are valid Markdown per Prettier
- ✅ No code changes; documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)