### PR TITLE
feat(events): event create/edit form with forward fractal drill-down (#46)

### DIFF
--- a/apps/admin/app/(protected)/events/[slug]/edit/page.tsx
+++ b/apps/admin/app/(protected)/events/[slug]/edit/page.tsx
@@ -1,20 +1,21 @@
-import { PlaceholderPage } from "../../../../../components/placeholder-page";
+import { redirect } from "next/navigation";
+import { getUser } from "../../../../../lib/auth";
+import { getServerSupabaseClient } from "../../../../auth/_lib/server-supabase";
+import { EventFormClient } from "../../_components/event-form-client";
 
-interface EventDetailPageProps {
+interface EditEventPageProps {
   params: Promise<{ slug: string }>;
 }
 
-export default async function EventDetailPage({
-  params,
-}: EventDetailPageProps) {
+export default async function EditEventPage({ params }: EditEventPageProps) {
   const { slug } = await params;
 
-  return (
-    <PlaceholderPage
-      title={`Edit event: ${slug}`}
-      description="Event editor surface scaffolded for dashboard deep-link flows."
-      trackedIn="a later batch (TBD)"
-      rows={3}
-    />
-  );
+  // Resolve the owner id server-side (session already validated by the
+  // protected layout) so the client hook can build its (userId, slug) query
+  // key on first render without an auth round-trip / loading flash.
+  const client = await getServerSupabaseClient();
+  const user = await getUser(client);
+  if (!user) redirect("/auth/login");
+
+  return <EventFormClient mode="edit" userId={user.id} slug={slug} />;
 }

--- a/apps/admin/app/(protected)/events/_components/event-form-client.tsx
+++ b/apps/admin/app/(protected)/events/_components/event-form-client.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
-import { Check, ChevronsUpDown, ExternalLink, X } from "lucide-react";
+import { ArrowUpRight, Check, ChevronsUpDown, X } from "lucide-react";
 import { useForm, useWatch, Controller, type Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -209,6 +209,19 @@ export const BLANK_VALUES: EventFormValues = {
 export function toTemporalOrNull(json: unknown): TemporalData | null {
   const result = temporalDataSchema.safeParse(json);
   return result.success ? result.data : null;
+}
+
+/**
+ * Maps a number-input's value to a nullable number. Treats both an empty field
+ * and unparseable input (e.g. a lone "-" or "1.2.3", which yield NaN from
+ * `valueAsNumber`) as null, so the user never sees a raw "received nan" error.
+ */
+export function parseNullableNumber(
+  raw: string,
+  parsed: number,
+): number | null {
+  if (raw === "" || Number.isNaN(parsed)) return null;
+  return parsed;
 }
 
 /** Read a numeric coordinate out of the stored `spatial_data` JSONB. */
@@ -1049,9 +1062,10 @@ export function EventFormClient(props: Props) {
                             value={field.value ?? ""}
                             onChange={(e) =>
                               field.onChange(
-                                e.target.value === ""
-                                  ? null
-                                  : e.target.valueAsNumber,
+                                parseNullableNumber(
+                                  e.target.value,
+                                  e.target.valueAsNumber,
+                                ),
                               )
                             }
                             onBlur={field.onBlur}
@@ -1080,9 +1094,10 @@ export function EventFormClient(props: Props) {
                             value={field.value ?? ""}
                             onChange={(e) =>
                               field.onChange(
-                                e.target.value === ""
-                                  ? null
-                                  : e.target.valueAsNumber,
+                                parseNullableNumber(
+                                  e.target.value,
+                                  e.target.valueAsNumber,
+                                ),
                               )
                             }
                             onBlur={field.onBlur}
@@ -1182,7 +1197,7 @@ export function EventFormClient(props: Props) {
                           disabled={createTimeline.isPending}
                           onClick={handleCreateSubTimeline}
                         >
-                          <ExternalLink className="h-4 w-4" />
+                          <ArrowUpRight className="h-4 w-4" />
                         </Button>
                       </div>
                       <p className="mt-1 text-xs text-foreground-muted">

--- a/apps/admin/app/(protected)/events/_components/event-form-client.tsx
+++ b/apps/admin/app/(protected)/events/_components/event-form-client.tsx
@@ -1,0 +1,1298 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Check, ChevronsUpDown, ExternalLink, X } from "lucide-react";
+import { useForm, useWatch, Controller, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { eventSchema, eventTypeEnum } from "@repo/services/schemas/event";
+import type { EventInput } from "@repo/services/schemas/event";
+import type {
+  CreateEventInput,
+  EventWithRelations,
+} from "@repo/services/event-service";
+import {
+  temporalDataSchema,
+  compareTemporal,
+} from "@repo/services/schemas/temporal";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import { generateSlug } from "@repo/services/utils/slug";
+
+import {
+  useEventBySlug,
+  useCreateEvent,
+  useUpdateEvent,
+} from "@repo/ui/hooks/use-events";
+import {
+  useTimelines,
+  useCreateTimeline,
+  useAddEventToTimeline,
+  useRemoveEventFromTimeline,
+  useEventTimelineLinks,
+} from "@repo/ui/hooks/use-timelines";
+import { useUiStore } from "@repo/ui/stores";
+
+import { Alert, AlertDescription, AlertTitle } from "@repo/ui/components/alert";
+import { Badge } from "@repo/ui/components/badge";
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/form";
+import { Label } from "@repo/ui/components/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import { Separator } from "@repo/ui/components/separator";
+import { SaveDropdown } from "@repo/ui/components/save-dropdown";
+import { SlugField } from "@repo/ui/components/slug-field";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { Slider } from "@repo/ui/components/slider";
+import { TemporalInput } from "@repo/ui/components/temporal-input";
+import { Textarea } from "@repo/ui/components/textarea";
+import { cn } from "@repo/ui/lib/utils";
+
+import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+// The unsaved-changes guard is feature-agnostic; reuse the timeline editor's.
+import { useUnsavedChangesGuard } from "../../timelines/_components/use-unsaved-changes-guard";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type EventType = z.infer<typeof eventTypeEnum>;
+
+/**
+ * The form's working value type. Uses the schema's snake_case field names so
+ * `zodResolver` validates directly. Two shape differences from the persisted
+ * `eventSchema`:
+ *  - `temporal_data` is nullable here (the empty UI state); the required check
+ *    lives in `eventFormSchema` below for a clean message.
+ *  - `spatial_data` (a lat/lng JSONB blob) is split into two scalar
+ *    `latitude`/`longitude` inputs and recombined on persist.
+ *  - `appears_in` holds the "also appears in" timeline ids (the `timeline_events`
+ *    junction), reconciled separately from the event row write.
+ *
+ * Publication is intentionally NOT editable here, mirroring the timeline editor:
+ * the editor only writes draft content. Publish/unpublish is a separate control
+ * (event detail + the publish workflow, #48).
+ */
+export interface EventFormValues {
+  title: string;
+  slug: string;
+  summary: string;
+  detail: string;
+  event_type: EventType;
+  importance: number;
+  location: string;
+  latitude: number | null;
+  longitude: number | null;
+  temporal_data: TemporalData | null;
+  end_temporal_data: TemporalData | null;
+  timeline_id: string | undefined;
+  appears_in: string[];
+  detail_timeline_id: string | undefined;
+  metadata: Record<string, unknown> | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Validation — wrap the canonical schema (do not mutate it)
+// ---------------------------------------------------------------------------
+
+/**
+ * Form-only schema: reuses `eventSchema` for every field, but
+ *  - drops `spatial_data` in favour of scalar `latitude`/`longitude`;
+ *  - makes the temporal fields nullable (the empty UI state), then requires a
+ *    start via superRefine with a friendly message;
+ *  - adds the "also appears in" id list;
+ *  - enforces the cross-field rules from #46: end-not-before-start (hard error),
+ *    expands-into ≠ primary timeline, and coordinates supplied as a pair.
+ * These refinements are validation-only and never reach the service.
+ */
+export const eventFormSchema = eventSchema
+  .omit({ spatial_data: true })
+  .extend({
+    temporal_data: temporalDataSchema.nullable(),
+    end_temporal_data: temporalDataSchema.nullable().optional(),
+    latitude: z.number().min(-90).max(90).nullable().optional(),
+    longitude: z.number().min(-180).max(180).nullable().optional(),
+    appears_in: z.array(z.string().uuid()).default([]),
+  })
+  .superRefine((data, ctx) => {
+    if (data.temporal_data === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["temporal_data"],
+        message: "A start date is required.",
+      });
+    }
+    if (
+      data.temporal_data &&
+      data.end_temporal_data &&
+      compareTemporal(data.end_temporal_data, data.temporal_data) < 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["end_temporal_data"],
+        message: "End must be the same as or later than the start.",
+      });
+    }
+    if (
+      data.detail_timeline_id &&
+      data.timeline_id &&
+      data.detail_timeline_id === data.timeline_id
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["detail_timeline_id"],
+        message: "An event can't expand into its own primary timeline.",
+      });
+    }
+    const hasLat = data.latitude != null;
+    const hasLng = data.longitude != null;
+    if (hasLat !== hasLng) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [hasLat ? "longitude" : "latitude"],
+        message: "Latitude and longitude must be provided together.",
+      });
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Pure mappers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+export const BLANK_VALUES: EventFormValues = {
+  title: "",
+  slug: "",
+  summary: "",
+  detail: "",
+  event_type: "milestone",
+  importance: 5,
+  location: "",
+  latitude: null,
+  longitude: null,
+  temporal_data: null,
+  end_temporal_data: null,
+  timeline_id: undefined,
+  appears_in: [],
+  detail_timeline_id: undefined,
+  metadata: undefined,
+};
+
+/** Coerce stored JSON to TemporalData, treating invalid/empty (`{}`) as null. */
+export function toTemporalOrNull(json: unknown): TemporalData | null {
+  const result = temporalDataSchema.safeParse(json);
+  return result.success ? result.data : null;
+}
+
+/** Read a numeric coordinate out of the stored `spatial_data` JSONB. */
+export function readCoordinate(
+  spatial: unknown,
+  key: "lat" | "lng",
+): number | null {
+  if (spatial && typeof spatial === "object" && !Array.isArray(spatial)) {
+    const value = (spatial as Record<string, unknown>)[key];
+    return typeof value === "number" && Number.isFinite(value) ? value : null;
+  }
+  return null;
+}
+
+/** Recombine the two scalar inputs back into a `spatial_data` blob. */
+export function toSpatialData(
+  latitude: number | null,
+  longitude: number | null,
+): Record<string, number> | undefined {
+  if (latitude == null || longitude == null) return undefined;
+  return { lat: latitude, lng: longitude };
+}
+
+export function mapRowToFormValues(
+  row: EventWithRelations,
+  appearsIn: string[],
+): EventFormValues {
+  return {
+    title: row.title,
+    slug: row.slug,
+    summary: row.summary ?? "",
+    detail: row.detail ?? "",
+    event_type: (row.event_type as EventType | null) ?? "milestone",
+    importance: row.importance ?? 5,
+    location: row.location ?? "",
+    latitude: readCoordinate(row.spatial_data, "lat"),
+    longitude: readCoordinate(row.spatial_data, "lng"),
+    // Legacy rows may still contain '{}' JSON from migration defaults; treat
+    // anything that isn't real TemporalData as null so the editor doesn't render
+    // a garbage "undefined …" value.
+    temporal_data: toTemporalOrNull(row.temporal_data),
+    end_temporal_data: toTemporalOrNull(row.end_temporal_data),
+    timeline_id: row.timeline_id ?? undefined,
+    appears_in: appearsIn,
+    detail_timeline_id: row.detail_timeline_id ?? undefined,
+    metadata: (row.metadata as Record<string, unknown> | null) ?? undefined,
+  };
+}
+
+/** Drops empty-string optionals so we never persist "" for nullable text. */
+function toPersistedFields(values: EventFormValues) {
+  return {
+    title: values.title,
+    summary: values.summary || undefined,
+    detail: values.detail || undefined,
+    event_type: values.event_type,
+    importance: values.importance,
+    location: values.location || undefined,
+    temporal_data: values.temporal_data as TemporalData,
+    end_temporal_data: values.end_temporal_data ?? null,
+    timeline_id: values.timeline_id ?? null,
+    detail_timeline_id: values.detail_timeline_id ?? null,
+    metadata: values.metadata,
+  };
+}
+
+export function toCreateInput(values: EventFormValues): CreateEventInput {
+  return {
+    ...toPersistedFields(values),
+    spatial_data: toSpatialData(values.latitude, values.longitude),
+    slug: values.slug || undefined,
+  };
+}
+
+export function toUpdateData(values: EventFormValues): Partial<EventInput> {
+  return {
+    ...toPersistedFields(values),
+    // On update an empty `{}` clears any previously stored coordinates, whereas
+    // `undefined` would leave them untouched.
+    spatial_data: toSpatialData(values.latitude, values.longitude) ?? {},
+    slug: values.slug,
+  };
+}
+
+/** Computes the timeline_events junction membership diff for an edit save. */
+export function diffAppearsIn(
+  initial: string[],
+  next: string[],
+): { toAdd: string[]; toRemove: string[] } {
+  const initialSet = new Set(initial);
+  const nextSet = new Set(next);
+  return {
+    toAdd: next.filter((id) => !initialSet.has(id)),
+    toRemove: initial.filter((id) => !nextSet.has(id)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------------------
+
+const LABEL_CLASS = "mb-1.5 block text-sm font-medium text-foreground";
+const INPUT_CLASS =
+  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-4">
+      <h2 className="mb-1.5 font-display text-sm font-normal text-foreground">
+        {children}
+      </h2>
+      <Separator />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Timeline pickers
+// ---------------------------------------------------------------------------
+
+type ServiceClient = Parameters<typeof useTimelines>[0];
+type TimelineOption = { id: string; title: string };
+
+/** Single-select timeline combobox (primary timeline + expands-into). */
+function TimelinePicker({
+  options,
+  isPending,
+  value,
+  onChange,
+  placeholder,
+  excludeIds = [],
+  allowClear = false,
+}: {
+  options: TimelineOption[];
+  isPending: boolean;
+  value: string | undefined;
+  onChange: (id: string | undefined) => void;
+  placeholder: string;
+  excludeIds?: string[];
+  allowClear?: boolean;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const visible = options.filter((o) => !excludeIds.includes(o.id));
+  const selected = options.find((o) => o.id === value);
+  const selectedLabel = selected?.title ?? (value ? "Selected timeline" : "");
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="secondary"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "w-full justify-between font-normal",
+            !value && "text-muted-foreground",
+          )}
+        >
+          {selectedLabel || placeholder}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput placeholder="Search timelines…" />
+          <CommandList>
+            <CommandEmpty>
+              {isPending ? "Loading…" : "No timelines found."}
+            </CommandEmpty>
+            <CommandGroup>
+              {allowClear && (
+                <CommandItem
+                  value="__none__"
+                  onSelect={() => {
+                    onChange(undefined);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value ? "opacity-0" : "opacity-100",
+                    )}
+                  />
+                  — none —
+                </CommandItem>
+              )}
+              {visible.map((option) => (
+                <CommandItem
+                  key={option.id}
+                  value={option.title}
+                  onSelect={() => {
+                    onChange(option.id === value ? undefined : option.id);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === option.id ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  {option.title}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/** Multi-select for "also appears in" — selected timelines render as chips. */
+function TimelineMultiPicker({
+  options,
+  isPending,
+  value,
+  onChange,
+  excludeIds = [],
+}: {
+  options: TimelineOption[];
+  isPending: boolean;
+  value: string[];
+  onChange: (ids: string[]) => void;
+  excludeIds?: string[];
+}) {
+  const [open, setOpen] = React.useState(false);
+  const visible = options.filter((o) => !excludeIds.includes(o.id));
+  const byId = React.useMemo(
+    () => new Map(options.map((o) => [o.id, o])),
+    [options],
+  );
+
+  const toggle = (id: string) => {
+    onChange(
+      value.includes(id) ? value.filter((v) => v !== id) : [...value, id],
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {value.map((id) => (
+            <Badge key={id} variant="secondary" className="gap-1">
+              {byId.get(id)?.title ?? "Timeline"}
+              <button
+                type="button"
+                aria-label={`Remove ${byId.get(id)?.title ?? "timeline"}`}
+                onClick={() => toggle(id)}
+                className="rounded-sm hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="font-normal text-muted-foreground"
+          >
+            + Add timeline
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-72 p-0" align="start">
+          <Command>
+            <CommandInput placeholder="Search timelines…" />
+            <CommandList>
+              <CommandEmpty>
+                {isPending ? "Loading…" : "No timelines found."}
+              </CommandEmpty>
+              <CommandGroup>
+                {visible.map((option) => (
+                  <CommandItem
+                    key={option.id}
+                    value={option.title}
+                    onSelect={() => toggle(option.id)}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        value.includes(option.id) ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {option.title}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+type Props =
+  | { mode: "create" }
+  | { mode: "edit"; userId: string; slug: string };
+
+export function EventFormClient(props: Props) {
+  const router = useRouter();
+  const addToast = useUiStore((s) => s.addToast);
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+
+  const createEvent = useCreateEvent(client);
+  const updateEvent = useUpdateEvent(client);
+  const addToTimeline = useAddEventToTimeline(client);
+  const removeFromTimeline = useRemoveEventFromTimeline(client);
+  const createTimeline = useCreateTimeline(client);
+
+  // Timelines available to the pickers. RLS already constrains writes — linking
+  // to a timeline the user can't write to will fail at save and surface a toast.
+  const { data: timelines, isPending: timelinesPending } = useTimelines(
+    client as ServiceClient,
+    {},
+  );
+  const timelineOptions: TimelineOption[] = React.useMemo(
+    () => (timelines ?? []).map((t) => ({ id: t.id, title: t.title })),
+    [timelines],
+  );
+
+  const isEdit = props.mode === "edit";
+  const editQuery = useEventBySlug(
+    client,
+    isEdit ? props.userId : "",
+    isEdit ? props.slug : "",
+    { enabled: isEdit },
+  );
+  const linksQuery = useEventTimelineLinks(client, editQuery.data?.id ?? "", {
+    enabled: isEdit && editQuery.data?.id !== undefined,
+  });
+
+  const cancelHref =
+    props.mode === "edit" ? `/events/${props.slug}` : "/events";
+
+  const form = useForm<EventFormValues>({
+    resolver: zodResolver(eventFormSchema) as Resolver<EventFormValues>,
+    defaultValues: BLANK_VALUES,
+    mode: "onTouched",
+  });
+
+  // Snapshot of the persisted "also appears in" set, for the edit-save diff.
+  const initialAppearsInRef = React.useRef<string[]>([]);
+
+  // Hydrate the form once both the event row and its junction links resolve
+  // (guard against re-hydration on background refetch wiping user edits).
+  const hydratedRef = React.useRef(false);
+  const editRow = editQuery.data;
+  const links = linksQuery.data;
+  React.useEffect(() => {
+    if (!isEdit || hydratedRef.current) return;
+    if (editRow === undefined || links === undefined) return;
+    form.reset(mapRowToFormValues(editRow, links));
+    initialAppearsInRef.current = links;
+    hydratedRef.current = true;
+  }, [isEdit, editRow, links, form]);
+
+  const isDirty = form.formState.isDirty;
+  const guard = useUnsavedChangesGuard(isDirty);
+
+  const addAnotherRef = React.useRef(false);
+
+  // -------------------------------------------------------------------------
+  // Junction reconciliation ("also appears in")
+  // -------------------------------------------------------------------------
+
+  const syncAppearsIn = React.useCallback(
+    async (eventId: string, toAdd: string[], toRemove: string[]) => {
+      await Promise.all([
+        ...toAdd.map((timelineId) =>
+          addToTimeline.mutateAsync({ timelineId, eventId }),
+        ),
+        ...toRemove.map((timelineId) =>
+          removeFromTimeline.mutateAsync({ timelineId, eventId }),
+        ),
+      ]);
+    },
+    [addToTimeline, removeFromTimeline],
+  );
+
+  // -------------------------------------------------------------------------
+  // Save flow
+  // -------------------------------------------------------------------------
+
+  const finalize = React.useCallback(
+    (slug: string, addAnother: boolean, values: EventFormValues) => {
+      if (addAnother) {
+        // Curated carry-forward per the wireframe: event_type + primary timeline.
+        form.reset({
+          ...BLANK_VALUES,
+          event_type: values.event_type,
+          timeline_id: values.timeline_id,
+        });
+        initialAppearsInRef.current = [];
+        return;
+      }
+      router.push(`/events/${slug}`);
+    },
+    [form, router],
+  );
+
+  const onValid = React.useCallback(
+    async (values: EventFormValues) => {
+      const addAnother = addAnotherRef.current;
+      addAnotherRef.current = false;
+
+      try {
+        let savedSlug: string;
+        let savedId: string;
+
+        if (isEdit) {
+          const row = await updateEvent.mutateAsync({
+            id: editRow!.id,
+            data: toUpdateData(values),
+          });
+          savedSlug = row.slug;
+          savedId = row.id;
+        } else {
+          const row = await createEvent.mutateAsync(toCreateInput(values));
+          savedSlug = row.slug;
+          savedId = row.id;
+        }
+
+        // Reset to the saved values so isDirty clears before any redirect.
+        form.reset(values);
+
+        // Reconcile "also appears in" junction rows. A failure here doesn't
+        // undo the saved event, so report it without blocking the redirect.
+        const { toAdd, toRemove } = isEdit
+          ? diffAppearsIn(initialAppearsInRef.current, values.appears_in)
+          : { toAdd: values.appears_in, toRemove: [] as string[] };
+        let junctionFailed = false;
+        if (toAdd.length > 0 || toRemove.length > 0) {
+          try {
+            await syncAppearsIn(savedId, toAdd, toRemove);
+            initialAppearsInRef.current = values.appears_in;
+          } catch {
+            junctionFailed = true;
+          }
+        }
+
+        addToast({
+          id: `event-saved-${Date.now()}`,
+          message: junctionFailed
+            ? "Event saved, but some “also appears in” links failed — retry from the event page."
+            : isEdit
+              ? "Event updated."
+              : "Event created.",
+          variant: junctionFailed ? "warning" : "success",
+        });
+
+        finalize(savedSlug, addAnother, values);
+      } catch {
+        // Mutation errors surface via the form-level Alert below.
+      }
+    },
+    [
+      isEdit,
+      editRow,
+      updateEvent,
+      createEvent,
+      form,
+      addToast,
+      finalize,
+      syncAppearsIn,
+    ],
+  );
+
+  const submit = React.useCallback(
+    (opts?: { addAnother?: boolean }) => {
+      // SlugField generates the slug from the title on a debounce, so a quick
+      // title→Save can fire before it lands and trip the schema's slug rule.
+      // Flush it synchronously here so a quick-save never hard-fails on timing.
+      const { slug, title } = form.getValues();
+      if (slug.trim().length === 0 && title.trim().length > 0) {
+        try {
+          form.setValue("slug", generateSlug(title), { shouldValidate: false });
+        } catch {
+          // Non-sluggable title (e.g. emoji-only) — let validation surface it.
+        }
+      }
+      addAnotherRef.current = opts?.addAnother ?? false;
+      void form.handleSubmit(onValid)();
+    },
+    [form, onValid],
+  );
+
+  // -------------------------------------------------------------------------
+  // "Expands into" → create a sub-timeline with inherited defaults
+  // -------------------------------------------------------------------------
+
+  const handleCreateSubTimeline = React.useCallback(async () => {
+    const { title, temporal_data, end_temporal_data } = form.getValues();
+    if (!temporal_data) {
+      addToast({
+        id: `subtimeline-needs-date-${Date.now()}`,
+        message: "Set the event's start date before creating a sub-timeline.",
+        variant: "warning",
+      });
+      return;
+    }
+    try {
+      const created = await createTimeline.mutateAsync({
+        title: title.trim() ? `${title.trim()} — detail` : "Untitled detail",
+        temporal_data,
+        end_temporal_data: end_temporal_data ?? null,
+      });
+      form.setValue("detail_timeline_id", created.id, { shouldDirty: true });
+      addToast({
+        id: `subtimeline-created-${Date.now()}`,
+        message: "Sub-timeline created and linked. Save to persist the link.",
+        variant: "success",
+      });
+    } catch {
+      addToast({
+        id: `subtimeline-failed-${Date.now()}`,
+        message: "Couldn't create the sub-timeline.",
+        variant: "error",
+      });
+    }
+  }, [form, createTimeline, addToast]);
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  const watchedTitle = useWatch({ control: form.control, name: "title" });
+  const watchedPrimary = useWatch({
+    control: form.control,
+    name: "timeline_id",
+  });
+  const watchedAppearsIn = useWatch({
+    control: form.control,
+    name: "appears_in",
+  });
+  const slugMode = isEdit ? "edit" : "create";
+  const isSaving = createEvent.isPending || updateEvent.isPending;
+
+  const mutationError = createEvent.error ?? updateEvent.error ?? null;
+  const hasFieldErrors = Object.keys(form.formState.errors).length > 0;
+
+  if (isEdit && (editQuery.isPending || linksQuery.isPending)) {
+    return (
+      <div className="space-y-4 p-6">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (isEdit && editQuery.isError) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive" role="alert">
+          <AlertTitle>Couldn’t load this event</AlertTitle>
+          <AlertDescription>
+            {editQuery.error instanceof Error
+              ? editQuery.error.message
+              : "Unknown error."}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const breadcrumbs = isEdit
+    ? [
+        { label: "Events", href: "/events" },
+        { label: watchedTitle || "Edit event" },
+      ]
+    : [{ label: "Events", href: "/events" }, { label: "New event" }];
+
+  // Expands-into excludes the event's own home/appears-in timelines (a soft,
+  // client-side complement to the service-layer fractal-cycle guard).
+  const expandsIntoExclude = [
+    ...(watchedPrimary ? [watchedPrimary] : []),
+    ...(watchedAppearsIn ?? []),
+  ];
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex h-full flex-col overflow-hidden"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        {/* ── Toolbar ──────────────────────────────────────────────────── */}
+        <div className="flex shrink-0 items-center justify-between border-b border-border px-6 py-3">
+          <nav className="flex items-center gap-1 text-sm text-foreground-muted">
+            {breadcrumbs.map((crumb, i) => (
+              <React.Fragment key={crumb.label}>
+                {i > 0 && (
+                  <span aria-hidden className="mx-1">
+                    ▸
+                  </span>
+                )}
+                {crumb.href ? (
+                  <button
+                    type="button"
+                    className="hover:text-foreground"
+                    onClick={() => guard.requestNavigate(crumb.href!)}
+                  >
+                    {crumb.label}
+                  </button>
+                ) : (
+                  <span className="text-foreground">{crumb.label}</span>
+                )}
+              </React.Fragment>
+            ))}
+          </nav>
+
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => guard.requestNavigate(cancelHref)}
+            >
+              Cancel
+            </Button>
+            <SaveDropdown
+              onSave={() => submit()}
+              disabled={isSaving}
+              onSaveAndAddAnother={
+                isEdit ? undefined : () => submit({ addAnother: true })
+              }
+            />
+          </div>
+        </div>
+
+        {/* ── Body ─────────────────────────────────────────────────────── */}
+        <div className="flex flex-1 overflow-auto">
+          {/* Left column — main form */}
+          <div className="flex-1 space-y-8 overflow-auto px-6 py-6">
+            {(hasFieldErrors || mutationError) && (
+              <Alert variant="destructive" role="alert">
+                <AlertTitle>
+                  {mutationError
+                    ? "Couldn’t save this event"
+                    : "Please fix the highlighted fields"}
+                </AlertTitle>
+                <AlertDescription>
+                  {mutationError instanceof Error
+                    ? mutationError.message
+                    : "Some fields need your attention before saving."}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {/* Identity */}
+            <section>
+              <SectionHeading>Identity</SectionHeading>
+              <div className="space-y-5">
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>
+                        Title{" "}
+                        <span
+                          aria-label="required"
+                          className="text-destructive"
+                        >
+                          *
+                        </span>
+                      </FormLabel>
+                      <FormControl>
+                        <input
+                          {...field}
+                          className={INPUT_CLASS}
+                          placeholder="Event title"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <Controller
+                  control={form.control}
+                  name="event_type"
+                  render={({ field }) => (
+                    <div>
+                      <Label htmlFor="event-type" className={LABEL_CLASS}>
+                        Type{" "}
+                        <span
+                          aria-label="required"
+                          className="text-destructive"
+                        >
+                          *
+                        </span>
+                      </Label>
+                      <select
+                        id="event-type"
+                        className={INPUT_CLASS}
+                        value={field.value}
+                        onChange={(e) =>
+                          field.onChange(e.target.value as EventType)
+                        }
+                      >
+                        {eventTypeEnum.options.map((value) => (
+                          <option key={value} value={value}>
+                            {value.charAt(0).toUpperCase() + value.slice(1)}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="summary"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>Summary</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          placeholder="One-paragraph summary…"
+                          className="min-h-20"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="detail"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>Detail</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          placeholder="Long-form narrative…"
+                          className="min-h-35"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </section>
+
+            {/* When */}
+            <section>
+              <SectionHeading>When</SectionHeading>
+              <div className="space-y-4">
+                <Controller
+                  control={form.control}
+                  name="temporal_data"
+                  render={({ field, fieldState }) => (
+                    <TemporalInput
+                      label="Start date"
+                      required
+                      value={field.value}
+                      onChange={field.onChange}
+                      error={fieldState.error?.message}
+                    />
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name="end_temporal_data"
+                  render={({ field, fieldState }) => (
+                    <TemporalInput
+                      label="End date"
+                      value={field.value}
+                      onChange={field.onChange}
+                      error={fieldState.error?.message}
+                    />
+                  )}
+                />
+              </div>
+            </section>
+
+            {/* Where */}
+            <section>
+              <SectionHeading>Where</SectionHeading>
+              <div className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="location"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>Location</FormLabel>
+                      <FormControl>
+                        <input
+                          {...field}
+                          className={INPUT_CLASS}
+                          placeholder="e.g. Paris, France"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="flex gap-4">
+                  <FormField
+                    control={form.control}
+                    name="latitude"
+                    render={({ field }) => (
+                      <FormItem className="flex-1">
+                        <FormLabel className={LABEL_CLASS}>Latitude</FormLabel>
+                        <FormControl>
+                          <input
+                            type="number"
+                            step="any"
+                            min={-90}
+                            max={90}
+                            className={INPUT_CLASS}
+                            placeholder="48.8566"
+                            value={field.value ?? ""}
+                            onChange={(e) =>
+                              field.onChange(
+                                e.target.value === ""
+                                  ? null
+                                  : e.target.valueAsNumber,
+                              )
+                            }
+                            onBlur={field.onBlur}
+                            name={field.name}
+                            ref={field.ref}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="longitude"
+                    render={({ field }) => (
+                      <FormItem className="flex-1">
+                        <FormLabel className={LABEL_CLASS}>Longitude</FormLabel>
+                        <FormControl>
+                          <input
+                            type="number"
+                            step="any"
+                            min={-180}
+                            max={180}
+                            className={INPUT_CLASS}
+                            placeholder="2.3522"
+                            value={field.value ?? ""}
+                            onChange={(e) =>
+                              field.onChange(
+                                e.target.value === ""
+                                  ? null
+                                  : e.target.valueAsNumber,
+                              )
+                            }
+                            onBlur={field.onBlur}
+                            name={field.name}
+                            ref={field.ref}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </div>
+            </section>
+
+            {/* Timelines */}
+            <section>
+              <SectionHeading>Timelines</SectionHeading>
+              <div className="space-y-5">
+                <Controller
+                  control={form.control}
+                  name="timeline_id"
+                  render={({ field }) => (
+                    <div>
+                      <Label className={LABEL_CLASS}>Primary timeline</Label>
+                      <TimelinePicker
+                        options={timelineOptions}
+                        isPending={timelinesPending}
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Select the home timeline…"
+                        allowClear
+                      />
+                      <p className="mt-1 text-xs text-foreground-muted">
+                        The event’s home timeline. Drives collaborator access;
+                        an event with no primary timeline is owner-only.
+                      </p>
+                    </div>
+                  )}
+                />
+
+                <Controller
+                  control={form.control}
+                  name="appears_in"
+                  render={({ field }) => (
+                    <div>
+                      <Label className={LABEL_CLASS}>Also appears in</Label>
+                      <TimelineMultiPicker
+                        options={timelineOptions}
+                        isPending={timelinesPending}
+                        value={field.value}
+                        onChange={field.onChange}
+                        excludeIds={watchedPrimary ? [watchedPrimary] : []}
+                      />
+                      <p className="mt-1 text-xs text-foreground-muted">
+                        Additional timelines this event surfaces in, without
+                        changing its home.
+                      </p>
+                    </div>
+                  )}
+                />
+
+                <Controller
+                  control={form.control}
+                  name="detail_timeline_id"
+                  render={({ field, fieldState }) => (
+                    <div>
+                      <Label className={LABEL_CLASS}>
+                        Expands into (sub-timeline)
+                      </Label>
+                      <div className="flex gap-2">
+                        <div className="flex-1">
+                          <TimelinePicker
+                            options={timelineOptions}
+                            isPending={timelinesPending}
+                            value={field.value}
+                            onChange={field.onChange}
+                            placeholder="— none —"
+                            excludeIds={expandsIntoExclude}
+                            allowClear
+                          />
+                        </div>
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="md"
+                          className="shrink-0 px-3"
+                          aria-label="Create a sub-timeline from this event"
+                          title="Create a sub-timeline from this event"
+                          disabled={createTimeline.isPending}
+                          onClick={handleCreateSubTimeline}
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </Button>
+                      </div>
+                      <p className="mt-1 text-xs text-foreground-muted">
+                        The fractal drill-down: the sub-timeline this event
+                        decomposes into. ↗ mints a new one seeded from this
+                        event.
+                      </p>
+                      {fieldState.error && (
+                        <p className="mt-1 text-xs text-destructive">
+                          {fieldState.error.message}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                />
+              </div>
+            </section>
+
+            {/* Advanced */}
+            <section>
+              <details>
+                <summary className="cursor-pointer select-none text-sm text-foreground-muted hover:text-foreground">
+                  ▸ Advanced (metadata, spatial JSON)
+                </summary>
+                <div className="mt-3 space-y-4 rounded-md border border-border bg-surface/30 px-4 py-3">
+                  <p className="text-xs text-foreground-muted">
+                    A <code>metadata</code> / spatial JSON editor is a later,
+                    power-user enhancement. Coordinates are captured above.
+                  </p>
+                </div>
+              </details>
+            </section>
+          </div>
+
+          {/* Right column — metadata rail */}
+          <aside className="w-72 shrink-0 space-y-6 border-l border-border px-5 py-6">
+            <Controller
+              control={form.control}
+              name="slug"
+              render={({ field }) => (
+                <SlugField
+                  label="Slug"
+                  value={field.value}
+                  onChange={field.onChange}
+                  sourceValue={watchedTitle}
+                  mode={slugMode}
+                  warning={
+                    isEdit
+                      ? "Changing the slug will break existing links to this event."
+                      : undefined
+                  }
+                  description="Auto-generated from title."
+                />
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="importance"
+              render={({ field }) => (
+                <div>
+                  <Label className={LABEL_CLASS}>
+                    Importance{" "}
+                    <span className="text-foreground-muted">
+                      ({field.value})
+                    </span>
+                  </Label>
+                  <Slider
+                    min={1}
+                    max={10}
+                    step={1}
+                    value={[field.value]}
+                    onValueChange={(v) => field.onChange(v[0])}
+                    aria-label="Importance (1 to 10)"
+                  />
+                  <p className="mt-1 text-xs text-foreground-muted">
+                    1 (minor) – 10 (pivotal).
+                  </p>
+                </div>
+              )}
+            />
+
+            <p className="border-t border-border pt-4 text-xs text-foreground-muted">
+              New events are saved as drafts. You can publish from the event’s
+              page.
+            </p>
+          </aside>
+        </div>
+      </form>
+
+      {/* ── Confirm: discard unsaved changes ──────────────────────────── */}
+      <Dialog
+        open={guard.isConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) guard.cancelNavigation();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Discard unsaved changes?</DialogTitle>
+            <DialogDescription>
+              You have unsaved changes. If you leave now, they’ll be lost.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={guard.cancelNavigation}
+            >
+              Keep editing
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={guard.confirmNavigation}
+            >
+              Discard
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Form>
+  );
+}

--- a/apps/admin/app/(protected)/events/_components/event-form-client.tsx
+++ b/apps/admin/app/(protected)/events/_components/event-form-client.tsx
@@ -565,18 +565,23 @@ export function EventFormClient(props: Props) {
   // Snapshot of the persisted "also appears in" set, for the edit-save diff.
   const initialAppearsInRef = React.useRef<string[]>([]);
 
-  // Hydrate the form once both the event row and its junction links resolve
-  // (guard against re-hydration on background refetch wiping user edits).
+  // Hydrate the form once the event row is loaded and the junction-links query
+  // has *settled* — success or error. If the links query fails we still hydrate
+  // (with an empty "also appears in" set) so the rest of the form is usable;
+  // the failure is surfaced as a non-blocking warning on that field below.
+  // Guard against re-hydration on background refetch wiping user edits.
   const hydratedRef = React.useRef(false);
   const editRow = editQuery.data;
   const links = linksQuery.data;
+  const linksSettled = linksQuery.isSuccess || linksQuery.isError;
   React.useEffect(() => {
     if (!isEdit || hydratedRef.current) return;
-    if (editRow === undefined || links === undefined) return;
-    form.reset(mapRowToFormValues(editRow, links));
-    initialAppearsInRef.current = links;
+    if (editRow === undefined || !linksSettled) return;
+    const resolvedLinks = links ?? [];
+    form.reset(mapRowToFormValues(editRow, resolvedLinks));
+    initialAppearsInRef.current = resolvedLinks;
     hydratedRef.current = true;
-  }, [isEdit, editRow, links, form]);
+  }, [isEdit, editRow, linksSettled, links, form]);
 
   const isDirty = form.formState.isDirty;
   const guard = useUnsavedChangesGuard(isDirty);
@@ -1136,6 +1141,13 @@ export function EventFormClient(props: Props) {
                         Additional timelines this event surfaces in, without
                         changing its home.
                       </p>
+                      {isEdit && linksQuery.isError && (
+                        <p className="mt-1 text-xs text-destructive">
+                          Couldn’t load the current “also appears in” timelines
+                          — saving now may not preserve them. Reload before
+                          editing this field.
+                        </p>
+                      )}
                     </div>
                   )}
                 />

--- a/apps/admin/app/(protected)/events/new/page.tsx
+++ b/apps/admin/app/(protected)/events/new/page.tsx
@@ -1,0 +1,9 @@
+import { EventFormClient } from "../_components/event-form-client";
+
+export const metadata = {
+  title: "New event",
+};
+
+export default function NewEventPage() {
+  return <EventFormClient mode="create" />;
+}

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -615,6 +615,19 @@ describe("createEvent", () => {
     expect(result).toEqual(sampleEvent);
   });
 
+  it("throws when detail_timeline_id equals timeline_id (fractal cycle)", async () => {
+    const client = makeCreateClient({ data: sampleEvent, error: null });
+    await expect(
+      createEvent(client, {
+        ...validInput,
+        timeline_id: "timeline-1",
+        detail_timeline_id: "timeline-1",
+      }),
+    ).rejects.toThrow(
+      "EventService.createEvent: detail_timeline_id cannot equal timeline_id (fractal cycle)",
+    );
+  });
+
   it("throws when no authenticated user", async () => {
     const client = makeClient({
       authUser: { data: { user: null }, error: null },

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -403,6 +403,20 @@ export async function createEvent(
   client: SupabaseClient<Database>,
   data: CreateEventInput,
 ): Promise<EventRow> {
+  // Forward-fractal guard, mirroring updateEvent: an event must not expand into
+  // its own primary timeline. On create there are no descendants yet, so the
+  // self-reference equality is the only reachable cycle (the transitive check in
+  // assertNoDetailTimelineCycle needs an existing row id and runs on update).
+  if (
+    data.detail_timeline_id != null &&
+    data.timeline_id != null &&
+    data.detail_timeline_id === data.timeline_id
+  ) {
+    throw new Error(
+      "EventService.createEvent: detail_timeline_id cannot equal timeline_id (fractal cycle)",
+    );
+  }
+
   // Identify the current user so we can scope slug collision checks
   const {
     data: { user },

--- a/packages/services/src/modules/timeline-service.test.ts
+++ b/packages/services/src/modules/timeline-service.test.ts
@@ -21,6 +21,7 @@ import {
   addEventToTimeline,
   removeEventFromTimeline,
   setTimelineEventSortOrder,
+  getEventTimelineLinks,
   addMediaToTimeline,
 } from "./timeline-service";
 
@@ -1050,6 +1051,38 @@ describe("removeEventFromTimeline", () => {
     await expect(
       removeEventFromTimeline(client, "timeline-1", "event-1"),
     ).rejects.toThrow("TimelineService.removeEventFromTimeline: unlink failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEventTimelineLinks
+// ---------------------------------------------------------------------------
+
+describe("getEventTimelineLinks", () => {
+  it("returns the timeline ids an event appears in", async () => {
+    const client = makeClient({
+      fromResult: {
+        data: [{ timeline_id: "timeline-1" }, { timeline_id: "timeline-2" }],
+        error: null,
+      },
+    });
+    const result = await getEventTimelineLinks(client, "event-1");
+    expect(result).toEqual(["timeline-1", "timeline-2"]);
+  });
+
+  it("returns an empty array when the event has no junction links", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    const result = await getEventTimelineLinks(client, "event-1");
+    expect(result).toEqual([]);
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "links failed" } },
+    });
+    await expect(getEventTimelineLinks(client, "event-1")).rejects.toThrow(
+      "TimelineService.getEventTimelineLinks: links failed",
+    );
   });
 });
 

--- a/packages/services/src/modules/timeline-service.ts
+++ b/packages/services/src/modules/timeline-service.ts
@@ -602,6 +602,26 @@ export async function removeEventFromTimeline(
   assertNoError(error, "removeEventFromTimeline");
 }
 
+/**
+ * Returns the ids of the timelines an event "also appears in" — i.e. its
+ * `timeline_events` junction memberships. This is the secondary, comparative
+ * membership only; it does NOT include the event's primary `events.timeline_id`
+ * home timeline. The event editor uses it to pre-populate the "also appears in"
+ * multi-select when editing an existing event.
+ */
+export async function getEventTimelineLinks(
+  client: SupabaseClient<Database>,
+  eventId: string,
+): Promise<string[]> {
+  const { data, error } = await client
+    .from("timeline_events")
+    .select("timeline_id")
+    .eq("event_id", eventId);
+
+  assertNoError(error, "getEventTimelineLinks");
+  return (data ?? []).map((row) => row.timeline_id);
+}
+
 // ---------------------------------------------------------------------------
 // Junction: timeline_media
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/hooks/use-timelines.test.tsx
+++ b/packages/ui/src/hooks/use-timelines.test.tsx
@@ -15,6 +15,7 @@ import {
   useAddCollaborator,
   useRemoveCollaborator,
   useUpdateCollaboratorRole,
+  useEventTimelineLinks,
   timelineKeys,
 } from "./use-timelines";
 
@@ -34,6 +35,8 @@ vi.mock("@repo/services/timeline-service", () => ({
   updateCollaboratorRole: vi.fn(),
   addEventToTimeline: vi.fn(),
   removeEventFromTimeline: vi.fn(),
+  setTimelineEventSortOrder: vi.fn(),
+  getEventTimelineLinks: vi.fn(),
   addMediaToTimeline: vi.fn(),
 }));
 
@@ -50,6 +53,7 @@ import {
   addCollaborator,
   removeCollaborator,
   updateCollaboratorRole,
+  getEventTimelineLinks,
 } from "@repo/services/timeline-service";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -119,6 +123,33 @@ describe("useTimelineCollaborators", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(getCollaborators).toHaveBeenCalledWith(mockClient, "tl-1");
+  });
+});
+
+describe("useEventTimelineLinks", () => {
+  it("calls getEventTimelineLinks with client and eventId", async () => {
+    vi.mocked(getEventTimelineLinks).mockResolvedValue([
+      "tl-1",
+      "tl-2",
+    ] as never);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useEventTimelineLinks(mockClient, "event-1"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getEventTimelineLinks).toHaveBeenCalledWith(mockClient, "event-1");
+    expect(result.current.data).toEqual(["tl-1", "tl-2"]);
+  });
+
+  it("uses the eventLinks query key", () => {
+    expect(timelineKeys.eventLinks("event-1")).toEqual([
+      "timelines",
+      "event-links",
+      "event-1",
+    ]);
   });
 });
 

--- a/packages/ui/src/hooks/use-timelines.tsx
+++ b/packages/ui/src/hooks/use-timelines.tsx
@@ -26,6 +26,7 @@ import {
   addEventToTimeline,
   removeEventFromTimeline,
   setTimelineEventSortOrder,
+  getEventTimelineLinks,
 } from "@repo/services/timeline-service";
 import type {
   TimelineFilters,
@@ -57,6 +58,9 @@ export const timelineKeys = {
   bySlug: (slug: string) => [...timelineKeys.all, "slug", slug] as const,
   collaborators: (id: string) =>
     [...timelineKeys.all, "collaborators", id] as const,
+  /** The "also appears in" timeline_events memberships for a given event. */
+  eventLinks: (eventId: string) =>
+    [...timelineKeys.all, "event-links", eventId] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -143,6 +147,24 @@ export function useTimelineCollaborators(
   return useQuery({
     queryKey: timelineKeys.collaborators(timelineId),
     queryFn: () => getCollaborators(client, timelineId),
+    staleTime: 30_000,
+    ...options,
+  });
+}
+
+/**
+ * Fetch the ids of the timelines an event "also appears in" (its
+ * `timeline_events` junction memberships), for pre-populating the event
+ * editor's "also appears in" multi-select.
+ */
+export function useEventTimelineLinks(
+  client: ServiceClient,
+  eventId: string,
+  options?: Omit<UseQueryOptions<string[]>, "queryKey" | "queryFn">,
+) {
+  return useQuery({
+    queryKey: timelineKeys.eventLinks(eventId),
+    queryFn: () => getEventTimelineLinks(client, eventId),
     staleTime: 30_000,
     ...options,
   });

--- a/packages/ui/src/hooks/use-timelines.tsx
+++ b/packages/ui/src/hooks/use-timelines.tsx
@@ -160,7 +160,10 @@ export function useTimelineCollaborators(
 export function useEventTimelineLinks(
   client: ServiceClient,
   eventId: string,
-  options?: Omit<UseQueryOptions<string[]>, "queryKey" | "queryFn">,
+  options?: Omit<
+    UseQueryOptions<Awaited<ReturnType<typeof getEventTimelineLinks>>>,
+    "queryKey" | "queryFn"
+  >,
 ) {
   return useQuery({
     queryKey: timelineKeys.eventLinks(eventId),


### PR DESCRIPTION
Closes #46.

Implements the event create/edit editor: a shared two-column form backed by `useCreateEvent` / `useUpdateEvent`, mirroring the timeline editor's structure (RHF + `zodResolver`, form-only schema wrapping the canonical `eventSchema`, unsaved-changes guard, slug field, save-dropdown).

## What's included
- **Routes:** `events/new/page.tsx` and `events/[slug]/edit/page.tsx` (replaces the placeholder stub; resolves `userId` server-side).
- **Fields:** title, slug, summary, detail, `event_type` (off `eventTypeEnum`), importance (1–10 slider), location + split lat/lng coordinates, temporal start/end (`TemporalInput`).
- **Three distinct timeline relationships:**
  - Primary timeline (`timeline_id`) — single picker, the RLS source.
  - "Also appears in" (`timeline_events` junction) — multi-picker, diffed against the persisted set on save.
  - "Expands into" (`detail_timeline_id`) — single picker + `↗` shortcut that mints a sub-timeline seeded from the event.
- **Validation (Zod `superRefine`):** start required, end-before-start is a **hard error**, expands-into ≠ primary timeline, coordinates must come as a pair. Field- and form-level errors rendered.

## Acceptance criteria
- [x] Create form persists valid event rows
- [x] Edit form pre-populates and updates existing row
- [x] TemporalInput supports start/end; end-before-start is a hard error
- [x] Event-type selector matches the schema enum exactly
- [x] Importance control enforces 1..10
- [x] Primary timeline picker + "also appears in" multi-select work
- [x] "Expands into" picker works, with a create-new shortcut and fractal-cycle prevention
- [x] No `parent_event_id` field is present
- [x] Validation errors rendered at field and form level

## Decisions / deviations
- **"Expands into" is built, not hidden.** The issue marks it "blocked on #177", but **#177** (`detail_timeline_id`) and **#180** (drop `parent_event_id`) already shipped in migrations `00017`/`00019`. Fractal-cycle prevention is service-layer (`assertNoDetailTimelineCycle` + `updateEvent` guards); a soft client-side exclusion complements it.
- **Publish toggle omitted** (draft-only authoring) — matches the timeline-editor precedent and the publish-workflow ticket (#48); not in the AC.
- **Participants / categories / media** sub-editors are deferred to their own tickets (media is a Non-Goal here, #49); they're in the wireframe's full vision but not in #46's AC.

## Supporting changes
- New `getEventTimelineLinks` service fn + `useEventTimelineLinks` hook to pre-populate "also appears in" on edit.
- Defensive `detail_timeline_id === timeline_id` guard added to `createEvent` (matching the existing one in `updateEvent`).
- Tests for all three package-level additions. *(apps/admin has no test runner, so the form's exported mappers aren't unit-tested — same as the timeline editor.)*

## Validation
`pnpm format`, `check-types`, `lint`, `test` (333 ui + services), `test:coverage` (threshold met), and `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)