### PR TITLE
feat(ui): add motion tokens and motion classes (#255)

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -9,6 +9,7 @@
 
 @import "tailwindcss";
 @import "./tokens.css";
+@import "./motion.css";
 
 /* Scan packages/ui source files for Tailwind class names. The path is
  * relative to this file's location, walking up to the monorepo root and

--- a/packages/ui/src/styles/motion.css
+++ b/packages/ui/src/styles/motion.css
@@ -38,13 +38,16 @@
 /* enter-exit — overlays and panels.
  * Asymmetric: slow (320ms) decelerate in, fast (120ms) accelerate out, so
  * dismissal feels responsive. Driven by the Radix/shadcn `data-state`
- * convention (matches sheet/dialog), scale-from-95% + fade. */
+ * convention (matches sheet/dialog), scale-from-95% + fade. `both` holds the
+ * first/last keyframe outside the animation interval so the open state never
+ * flashes its pre-animation styles and the exit state stays faded-out while
+ * Radix Presence keeps the node mounted to finish the animation. */
 .enter-exit[data-state="open"] {
-  animation: enter-exit-in var(--duration-slow) var(--ease-decelerate);
+  animation: enter-exit-in var(--duration-slow) var(--ease-decelerate) both;
 }
 
 .enter-exit[data-state="closed"] {
-  animation: enter-exit-out var(--duration-fast) var(--ease-accelerate);
+  animation: enter-exit-out var(--duration-fast) var(--ease-accelerate) both;
 }
 
 @keyframes enter-exit-in {
@@ -84,6 +87,7 @@
  * before motion.css) so it wins when the query matches. */
 @media (prefers-reduced-motion: reduce) {
   :root {
+    --duration-instant: 0ms;
     --duration-fast: 0ms;
     --duration-base: 0ms;
     --duration-slow: 0ms;

--- a/packages/ui/src/styles/motion.css
+++ b/packages/ui/src/styles/motion.css
@@ -1,0 +1,92 @@
+/**
+ * Time Traveler motion classes — the five named motion classes for the public
+ * reader, bound to the motion-token scale in tokens.css.
+ *
+ * Source specs: ADR-0032 (motion-token scale + reduced-motion contract) and
+ * docs/design/public/06-mid-fidelity/motion-spec.md §2 (per-class choreography)
+ * / §5 (reduced-motion contract). Class → token bindings are fixed by those
+ * docs and must not be re-derived per consumer.
+ *
+ * Scope: this file provides the tokens/classes only. Applying classes to
+ * reader surfaces and the interruptible fractal-zoom viewport math are #65–#69.
+ */
+
+/* fractal-zoom — spatial continuity across temporal scale.
+ * deliberate (480ms) + standard. Transform only; opacity holds so the reader
+ * perceives one continuous space, not a page swap. The interruptible viewport
+ * interpolation is the canvas renderer's job (#65/#68, ADR-0032 IMP-003). */
+.fractal-zoom {
+  transition: transform var(--duration-deliberate) var(--ease-standard);
+  will-change: transform;
+}
+
+/* context-shift — lateral move between peer entities.
+ * slow (320ms) + standard. An 8px directional translate of the incoming region
+ * paired with an opacity rise; the consumer supplies the translate offset. */
+.context-shift {
+  transition:
+    transform var(--duration-slow) var(--ease-standard),
+    opacity var(--duration-slow) var(--ease-standard);
+}
+
+/* cross-fade — content swap that is not a spatial move.
+ * base (200ms) + standard. Opacity only; layout position stays stable. */
+.cross-fade {
+  transition: opacity var(--duration-base) var(--ease-standard);
+}
+
+/* enter-exit — overlays and panels.
+ * Asymmetric: slow (320ms) decelerate in, fast (120ms) accelerate out, so
+ * dismissal feels responsive. Driven by the Radix/shadcn `data-state`
+ * convention (matches sheet/dialog), scale-from-95% + fade. */
+.enter-exit[data-state="open"] {
+  animation: enter-exit-in var(--duration-slow) var(--ease-decelerate);
+}
+
+.enter-exit[data-state="closed"] {
+  animation: enter-exit-out var(--duration-fast) var(--ease-accelerate);
+}
+
+@keyframes enter-exit-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes enter-exit-out {
+  from {
+    opacity: 1;
+    transform: none;
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+
+/* ambient-presence — unobtrusive live-update signal (live dot, stale banner).
+ * Opacity only, <= base (200ms). NEVER pulse, blink, slide, or scale — it must
+ * never steal focus or scroll position (motion-spec §2.5, PRD §2.2.10). */
+.ambient-presence {
+  transition: opacity var(--duration-base) var(--ease-standard);
+}
+
+/* Reduced-motion contract (ADR-0032 IMP-002 / motion-spec §5): collapse every
+ * duration token to 0ms in ONE place. Because all classes above reference these
+ * vars, transitions become instant and the enter-exit keyframe animations
+ * complete in 0ms — no translate/scale interpolation runs. This media rule must
+ * follow the @theme-emitted :root variables (globals.css imports tokens.css
+ * before motion.css) so it wins when the query matches. */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --duration-fast: 0ms;
+    --duration-base: 0ms;
+    --duration-slow: 0ms;
+    --duration-deliberate: 0ms;
+  }
+}

--- a/packages/ui/src/styles/motion.stories.tsx
+++ b/packages/ui/src/styles/motion.stories.tsx
@@ -1,0 +1,242 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { durations, easings } from "./tokens";
+
+/**
+ * Motion foundations — demonstrates the five named motion classes from
+ * docs/design/public/06-mid-fidelity/motion-spec.md, bound to the motion-token
+ * scale (ADR-0032). Toggle the OS "reduce motion" setting to confirm every
+ * transition collapses to instant (the contract is enforced once at the token
+ * layer in motion.css).
+ */
+
+const durationRows: { cssVar: string; tsName: keyof typeof durations }[] = [
+  { cssVar: "--duration-instant", tsName: "instant" },
+  { cssVar: "--duration-fast", tsName: "fast" },
+  { cssVar: "--duration-base", tsName: "base" },
+  { cssVar: "--duration-slow", tsName: "slow" },
+  { cssVar: "--duration-deliberate", tsName: "deliberate" },
+];
+
+const easingRows: { cssVar: string; tsName: keyof typeof easings }[] = [
+  { cssVar: "--ease-standard", tsName: "standard" },
+  { cssVar: "--ease-decelerate", tsName: "decelerate" },
+  { cssVar: "--ease-accelerate", tsName: "accelerate" },
+];
+
+const TokenTable = () => (
+  <div className="flex flex-col gap-6">
+    <div>
+      <h3 className="mb-2 font-display text-base text-foreground">Durations</h3>
+      <div className="flex flex-col gap-1">
+        {durationRows.map((row) => (
+          <div key={row.cssVar} className="flex items-center gap-3 text-xs">
+            <code className="w-48 font-mono text-foreground">{row.cssVar}</code>
+            <code className="w-28 font-mono text-foreground-muted">
+              durations.{row.tsName}
+            </code>
+            <code className="font-mono text-foreground-subtle">
+              {durations[row.tsName]}
+            </code>
+          </div>
+        ))}
+      </div>
+    </div>
+    <div>
+      <h3 className="mb-2 font-display text-base text-foreground">Easing</h3>
+      <div className="flex flex-col gap-1">
+        {easingRows.map((row) => (
+          <div key={row.cssVar} className="flex items-center gap-3 text-xs">
+            <code className="w-48 font-mono text-foreground">{row.cssVar}</code>
+            <code className="w-28 font-mono text-foreground-muted">
+              easings.{row.tsName}
+            </code>
+            <code className="font-mono text-foreground-subtle">
+              {easings[row.tsName]}
+            </code>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+const DemoButton = ({
+  onClick,
+  children,
+}: {
+  onClick: () => void;
+  children: React.ReactNode;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20"
+  >
+    {children}
+  </button>
+);
+
+const Box = ({
+  className,
+  style,
+  label,
+}: {
+  className?: string;
+  style?: React.CSSProperties;
+  label: string;
+}) => (
+  <div
+    className={`flex h-20 w-40 items-center justify-center rounded-md border border-border bg-surface-2 text-xs text-foreground ${className ?? ""}`}
+    style={style}
+  >
+    {label}
+  </div>
+);
+
+const ClassDemo = ({
+  name,
+  binding,
+  children,
+}: {
+  name: string;
+  binding: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-3 rounded-md border border-border bg-surface p-4">
+    <div>
+      <code className="font-mono text-sm text-foreground">.{name}</code>
+      <span className="ml-2 text-xs text-foreground-muted">{binding}</span>
+    </div>
+    {children}
+  </div>
+);
+
+const meta: Meta = {
+  title: "Foundations/Motion",
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Tokens: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="mb-2 font-display text-xl text-foreground">
+          Motion tokens
+        </h2>
+        <p className="text-sm text-foreground-muted">
+          The duration + easing scale fixed by ADR-0032 / motion-spec §1. The
+          five motion classes bind to these names; under{" "}
+          <code className="font-mono text-xs">prefers-reduced-motion</code>{" "}
+          every duration collapses to 0ms in one place.
+        </p>
+      </div>
+      <TokenTable />
+    </div>
+  ),
+};
+
+export const Classes: Story = {
+  render: function ClassesStory() {
+    const [zoomed, setZoomed] = useState(false);
+    const [shifted, setShifted] = useState(false);
+    const [faded, setFaded] = useState(false);
+    const [open, setOpen] = useState(false);
+    const [present, setPresent] = useState(true);
+
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-foreground-muted">
+          Trigger each class and watch the timing. Enable your OS &ldquo;reduce
+          motion&rdquo; setting to confirm every change becomes instant.
+        </p>
+
+        <ClassDemo
+          name="fractal-zoom"
+          binding="deliberate (480ms) · standard — transform only"
+        >
+          <DemoButton onClick={() => setZoomed((v) => !v)}>
+            Toggle zoom
+          </DemoButton>
+          <Box
+            className="fractal-zoom"
+            style={{ transform: zoomed ? "scale(1.4)" : "scale(1)" }}
+            label="fractal-zoom"
+          />
+        </ClassDemo>
+
+        <ClassDemo
+          name="context-shift"
+          binding="slow (320ms) · standard — 8px translate + opacity"
+        >
+          <DemoButton onClick={() => setShifted((v) => !v)}>
+            Toggle shift
+          </DemoButton>
+          <Box
+            className="context-shift"
+            style={{
+              transform: shifted ? "translateX(8px)" : "translateX(0)",
+              opacity: shifted ? 1 : 0.4,
+            }}
+            label="context-shift"
+          />
+        </ClassDemo>
+
+        <ClassDemo
+          name="cross-fade"
+          binding="base (200ms) · standard — opacity only"
+        >
+          <DemoButton onClick={() => setFaded((v) => !v)}>
+            Toggle fade
+          </DemoButton>
+          <Box
+            className="cross-fade"
+            style={{ opacity: faded ? 0.2 : 1 }}
+            label="cross-fade"
+          />
+        </ClassDemo>
+
+        <ClassDemo
+          name="enter-exit"
+          binding="320ms decelerate in / 120ms accelerate out — scale + fade"
+        >
+          <DemoButton onClick={() => setOpen((v) => !v)}>
+            {open ? "Close" : "Open"}
+          </DemoButton>
+          {open && (
+            <div
+              data-state="open"
+              className="enter-exit flex h-20 w-40 items-center justify-center rounded-md border border-border bg-surface-2 text-xs text-foreground"
+            >
+              enter-exit (open)
+            </div>
+          )}
+          <span className="text-[10px] text-foreground-subtle">
+            Enter fires on mount; the symmetric exit animation needs Radix
+            presence (sheet/dialog) to keep the node mounted while it plays.
+          </span>
+        </ClassDemo>
+
+        <ClassDemo
+          name="ambient-presence"
+          binding="≤ base (200ms) · opacity only — never pulse/blink"
+        >
+          <DemoButton onClick={() => setPresent((v) => !v)}>
+            Toggle presence
+          </DemoButton>
+          <div className="flex items-center gap-2">
+            <span
+              className="ambient-presence h-2.5 w-2.5 rounded-full bg-era-ce"
+              style={{ opacity: present ? 1 : 0 }}
+              aria-hidden
+            />
+            <span className="text-xs text-foreground-muted">live dot</span>
+          </div>
+        </ClassDemo>
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/styles/motion.stories.tsx
+++ b/packages/ui/src/styles/motion.stories.tsx
@@ -144,7 +144,7 @@ export const Classes: Story = {
     const [zoomed, setZoomed] = useState(false);
     const [shifted, setShifted] = useState(false);
     const [faded, setFaded] = useState(false);
-    const [open, setOpen] = useState(false);
+    const [open, setOpen] = useState(true);
     const [present, setPresent] = useState(true);
 
     return (
@@ -206,18 +206,15 @@ export const Classes: Story = {
           <DemoButton onClick={() => setOpen((v) => !v)}>
             {open ? "Close" : "Open"}
           </DemoButton>
-          {open && (
-            <div
-              data-state="open"
-              className="enter-exit flex h-20 w-40 items-center justify-center rounded-md border border-border bg-surface-2 text-xs text-foreground"
-            >
-              enter-exit (open)
-            </div>
-          )}
-          <span className="text-[10px] text-foreground-subtle">
-            Enter fires on mount; the symmetric exit animation needs Radix
-            presence (sheet/dialog) to keep the node mounted while it plays.
-          </span>
+          {/* Node stays mounted; toggling data-state lets both halves of the
+              choreography (enter + exit) be observed. In real usage Radix
+              Presence supplies the same mounted-while-exiting behaviour. */}
+          <div
+            data-state={open ? "open" : "closed"}
+            className="enter-exit flex h-20 w-40 items-center justify-center rounded-md border border-border bg-surface-2 text-xs text-foreground"
+          >
+            enter-exit ({open ? "open" : "closed"})
+          </div>
         </ClassDemo>
 
         <ClassDemo

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -92,4 +92,23 @@
   --radius-md: 0.5rem;
   --radius-lg: 0.75rem;
 
+  /* ------------------------------------------------------------------ */
+  /* Motion — durations + easing (ADR-0032 / motion-spec §1).           */
+  /* Mirrors `durations`/`easings` in tokens.ts. The reduced-motion      */
+  /* collapse (resolving every duration to 0ms) lives in motion.css and  */
+  /* is enforced once at this token layer, not per component.            */
+  /* `--ease-*` is a Tailwind v4 theme namespace, so these also generate */
+  /* `ease-standard|decelerate|accelerate` utilities.                    */
+  /* ------------------------------------------------------------------ */
+
+  --duration-instant: 0ms;
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+  --duration-slow: 320ms;
+  --duration-deliberate: 480ms;
+
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-decelerate: cubic-bezier(0, 0, 0, 1);
+  --ease-accelerate: cubic-bezier(0.3, 0, 1, 1);
+
 }

--- a/packages/ui/src/styles/tokens.ts
+++ b/packages/ui/src/styles/tokens.ts
@@ -78,6 +78,30 @@ export const radii = {
   lg: "0.75rem",
 } as const;
 
+// Motion — duration scale (ADR-0032 / docs/design/public/06-mid-fidelity/
+// motion-spec.md §1.1). Semantic steps, not free values: the public reader's
+// five motion classes bind to these names instead of scattering millisecond
+// literals. `instant` is the reduced-motion target — under
+// `prefers-reduced-motion: reduce`, motion.css resolves every duration token
+// to 0ms in one place so no surface can ship un-reduced motion (ADR-0032
+// IMP-002, motion-spec §5).
+export const durations = {
+  instant: "0ms", // reduced-motion target; immediate state swap
+  fast: "120ms", // micro-feedback; the "out" half of enter-exit
+  base: "200ms", // cross-fade; facet/list/scale-toggle swaps; ambient-presence
+  slow: "320ms", // context-shift; overlay entrance (enter-exit "in")
+  deliberate: "480ms", // fractal-zoom camera flight — the only spatial transition
+} as const;
+
+// Motion — easing scale (ADR-0032 / motion-spec §1.2).
+export const easings = {
+  standard: "cubic-bezier(0.2, 0, 0, 1)", // default; fractal-zoom, context-shift, swaps
+  decelerate: "cubic-bezier(0, 0, 0, 1)", // entrances (enter half of enter-exit)
+  accelerate: "cubic-bezier(0.3, 0, 1, 1)", // exits (exit half of enter-exit)
+} as const;
+
 export type ColorToken = keyof typeof colors;
 export type FontToken = keyof typeof fonts;
 export type RadiusToken = keyof typeof radii;
+export type DurationToken = keyof typeof durations;
+export type EasingToken = keyof typeof easings;


### PR DESCRIPTION
## Summary

Implements the **R-X1 motion-token hard gate** (#255) from [ADR-0032](docs/adr/adr-0032-public-reader-motion-tokens.md) and the public-reader [motion-spec](docs/design/public/06-mid-fidelity/motion-spec.md). Adds a named duration/easing token scale to `@repo/ui` and binds the five named motion classes to it, so the reader (and admin) consume motion from tokens instead of hard-coded values. This must land before/with #65.

## Changes

- **`tokens.ts` / `tokens.css`** — add `--duration-{instant,fast,base,slow,deliberate}` (0/120/200/320/480ms) and `--ease-{standard,decelerate,accelerate}` following the existing dual-source token pattern (ADR-0022).
- **`motion.css` (new)** — the five classes (`fractal-zoom`, `context-shift`, `cross-fade`, `enter-exit`, `ambient-presence`) bound exactly to the spec'd tokens, plus a **single** `prefers-reduced-motion: reduce` rule that collapses every duration to 0ms at the token layer (ADR-0032 IMP-002) — no per-component handling.
- **`globals.css`** — import `motion.css` after `tokens.css` (order matters so the media override wins).
- **`motion.stories.tsx` (new)** — token reference table + interactive per-class demo (the manual verification surface).

## Out of scope (per ADR-0032)

- Re-pointing existing `sheet`/`dialog`/`shell` durations at the new tokens (IMP-004/NEG-002 — optional follow-up).
- Applying classes to reader surfaces + interruptible `fractal-zoom` viewport math (#65–#69).

## Acceptance criteria

- [x] Duration + easing tokens exist in `@repo/ui` global styles; resolve in both `apps/admin` and `apps/reader` (both import `@repo/ui/styles/globals.css`).
- [x] All five motion classes defined and documented with default duration/easing.
- [x] `prefers-reduced-motion: reduce` zeroes all durations and disables transform interpolation via one centralized rule.
- [x] No consumer needs to hard-code a duration/easing.
- [x] `pnpm verify` passes; lint stays at zero warnings.

## Verification

- `pnpm verify` (format, lint, check-types, test:coverage @ 80%, build) — all green.
- Manual (Storybook **Foundations/Motion**): each class animates at its spec'd timing; toggling OS "reduce motion" makes every transition instant — **confirmed working**.

Closes #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)