### PR TITLE
feat(reader): public reader app shell + routing skeleton (#258)

### DIFF
--- a/apps/reader/.env.local.example
+++ b/apps/reader/.env.local.example
@@ -1,0 +1,17 @@
+# Public reader app environment.
+#
+# The reader is an anonymous, read-only surface (ADR-0030). It uses the anon
+# Supabase key ONLY — there is intentionally NO SUPABASE_SERVICE_ROLE_KEY here,
+# and one must never be added (it would leak into the public client bundle).
+
+# Public Supabase URL for browser/client usage.
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+
+# Public anonymous key for browser/client usage.
+# NEEDS: Replace with your Supabase project's anon key for non-local environments.
+NEXT_PUBLIC_SUPABASE_ANON_KEY=REPLACE_WITH_SUPABASE_ANON_KEY
+
+# Base URL of the admin/auth app the reader deep-links OUT to for the single
+# "Sign in" affordance. Local dev falls back to the admin dev server on :3000.
+# Set this in staging/production (e.g. https://admin.yourproject.com).
+# NEXT_PUBLIC_ADMIN_URL=https://admin.yourproject.com

--- a/apps/reader/.gitignore
+++ b/apps/reader/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/apps/reader/app/_components/reader-shell.tsx
+++ b/apps/reader/app/_components/reader-shell.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef, type ReactNode } from "react";
+import { ReaderNav } from "@repo/ui/components/reader-nav";
+import { ReaderFooter } from "@repo/ui/components/reader-footer";
+import { SkipLink } from "@repo/ui/components/skip-link";
+import { StaleContentBanner } from "@repo/ui/components/stale-content-banner";
+import { ReaderLink } from "../../components/reader-link";
+import { READER_NAV_ITEMS, FOOTER_LINKS, SIGN_IN_HREF } from "../../lib/nav";
+
+/**
+ * ReaderShell — the persistent public-reader chrome that wraps every route.
+ *
+ * A thin client wrapper around the framework-agnostic `@repo/ui` reader-*
+ * composites: it resolves `usePathname()` for active-route state and moves
+ * focus to the destination heading on navigation (accessibility-spec §2.2).
+ * It deliberately does NOT import the admin `Shell` ([ADR-0030]/[ADR-0031]).
+ *
+ * The stale-content banner is mounted here (hidden) as the shared primitive;
+ * wiring it to a live subscription is each data screen's own ticket (#258 is
+ * the primitive + provider only).
+ */
+export function ReaderShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname() ?? "/";
+  const mainRef = useRef<HTMLElement>(null);
+  const isFirstRenderRef = useRef(true);
+
+  // Move focus to the destination screen's <h1> (or the main landmark) on
+  // navigation, so keyboard/SR users land on the new content. Skipped on the
+  // initial load so we never steal focus from a fresh page. Focus restoration
+  // is independent of motion — it happens at the static end state.
+  useEffect(() => {
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
+    const main = mainRef.current;
+    if (!main) return;
+    const heading = main.querySelector<HTMLElement>("h1");
+    const target = heading ?? main;
+    // A heading is not focusable by default — guarantee it can receive focus
+    // without joining the Tab order.
+    if (!target.hasAttribute("tabindex")) {
+      target.setAttribute("tabindex", "-1");
+    }
+    target.focus();
+  }, [pathname]);
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <SkipLink />
+      <ReaderNav
+        items={READER_NAV_ITEMS}
+        currentPath={pathname}
+        signInHref={SIGN_IN_HREF}
+        LinkComponent={ReaderLink}
+      />
+      {/* Shared connection-loss primitive — hidden until a screen drives it. */}
+      <StaleContentBanner state="hidden" />
+      <main
+        id="main-content"
+        ref={mainRef}
+        tabIndex={-1}
+        className="mx-auto w-full max-w-[1200px] flex-1 px-4 py-8 outline-none sm:px-6"
+      >
+        {children}
+      </main>
+      <ReaderFooter links={FOOTER_LINKS} LinkComponent={ReaderLink} />
+    </div>
+  );
+}

--- a/apps/reader/app/_components/realtime-provider.tsx
+++ b/apps/reader/app/_components/realtime-provider.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { createContext, use, useEffect, useState, type ReactNode } from "react";
+import type { createClient } from "@repo/services/supabase/client";
+
+/**
+ * Anon Supabase client for the reader's browser-side Realtime layer.
+ *
+ * The client is created lazily AFTER mount (dynamic import inside an effect) so
+ * the module-level env-var guard in `@repo/services/supabase/client` never runs
+ * during SSR/prerender — the static landing route (`/`) would otherwise fail to
+ * build in an env-less CI. Reader access is anon-only; there is no service-role
+ * path here ([ADR-0030] reader app placement).
+ *
+ * This ticket (#258) starts NO subscriptions — each data screen owns its own
+ * subscription; the provider only makes the anon client available + hosts the
+ * shared connection state the stale-content banner will eventually read.
+ */
+type ReaderSupabaseClient = ReturnType<typeof createClient>;
+
+const ReaderSupabaseContext = createContext<ReaderSupabaseClient | null>(null);
+
+/** The anon browser client, or `null` until it is created post-mount. */
+export const useReaderSupabase = (): ReaderSupabaseClient | null =>
+  use(ReaderSupabaseContext);
+
+export function ReaderRealtimeProvider({ children }: { children: ReactNode }) {
+  const [client, setClient] = useState<ReaderSupabaseClient | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void import("@repo/services/supabase/client").then(({ createClient }) => {
+      if (active) setClient(createClient());
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <ReaderSupabaseContext value={client}>{children}</ReaderSupabaseContext>
+  );
+}

--- a/apps/reader/app/explore/page.tsx
+++ b/apps/reader/app/explore/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * Routing-skeleton placeholder for Explore (`/explore`). The timeline-explorer
+ * screen is a separate ticket; this exists so the persistent shell can be
+ * verified across navigations. The `h1` is the focus target on navigation.
+ */
+export default function ExplorePage() {
+  return (
+    <div className="space-y-3 py-12">
+      <h1
+        tabIndex={-1}
+        className="font-display text-3xl text-foreground outline-none"
+      >
+        Explore
+      </h1>
+      <p className="font-body text-sm text-foreground-muted">
+        The timeline explorer is coming soon.
+      </p>
+    </div>
+  );
+}

--- a/apps/reader/app/layout.tsx
+++ b/apps/reader/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Fraunces, Inter_Tight, JetBrains_Mono } from "next/font/google";
 import { Providers } from "./providers";
+import { ReaderShell } from "./_components/reader-shell";
 import "./globals.css";
 
 const fraunces = Fraunces({
@@ -36,7 +37,9 @@ export default function RootLayout({
       className={`${fraunces.variable} ${interTight.variable} ${jetbrainsMono.variable}`}
     >
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          <ReaderShell>{children}</ReaderShell>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/reader/app/not-found.tsx
+++ b/apps/reader/app/not-found.tsx
@@ -1,25 +1,31 @@
 import Link from "next/link";
 
+/**
+ * 404 rendered inside the persistent shell (the shell owns the single `main`
+ * landmark, so this renders content only — no nested `<main>`). The `h1` is the
+ * focus target on navigation.
+ */
 export default function NotFound() {
   return (
-    <main className="flex min-h-screen items-center justify-center p-8">
-      <div className="max-w-md space-y-4 text-center">
-        <p className="font-mono text-xs uppercase tracking-wider text-foreground-subtle">
-          404
-        </p>
-        <h1 className="font-display text-4xl text-foreground">
-          This page is outside the timeline
-        </h1>
-        <p className="font-body text-sm text-foreground-muted">
-          The reader route you requested is not available yet.
-        </p>
-        <Link
-          href="/"
-          className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          Back to reader home
-        </Link>
-      </div>
-    </main>
+    <div className="mx-auto max-w-md space-y-4 py-20 text-center">
+      <p className="font-mono text-xs uppercase tracking-wider text-foreground-subtle">
+        404
+      </p>
+      <h1
+        tabIndex={-1}
+        className="font-display text-4xl text-foreground outline-none"
+      >
+        This page is outside the timeline
+      </h1>
+      <p className="font-body text-sm text-foreground-muted">
+        The reader route you requested is not available.
+      </p>
+      <Link
+        href="/"
+        className="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        Back to reader home
+      </Link>
+    </div>
   );
 }

--- a/apps/reader/app/page.tsx
+++ b/apps/reader/app/page.tsx
@@ -1,27 +1,25 @@
-import { Button } from "@repo/ui/components/button";
-import { timelineVisibilityEnum } from "@repo/services/schemas/timeline";
-
+/**
+ * Reader landing placeholder. The persistent chrome (nav, footer, skip-link)
+ * is supplied by the shell in `app/layout.tsx`; this route only renders the
+ * `main` content. The full landing screen (featured/recent rails) is a
+ * separate ticket. The `h1` is the focus target on navigation.
+ */
 export default function ReaderHomePage() {
   return (
-    <main className="flex min-h-screen items-center justify-center p-8">
-      <div className="max-w-2xl space-y-4 text-center">
-        <p className="font-mono text-xs uppercase tracking-wider text-foreground-subtle">
-          Reader app scaffold
-        </p>
-        <h1 className="font-display text-4xl text-foreground">
-          Time Traveler Reader
-        </h1>
-        <p className="font-body text-sm text-foreground-muted">
-          Public read-only routes will be added in follow-up tickets.
-        </p>
-        <p className="font-mono text-xs text-foreground-subtle">
-          Shared services wired: visibility values include{" "}
-          {timelineVisibilityEnum.options.join(", ")}.
-        </p>
-        <div className="flex justify-center">
-          <Button type="button">Placeholder route ready</Button>
-        </div>
-      </div>
-    </main>
+    <div className="mx-auto max-w-2xl space-y-4 py-16 text-center">
+      <p className="font-mono text-xs uppercase tracking-wider text-foreground-subtle">
+        Public reader
+      </p>
+      <h1
+        tabIndex={-1}
+        className="font-display text-4xl text-foreground outline-none"
+      >
+        Time Traveler
+      </h1>
+      <p className="font-body text-sm text-foreground-muted">
+        Explore published timelines, stories, and the people, places, and events
+        that shaped them — across the full span of time.
+      </p>
+    </div>
   );
 }

--- a/apps/reader/app/providers.tsx
+++ b/apps/reader/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
+import { ReaderRealtimeProvider } from "./_components/realtime-provider";
 
 function makeQueryClient() {
   return new QueryClient({
@@ -22,6 +23,8 @@ export function Providers({ children }: ProvidersProps) {
   const [queryClient] = useState(makeQueryClient);
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <ReaderRealtimeProvider>{children}</ReaderRealtimeProvider>
+    </QueryClientProvider>
   );
 }

--- a/apps/reader/app/search/page.tsx
+++ b/apps/reader/app/search/page.tsx
@@ -1,0 +1,21 @@
+/**
+ * Routing-skeleton placeholder for Search (`/search`). Search is present in the
+ * global nav but **stubbed** at launch (00-app-shell annotation 2;
+ * screen-inventory §3) — it routes here to a "coming soon" frame so the IA
+ * stays stable when search ships. The `h1` is the focus target on navigation.
+ */
+export default function SearchPage() {
+  return (
+    <div className="space-y-3 py-12">
+      <h1
+        tabIndex={-1}
+        className="font-display text-3xl text-foreground outline-none"
+      >
+        Search
+      </h1>
+      <p className="font-body text-sm text-foreground-muted">
+        Search is coming soon.
+      </p>
+    </div>
+  );
+}

--- a/apps/reader/app/stories/page.tsx
+++ b/apps/reader/app/stories/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * Routing-skeleton placeholder for Stories (`/stories`). The story browser is a
+ * separate ticket; this exists so the persistent shell can be verified across
+ * navigations. The `h1` is the focus target on navigation.
+ */
+export default function StoriesPage() {
+  return (
+    <div className="space-y-3 py-12">
+      <h1
+        tabIndex={-1}
+        className="font-display text-3xl text-foreground outline-none"
+      >
+        Stories
+      </h1>
+      <p className="font-body text-sm text-foreground-muted">
+        The story browser is coming soon.
+      </p>
+    </div>
+  );
+}

--- a/apps/reader/components/reader-link.tsx
+++ b/apps/reader/components/reader-link.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import Link from "next/link";
+import type { ReaderLinkProps } from "@repo/ui/components/reader-link";
+
+/**
+ * Next-specific adapter for the reader composites' framework-agnostic
+ * `LinkComponent` slot. Confines `next/link` to the app layer so the
+ * `@repo/ui` reader-* primitives stay framework-free (and unit-testable
+ * without Next). Mirrors `apps/admin/components/shell-link.tsx`.
+ */
+export const ReaderLink = ({
+  href,
+  className,
+  children,
+  ...rest
+}: ReaderLinkProps) => (
+  <Link href={href} className={className} {...rest}>
+    {children}
+  </Link>
+);

--- a/apps/reader/lib/nav.ts
+++ b/apps/reader/lib/nav.ts
@@ -1,0 +1,32 @@
+import type { ReaderNavItem } from "@repo/ui/components/reader-nav";
+import type { ReaderFooterLink } from "@repo/ui/components/reader-footer";
+
+/**
+ * Reader chrome navigation model.
+ *
+ * Three top-level destinations only — Explore / Stories / Search — per
+ * docs/design/public/06-mid-fidelity/00-app-shell.md annotation 2. Entity
+ * types (periods/characters/events) are reached via contextual cross-links,
+ * never the global nav. Search is present but stubbed at launch.
+ */
+export const READER_NAV_ITEMS: ReaderNavItem[] = [
+  { label: "Explore", href: "/explore" },
+  { label: "Stories", href: "/stories" },
+  { label: "Search", href: "/search" },
+];
+
+/**
+ * Base URL of the admin/auth surface the reader deep-links OUT to. The reader
+ * is anonymous and gates nothing (00-app-shell annotation 3); this only builds
+ * the Sign-in href. Set `NEXT_PUBLIC_ADMIN_URL` in staging/production; local
+ * dev falls back to the admin dev server on :3000.
+ */
+const ADMIN_URL = process.env.NEXT_PUBLIC_ADMIN_URL ?? "http://localhost:3000";
+
+export const SIGN_IN_HREF = `${ADMIN_URL}/auth/login`;
+
+export const FOOTER_LINKS: ReaderFooterLink[] = [
+  { label: "About", href: "/about" },
+  { label: "Sign in", href: SIGN_IN_HREF, external: true },
+  { label: "Legal", href: "/legal" },
+];

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -70,6 +70,7 @@ model); the next new ADR is the next free number (`0029` onward), per the
 | [0030](adr-0030-public-reader-app-placement.md)            | Public reader lives in dedicated `apps/reader` Next.js app                      | Accepted         | Amends 0003                                |
 | [0031](adr-0031-public-reader-design-divergence.md)        | Public reader design divergence (shared tokens, divergent motion + composition) | Accepted         | —                                          |
 | [0032](adr-0032-public-reader-motion-tokens.md)            | Public reader motion-token scale (durations, easing, reduced-motion contract)   | Accepted         | —                                          |
+| [0033](adr-0033-reader-shell-composites-in-ui-package.md)  | Reader shell composites live in `@repo/ui` (`reader-*`); apps/reader holds glue | Accepted         | —                                          |
 
 † ADR `0006` supersedes the original event-to-event `parent_event_id` nesting
 approach, which was never given its own ADR; it is documented inside `0006` as

--- a/docs/adr/adr-0033-reader-shell-composites-in-ui-package.md
+++ b/docs/adr/adr-0033-reader-shell-composites-in-ui-package.md
@@ -1,0 +1,162 @@
+---
+title: "ADR-0033: Reader shell composites live in @repo/ui (reader-* components), not in apps/reader"
+status: "Accepted"
+date: "2026-06-09"
+authors: "shaes-farm"
+tags: ["design-system", "public-reader", "app-shell", "ui-package", "testing"]
+supersedes: ""
+superseded_by: ""
+amends: ""
+amended_by: ""
+---
+
+# ADR-0033: Reader shell composites live in @repo/ui (reader-\* components), not in apps/reader
+
+## Status
+
+**Accepted**
+
+## Context
+
+[ADR-0030](adr-0030-public-reader-app-placement.md) places the public reader in
+a dedicated `apps/reader` app, and [ADR-0031](adr-0031-public-reader-design-divergence.md)
+fixes that the reader **never shares the admin navigation shell** — it is a
+separate composition over the shared `@repo/ui` tokens/primitives. Neither ADR
+says **where the reader's own shell composition lives**: directly inside
+`apps/reader/app`, or as reusable components in `@repo/ui`.
+
+Issue #258 (reader app shell + routing skeleton, screen 0) is the first ticket
+to build that chrome, and it does so under three constraints that force the
+question:
+
+- The shell's **stale-content banner** and **`ambient-presence` live dot** are
+  explicitly **reused by every data screen** (screen-inventory §3; #258 ships
+  the primitives, the screen tickets #65–#69 wire them).
+- `apps/reader` (like `apps/admin`) **has no test runner** — Vitest runs only in
+  `packages/ui` and `packages/services`, and the husky pre-push hook enforces an
+  80% coverage threshold. Logic placed in `apps/reader` is effectively untested.
+- The reader chrome must stay **framework-decoupled from the admin shell**
+  (ADR-0031) while still consuming the shared design tokens.
+
+The established precedent for shared chrome is the admin `Shell`
+([`packages/ui/src/components/shell.tsx`](../../packages/ui/src/components/shell.tsx)):
+a framework-agnostic component in `@repo/ui` with a `LinkComponent` slot, mounted
+by a thin app-level wrapper
+([`apps/admin/app/(protected)/_components/protected-shell.tsx`](<../../apps/admin/app/(protected)/_components/protected-shell.tsx>))
+that supplies `next/link` and `usePathname()`.
+
+## Decision
+
+The reader's shell composites are authored in **`@repo/ui` as `reader-*`
+components**, and `apps/reader` contributes only the **thin Next.js adapters**
+(link adapter, pathname + focus-on-navigation wrapper, env-derived config, and
+the route tree).
+
+Concretely:
+
+- **In `@repo/ui/components`:** `reader-nav`, `reader-footer`, `reader-live-dot`,
+  `stale-content-banner`, `skip-link`, and the framework-agnostic link contract
+  `reader-link` (`ReaderLinkProps` / `ReaderLinkComponent` / `DefaultReaderLink`).
+  These are presentational, server-renderable, carry their own unit tests, and
+  take a generic `LinkComponent` slot. They depend only on shared tokens, the
+  motion classes ([ADR-0032](adr-0032-public-reader-motion-tokens.md)), and
+  existing `@repo/ui` primitives.
+- **In `apps/reader`:** `components/reader-link.tsx` (`next/link` adapter),
+  `app/_components/reader-shell.tsx` (`"use client"` wrapper that resolves
+  `usePathname()` and moves focus to the destination `h1` on navigation),
+  `app/_components/realtime-provider.tsx` (anon browser-client context), and
+  `lib/nav.ts` (the nav model + admin-deep-link config).
+
+The reader composites are a **separate family** from the admin `Shell` — a
+dedicated `reader-link` contract rather than reuse of `ShellLinkProps` — so the
+"reader never imports the admin shell" rule (ADR-0031) holds at the import level,
+not merely by convention.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: The reused primitives (stale-content banner, live dot) are
+  unit-tested and counted toward the 80% coverage gate, instead of living
+  untested in `apps/reader`.
+- **POS-002**: Screen tickets (#65–#69) import the banner + live dot directly
+  from `@repo/ui` without a later extraction/move.
+- **POS-003**: The admin/reader separation (ADR-0031) is enforced structurally —
+  the reader composites are their own module family with their own link contract,
+  so there is no path by which the reader pulls in the admin `Shell`.
+- **POS-004**: Mirrors the proven admin pattern (framework-agnostic component +
+  thin app wrapper), keeping the monorepo's chrome conventions consistent.
+
+### Negative
+
+- **NEG-001**: Reader-specific presentation now lives in the shared package, so
+  `@repo/ui` carries app-specific (reader) composites, not only generic
+  primitives. Mitigated by the `reader-*` naming prefix making ownership obvious.
+- **NEG-002**: Two link contracts now exist (`ShellLinkProps` and
+  `ReaderLinkProps`) with near-identical shape. This is intentional duplication
+  to keep the surfaces decoupled (ADR-0031), accepted over a shared base type.
+- **NEG-003**: Truly app-local, non-Next-specific reader UI must still make a
+  placement judgment; this ADR sets the default (shared, reusable → `@repo/ui`;
+  Next-coupled glue → `apps/reader`) but does not mechanically decide every case.
+
+## Alternatives Considered
+
+### Option A (rejected) — Build the shell entirely inside apps/reader
+
+- **ALT-001**: **Description**: Author nav/footer/banner/live-dot/skip-link as
+  components under `apps/reader/app/_components`, colocated with the route tree.
+- **ALT-002**: **Rejection reason**: `apps/reader` has no Vitest runner, so the
+  reused primitives would ship untested under an 80% gate; and the banner + live
+  dot — explicitly reused by sibling screen tickets — would need a later move to
+  `@repo/ui` to be shared, churning imports.
+
+### Option B (rejected) — Reuse the admin Shell with reader props
+
+- **ALT-003**: **Description**: Parameterize `packages/ui/src/components/shell.tsx`
+  to render a reader variant (no sidebar/breadcrumb) via props.
+- **ALT-004**: **Rejection reason**: Directly violates ADR-0030/ADR-0031 ("the
+  reader never shares the admin navigation shell") and the #258 acceptance
+  criterion "No import of the admin navigation shell." It would also couple the
+  two surfaces' evolution.
+
+## Implementation Notes
+
+- **IMP-001**: The reader composites consume only shared tokens + the motion
+  classes; reduced-motion is inherited from the token-layer collapse in
+  [`motion.css`](../../packages/ui/src/styles/motion.css)
+  ([ADR-0032](adr-0032-public-reader-motion-tokens.md) IMP-002), not re-specified
+  per component. The live dot and stale banner use `.ambient-presence`
+  (opacity-only; never pulse/blink).
+- **IMP-002**: Focus-on-navigation lives in the app wrapper (`reader-shell.tsx`),
+  not the composites, because it requires `usePathname()`; the `main` landmark is
+  programmatically focusable (`tabindex="-1"`) and the destination `h1` receives
+  focus at the static end state (accessibility-spec §2.2).
+- **IMP-003**: The anon Supabase client is created **lazily after mount** via a
+  dynamic import inside an effect (`realtime-provider.tsx`), so the module-level
+  env-var guard in `@repo/services/supabase/client` never runs during
+  SSR/prerender — otherwise the static landing route (`/`) fails to build in an
+  env-less CI. Reader access is anon-only; no service-role path exists in
+  `apps/reader`.
+- **IMP-004**: Future reader screen tickets import the banner/live-dot from
+  `@repo/ui/components/*` and drive their state from per-screen subscriptions;
+  #258 starts no subscriptions (provider + primitives only).
+
+## References
+
+- **REF-001**: [ADR-0030](adr-0030-public-reader-app-placement.md) — dedicated
+  `apps/reader`; the two surfaces never share a navigation shell.
+- **REF-002**: [ADR-0031](adr-0031-public-reader-design-divergence.md) — reader
+  reuses shared tokens, diverges in composition; nav shell is never shared.
+- **REF-003**: [ADR-0032](adr-0032-public-reader-motion-tokens.md) — motion-token
+  scale + reduced-motion contract consumed by the reader composites.
+- **REF-004**: [ADR-0020](adr-0020-ui-package-shadcn-tailwind.md) — `@repo/ui`
+  design system; the home for shared components.
+- **REF-005**: [`docs/design/public/06-mid-fidelity/00-app-shell.md`](../design/public/06-mid-fidelity/00-app-shell.md)
+  — app-shell mid-fidelity spec implemented by these composites.
+- **REF-006**: [`docs/design/public/06-mid-fidelity/accessibility-spec.md`](../design/public/06-mid-fidelity/accessibility-spec.md)
+  — focus order, landmarks, live-region rules.
+- **REF-007**: [Issue #258](https://github.com/shaes-farm/time-traveler/issues/258)
+  — Public reader app shell + routing skeleton (screen 0).
+- **REF-008**: `packages/ui/src/components/shell.tsx` +
+  `apps/admin/app/(protected)/_components/protected-shell.tsx` — the admin
+  precedent this pattern mirrors.

--- a/docs/design/public/06-mid-fidelity/00-app-shell.md
+++ b/docs/design/public/06-mid-fidelity/00-app-shell.md
@@ -3,6 +3,17 @@
 Builds on: [04 wireframe — App shell](../04-wireframes/00-app-shell.md) · [README visual-system reference](README.md#reader-visual-system-reference) · [motion-spec](motion-spec.md) · [accessibility-spec](accessibility-spec.md)
 Resolves for this screen: live-dot visual treatment + reduced-motion fallback (deferred to #172 by [04 app-shell](../04-wireframes/00-app-shell.md)).
 
+> **Implemented (#258).** This spec is realized by the reader shell shipped in #258.
+> Composites live in `@repo/ui` as `reader-*` components: `ReaderNav`
+> (`banner`/`navigation` + brand + live-dot slot + Sign-in deep-link),
+> `ReaderFooter` (`contentinfo`), `ReaderLiveDot` (`ambient-presence`),
+> `StaleContentBanner` (the reusable connection-loss primitive), and `SkipLink`.
+> They are composed by `apps/reader/app/_components/reader-shell.tsx`, which owns
+> pathname resolution and focus-on-navigation. Placement rationale is
+> [ADR-0033](../../../adr/adr-0033-reader-shell-composites-in-ui-package.md). The
+> sub-640px hamburger focus-trap (#171) and the live-dot/banner final visual
+> treatment (#172) remain open per the deferrals below.
+
 **Purpose.** The persistent reader chrome (nav, brand, single Sign-in deep-link, footer, skip-link) — structure fixed in the [04 wireframe](../04-wireframes/00-app-shell.md); this doc fixes its token application, states, motion, and a11y. Distinct from the admin shell ([ADR-0030](../../../adr/adr-0030-public-reader-app-placement.md)/[ADR-0031](../../../adr/adr-0031-public-reader-design-divergence.md)).
 
 ## Visual hierarchy + token callouts

--- a/packages/ui/src/components/reader-footer.test.tsx
+++ b/packages/ui/src/components/reader-footer.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReaderFooter, type ReaderFooterLink } from "./reader-footer";
+
+const LINKS: ReaderFooterLink[] = [
+  { label: "About", href: "/about" },
+  {
+    label: "Sign in",
+    href: "https://admin.example/auth/login",
+    external: true,
+  },
+  { label: "Legal", href: "/legal" },
+];
+
+describe("ReaderFooter", () => {
+  it("renders a contentinfo landmark with the brand + tagline", () => {
+    render(<ReaderFooter links={LINKS} />);
+    const footer = screen.getByRole("contentinfo");
+    expect(footer).toBeInTheDocument();
+    expect(
+      within(footer).getByText(/an immersive temporal reader/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders every footer link", () => {
+    render(<ReaderFooter links={LINKS} />);
+    const footer = screen.getByRole("contentinfo");
+    expect(within(footer).getAllByRole("link")).toHaveLength(3);
+    expect(within(footer).getByRole("link", { name: "About" })).toHaveAttribute(
+      "href",
+      "/about",
+    );
+  });
+
+  it("renders external links as plain anchors with their href", () => {
+    render(<ReaderFooter links={LINKS} />);
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute(
+      "href",
+      "https://admin.example/auth/login",
+    );
+  });
+});

--- a/packages/ui/src/components/reader-footer.tsx
+++ b/packages/ui/src/components/reader-footer.tsx
@@ -1,0 +1,70 @@
+import { cn } from "@repo/ui/lib/utils";
+import {
+  DefaultReaderLink,
+  type ReaderLinkComponent,
+} from "@repo/ui/components/reader-link";
+
+/**
+ * ReaderFooter — the minimal reader `contentinfo` footer: a brand line plus
+ * About / Sign in / Legal links. No sitemap, no entity directories — that
+ * would re-introduce admin-style navigation density (00-app-shell annotation 7).
+ *
+ * The "Sign in" link deep-links OUT to admin/auth (plain anchor); About/Legal
+ * are in-app routes resolved through `LinkComponent`.
+ */
+export interface ReaderFooterLink {
+  label: string;
+  href: string;
+  /** When true, render as a plain anchor (deep-link out of the reader app). */
+  external?: boolean;
+}
+
+export interface ReaderFooterProps {
+  links: ReaderFooterLink[];
+  /** Brand tagline shown beside the wordmark. */
+  tagline?: string;
+  LinkComponent?: ReaderLinkComponent;
+  className?: string;
+}
+
+export const ReaderFooter = ({
+  links,
+  tagline = "An immersive temporal reader",
+  LinkComponent = DefaultReaderLink,
+  className,
+}: ReaderFooterProps) => (
+  <footer
+    role="contentinfo"
+    className={cn("border-t border-border-muted bg-background", className)}
+  >
+    <div className="mx-auto flex max-w-[1200px] flex-col gap-2 px-4 py-6 text-sm text-foreground-muted sm:flex-row sm:items-center sm:justify-between sm:px-6">
+      <p className="font-display text-foreground">
+        Time Traveler{" "}
+        <span className="font-body text-xs text-foreground-muted">
+          · {tagline}
+        </span>
+      </p>
+      <ul className="flex flex-wrap items-center gap-4">
+        {links.map((link) => (
+          <li key={link.href}>
+            {link.external ? (
+              <a
+                href={link.href}
+                className="text-foreground-muted transition-colors hover:text-foreground"
+              >
+                {link.label}
+              </a>
+            ) : (
+              <LinkComponent
+                href={link.href}
+                className="text-foreground-muted transition-colors hover:text-foreground"
+              >
+                {link.label}
+              </LinkComponent>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  </footer>
+);

--- a/packages/ui/src/components/reader-link.tsx
+++ b/packages/ui/src/components/reader-link.tsx
@@ -1,0 +1,31 @@
+import type { ComponentType, ReactNode } from "react";
+
+/**
+ * Framework-agnostic link contract for the **public reader** chrome.
+ *
+ * Deliberately separate from the admin `ShellLinkProps` (shell.tsx): the
+ * reader never shares the admin navigation shell ([ADR-0030]/[ADR-0031]),
+ * so its composites carry their own link slot. The reader app supplies a
+ * `next/link` adapter; Storybook/tests supply a plain `<a>`.
+ */
+export interface ReaderLinkProps {
+  href: string;
+  className?: string;
+  children?: ReactNode;
+  "aria-label"?: string;
+  "aria-current"?: "page" | undefined;
+}
+
+export type ReaderLinkComponent = ComponentType<ReaderLinkProps>;
+
+/** Plain-anchor fallback so the composites render without a framework adapter. */
+export const DefaultReaderLink = ({
+  href,
+  className,
+  children,
+  ...rest
+}: ReaderLinkProps) => (
+  <a href={href} className={className} {...rest}>
+    {children}
+  </a>
+);

--- a/packages/ui/src/components/reader-live-dot.test.tsx
+++ b/packages/ui/src/components/reader-live-dot.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReaderLiveDot } from "./reader-live-dot";
+
+describe("ReaderLiveDot", () => {
+  it("defaults to hidden: transparent, aria-hidden, no announcement", () => {
+    const { container } = render(<ReaderLiveDot />);
+    const dot = container.querySelector("span[data-state]");
+    expect(dot).toHaveAttribute("data-state", "hidden");
+    expect(dot).toHaveAttribute("aria-hidden", "true");
+    expect(dot).toHaveClass("opacity-0");
+    expect(screen.queryByText(/updates/i)).not.toBeInTheDocument();
+  });
+
+  it("always uses the opacity-only ambient-presence class (never pulse/blink)", () => {
+    const { container } = render(<ReaderLiveDot state="subscribed" />);
+    expect(container.querySelector("span[data-state]")).toHaveClass(
+      "ambient-presence",
+    );
+  });
+
+  it.each([
+    [
+      "subscribed",
+      "opacity-100",
+      "text-foreground-subtle",
+      /live updates active/i,
+    ],
+    [
+      "update",
+      "opacity-100",
+      "text-foreground-muted",
+      /new updates available/i,
+    ],
+    ["paused", "opacity-100", "text-foreground-subtle", /live updates paused/i],
+  ] as const)(
+    "renders the %s state with its color + screen-reader label",
+    (state, opacity, color, label) => {
+      const { container } = render(<ReaderLiveDot state={state} />);
+      const dot = container.querySelector("span[data-state]");
+      expect(dot).toHaveAttribute("data-state", state);
+      expect(dot).not.toHaveAttribute("aria-hidden");
+      expect(dot).toHaveClass(opacity, color);
+      expect(screen.getByText(label)).toHaveClass("sr-only");
+    },
+  );
+});

--- a/packages/ui/src/components/reader-live-dot.tsx
+++ b/packages/ui/src/components/reader-live-dot.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@repo/ui/lib/utils";
+
+/**
+ * ReaderLiveDot — the `ambient-presence` live-update indicator that sits near
+ * the brand in the reader nav. A 6px dot whose only signal is opacity/color;
+ * it must NEVER pulse, blink, slide, or scale (motion-spec §2.5; PRD §2.2.10).
+ * Motion is opacity-only via the `.ambient-presence` class (motion.css), which
+ * collapses to instant under `prefers-reduced-motion` at the token layer.
+ *
+ * States (docs/design/public/06-mid-fidelity/00-app-shell.md §Live dot):
+ *  - hidden     — idle / no subscription → not announced, fully transparent
+ *  - subscribed — active subscription   → `--color-foreground-subtle`
+ *  - update     — recent published update → brief opacity rise to `--color-foreground-muted`
+ *  - paused     — connection lost        → static, no color alarm
+ *
+ * Presentational only: the parent drives `state` from Realtime subscription
+ * status. This ticket (#258) never starts a subscription — the dot stays
+ * `hidden` until a screen ticket drives it.
+ */
+export type ReaderLiveState = "hidden" | "subscribed" | "update" | "paused";
+
+const STATE_LABEL: Record<ReaderLiveState, string> = {
+  hidden: "",
+  subscribed: "Live updates active",
+  update: "New updates available",
+  paused: "Live updates paused",
+};
+
+const STATE_CLASS: Record<ReaderLiveState, string> = {
+  hidden: "opacity-0 text-foreground-subtle",
+  subscribed: "opacity-100 text-foreground-subtle",
+  update: "opacity-100 text-foreground-muted",
+  paused: "opacity-100 text-foreground-subtle",
+};
+
+export interface ReaderLiveDotProps {
+  state?: ReaderLiveState;
+  className?: string;
+}
+
+export const ReaderLiveDot = ({
+  state = "hidden",
+  className,
+}: ReaderLiveDotProps) => {
+  const label = STATE_LABEL[state];
+  return (
+    <span
+      data-state={state}
+      aria-hidden={state === "hidden" ? true : undefined}
+      className={cn(
+        "ambient-presence inline-block h-1.5 w-1.5 rounded-full bg-current",
+        STATE_CLASS[state],
+        className,
+      )}
+    >
+      {label ? <span className="sr-only">{label}</span> : null}
+    </span>
+  );
+};

--- a/packages/ui/src/components/reader-nav.test.tsx
+++ b/packages/ui/src/components/reader-nav.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReaderNav, type ReaderNavItem } from "./reader-nav";
+
+const ITEMS: ReaderNavItem[] = [
+  { label: "Explore", href: "/explore" },
+  { label: "Stories", href: "/stories" },
+  { label: "Search", href: "/search" },
+];
+
+const renderNav = (currentPath = "/explore") =>
+  render(
+    <ReaderNav
+      items={ITEMS}
+      currentPath={currentPath}
+      signInHref="https://admin.example/auth/login"
+    />,
+  );
+
+describe("ReaderNav", () => {
+  it("exposes banner + primary navigation landmarks", () => {
+    renderNav();
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: /primary/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders exactly the three reader destinations", () => {
+    renderNav();
+    const nav = screen.getByRole("navigation", { name: /primary/i });
+    const links = within(nav).getAllByRole("link");
+    expect(links.map((l) => l.textContent)).toEqual([
+      "Explore",
+      "Stories",
+      "Search",
+    ]);
+  });
+
+  it("marks the active route with aria-current=page", () => {
+    renderNav("/stories");
+    expect(screen.getByRole("link", { name: "Stories" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.getByRole("link", { name: "Explore" })).not.toHaveAttribute(
+      "aria-current",
+    );
+  });
+
+  it("treats nested routes as active for their section", () => {
+    renderNav("/explore/some-timeline");
+    expect(screen.getByRole("link", { name: "Explore" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("marks the brand current only on the home route", () => {
+    renderNav("/");
+    expect(
+      screen.getByRole("link", { name: /time traveler — home/i }),
+    ).toHaveAttribute("aria-current", "page");
+  });
+
+  it("renders Sign in as a deep-link out to the provided href", () => {
+    renderNav();
+    expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute(
+      "href",
+      "https://admin.example/auth/login",
+    );
+  });
+
+  it("hides the live dot by default", () => {
+    const { container } = renderNav();
+    expect(container.querySelector("span[data-state]")).toHaveAttribute(
+      "data-state",
+      "hidden",
+    );
+  });
+});

--- a/packages/ui/src/components/reader-nav.tsx
+++ b/packages/ui/src/components/reader-nav.tsx
@@ -1,0 +1,117 @@
+import { Hourglass } from "lucide-react";
+import { cn } from "@repo/ui/lib/utils";
+import {
+  DefaultReaderLink,
+  type ReaderLinkComponent,
+} from "@repo/ui/components/reader-link";
+import {
+  ReaderLiveDot,
+  type ReaderLiveState,
+} from "@repo/ui/components/reader-live-dot";
+
+/**
+ * ReaderNav — the persistent public-reader top bar (`banner` + `navigation`).
+ *
+ * Composition is fixed by docs/design/public/04-wireframes/00-app-shell.md and
+ * the token application in 06-mid-fidelity/00-app-shell.md. It is a SEPARATE
+ * composition from the admin Shell (no sidebar, breadcrumb rail, or authoring
+ * affordances) and must never import it ([ADR-0030]/[ADR-0031]).
+ *
+ * Three nav destinations only — Explore / Stories / Search (Search is stubbed
+ * at launch). Entity types (periods/characters/events) are reached via
+ * contextual cross-links, never the global nav (00-app-shell annotation 2).
+ *
+ * The single "Sign in" affordance is a low-emphasis, right-aligned deep-link
+ * OUT to the admin/auth surface; it gates nothing (annotation 3). It renders as
+ * a plain anchor because it leaves the reader app entirely.
+ *
+ * Presentational + server-renderable: active state comes from the `currentPath`
+ * prop, so the shell can resolve `usePathname()` in a thin client wrapper.
+ *
+ * NOTE (#171): the <640px hamburger panel + focus-trap is owned by #171. This
+ * component keeps the nav inline-and-condensed on small screens; the trap is
+ * deliberately not built here.
+ */
+export interface ReaderNavItem {
+  label: string;
+  href: string;
+}
+
+export interface ReaderNavProps {
+  items: ReaderNavItem[];
+  currentPath: string;
+  /** Deep-link OUT to the admin/auth surface. Gates nothing. */
+  signInHref: string;
+  /** Realtime indicator state; `hidden` (default) until a screen drives it. */
+  liveState?: ReaderLiveState;
+  /** Framework link adapter (e.g. `next/link`). Falls back to a plain `<a>`. */
+  LinkComponent?: ReaderLinkComponent;
+}
+
+const isActive = (currentPath: string, href: string): boolean =>
+  currentPath === href || (href !== "/" && currentPath.startsWith(`${href}/`));
+
+export const ReaderNav = ({
+  items,
+  currentPath,
+  signInHref,
+  liveState = "hidden",
+  LinkComponent = DefaultReaderLink,
+}: ReaderNavProps) => {
+  const brandActive = currentPath === "/";
+  return (
+    <header
+      role="banner"
+      className="sticky top-0 z-40 border-b border-border-muted bg-background"
+    >
+      <div className="mx-auto flex h-14 max-w-[1200px] items-center gap-4 px-4 sm:px-6">
+        {/* Brand / home + ambient-presence live dot */}
+        <div className="flex items-center gap-2">
+          <LinkComponent
+            href="/"
+            aria-label="Time Traveler — home"
+            aria-current={brandActive ? "page" : undefined}
+            className="flex items-center gap-2 font-display text-lg leading-none text-foreground transition-colors hover:text-foreground"
+          >
+            <Hourglass className="h-5 w-5 shrink-0" aria-hidden />
+            <span className="hidden sm:inline">Time Traveler</span>
+          </LinkComponent>
+          <ReaderLiveDot state={liveState} />
+        </div>
+
+        {/* Primary destinations */}
+        <nav aria-label="Primary" className="flex flex-1 items-center">
+          <ul className="flex items-center gap-4 sm:gap-6">
+            {items.map((item) => {
+              const active = isActive(currentPath, item.href);
+              return (
+                <li key={item.href}>
+                  <LinkComponent
+                    href={item.href}
+                    aria-current={active ? "page" : undefined}
+                    className={cn(
+                      "border-b-2 pb-0.5 text-sm transition-colors",
+                      active
+                        ? "border-foreground text-foreground"
+                        : "border-transparent text-foreground-muted hover:text-foreground",
+                    )}
+                  >
+                    {item.label}
+                  </LinkComponent>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+
+        {/* Single, quiet sign-in deep-link OUT to admin/auth. */}
+        <a
+          href={signInHref}
+          className="shrink-0 text-xs text-foreground-muted transition-colors hover:text-foreground"
+        >
+          Sign in
+        </a>
+      </div>
+    </header>
+  );
+};

--- a/packages/ui/src/components/skip-link.test.tsx
+++ b/packages/ui/src/components/skip-link.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SkipLink } from "./skip-link";
+
+describe("SkipLink", () => {
+  it("targets the main landmark by default and is sr-only until focused", () => {
+    render(<SkipLink />);
+    const link = screen.getByRole("link", { name: /skip to content/i });
+    expect(link).toHaveAttribute("href", "#main-content");
+    expect(link).toHaveClass("sr-only");
+    expect(link).toHaveClass("focus-visible:not-sr-only");
+  });
+
+  it("honors a custom target id and label", () => {
+    render(<SkipLink targetId="reader-main">Jump to reader</SkipLink>);
+    expect(
+      screen.getByRole("link", { name: /jump to reader/i }),
+    ).toHaveAttribute("href", "#reader-main");
+  });
+});

--- a/packages/ui/src/components/skip-link.tsx
+++ b/packages/ui/src/components/skip-link.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@repo/ui/lib/utils";
+
+/**
+ * SkipLink — the keyboard-first "Skip to content" affordance that MUST be the
+ * first focusable element in the reader shell (accessibility-spec §2.3;
+ * 00-app-shell annotation 5). Visually hidden until focused, then revealed
+ * pinned to the top-left; activating it jumps focus to the `main` landmark.
+ *
+ * Render this as the very first child of the document body, before the nav.
+ */
+export interface SkipLinkProps {
+  /** Fragment target of the `main` landmark. Defaults to `#main-content`. */
+  targetId?: string;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export const SkipLink = ({
+  targetId = "main-content",
+  children = "Skip to content",
+  className,
+}: SkipLinkProps) => (
+  <a
+    href={`#${targetId}`}
+    className={cn(
+      // Off-screen until focused; revealed on focus as a visible chip.
+      "sr-only rounded-md bg-surface px-4 py-2 text-sm font-medium text-foreground outline-none ring-ring",
+      "focus-visible:not-sr-only focus-visible:absolute focus-visible:left-4 focus-visible:top-4 focus-visible:z-50 focus-visible:ring-2",
+      className,
+    )}
+  >
+    {children}
+  </a>
+);

--- a/packages/ui/src/components/skip-link.tsx
+++ b/packages/ui/src/components/skip-link.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { cn } from "@repo/ui/lib/utils";
 
 /**
@@ -11,7 +12,7 @@ import { cn } from "@repo/ui/lib/utils";
 export interface SkipLinkProps {
   /** Fragment target of the `main` landmark. Defaults to `#main-content`. */
   targetId?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
   className?: string;
 }
 

--- a/packages/ui/src/components/stale-content-banner.test.tsx
+++ b/packages/ui/src/components/stale-content-banner.test.tsx
@@ -5,7 +5,7 @@ import { StaleContentBanner } from "./stale-content-banner";
 
 describe("StaleContentBanner", () => {
   it("is a polite, atomic live region (never assertive)", () => {
-    render(<StaleContentBanner state="stale" />);
+    render(<StaleContentBanner state="stale" onRefresh={() => {}} />);
     const region = screen.getByRole("status");
     expect(region).toHaveAttribute("aria-live", "polite");
     expect(region).toHaveAttribute("aria-atomic", "true");
@@ -19,12 +19,18 @@ describe("StaleContentBanner", () => {
   });
 
   it("uses the opacity-only ambient-presence class", () => {
-    render(<StaleContentBanner state="stale" />);
+    render(<StaleContentBanner state="stale" onRefresh={() => {}} />);
     expect(screen.getByRole("status")).toHaveClass("ambient-presence");
   });
 
+  it("pins below the sticky nav when visible so it survives scroll", () => {
+    render(<StaleContentBanner state="stale" onRefresh={() => {}} />);
+    const region = screen.getByRole("status");
+    expect(region).toHaveClass("sticky", "top-14");
+  });
+
   it("shows default stale copy with a redundant text label (never color-only)", () => {
-    render(<StaleContentBanner state="stale" />);
+    render(<StaleContentBanner state="stale" onRefresh={() => {}} />);
     expect(screen.getByText(/live updates paused/i)).toBeInTheDocument();
   });
 
@@ -56,7 +62,13 @@ describe("StaleContentBanner", () => {
   });
 
   it("allows overriding the message copy", () => {
-    render(<StaleContentBanner state="stale" message="Custom stale copy" />);
+    render(
+      <StaleContentBanner
+        state="stale"
+        message="Custom stale copy"
+        onRefresh={() => {}}
+      />,
+    );
     expect(screen.getByText("Custom stale copy")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/stale-content-banner.test.tsx
+++ b/packages/ui/src/components/stale-content-banner.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { StaleContentBanner } from "./stale-content-banner";
+
+describe("StaleContentBanner", () => {
+  it("is a polite, atomic live region (never assertive)", () => {
+    render(<StaleContentBanner state="stale" />);
+    const region = screen.getByRole("status");
+    expect(region).toHaveAttribute("aria-live", "polite");
+    expect(region).toHaveAttribute("aria-atomic", "true");
+  });
+
+  it("renders nothing visible when hidden but keeps the live region mounted", () => {
+    render(<StaleContentBanner state="hidden" />);
+    const region = screen.getByRole("status");
+    expect(region).toHaveClass("sr-only");
+    expect(region).toBeEmptyDOMElement();
+  });
+
+  it("uses the opacity-only ambient-presence class", () => {
+    render(<StaleContentBanner state="stale" />);
+    expect(screen.getByRole("status")).toHaveClass("ambient-presence");
+  });
+
+  it("shows default stale copy with a redundant text label (never color-only)", () => {
+    render(<StaleContentBanner state="stale" />);
+    expect(screen.getByText(/live updates paused/i)).toBeInTheDocument();
+  });
+
+  it("exposes a keyboard-reachable Refresh button in tab order while stale", async () => {
+    const onRefresh = vi.fn();
+    const user = userEvent.setup();
+    render(<StaleContentBanner state="stale" onRefresh={onRefresh} />);
+
+    const button = screen.getByRole("button", { name: /refresh/i });
+    // Reachable by keyboard (not removed from tab order) and activatable.
+    await user.tab();
+    expect(button).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("does not steal focus on appearance", () => {
+    render(<StaleContentBanner state="stale" onRefresh={() => {}} />);
+    // Appearance must not auto-focus anything — focus stays on <body>.
+    expect(document.body).toHaveFocus();
+  });
+
+  it("omits the Refresh button while reconnecting", () => {
+    render(<StaleContentBanner state="reconnecting" onRefresh={() => {}} />);
+    expect(screen.getByText(/reconnecting/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /refresh/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("allows overriding the message copy", () => {
+    render(<StaleContentBanner state="stale" message="Custom stale copy" />);
+    expect(screen.getByText("Custom stale copy")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/stale-content-banner.tsx
+++ b/packages/ui/src/components/stale-content-banner.tsx
@@ -1,0 +1,84 @@
+import { cn } from "@repo/ui/lib/utils";
+import { Button } from "@repo/ui/components/button";
+
+/**
+ * StaleContentBanner — the reusable connection-loss primitive for the reader.
+ *
+ * When a screen's Realtime subscription drops, the visible content stays usable
+ * (SSR-first) and this banner pins below the nav bar to signal staleness, with
+ * a Refresh affordance to re-fetch on demand (screen-inventory §3; motion-spec
+ * §3). Every data screen reuses this primitive — #258 ships the primitive only;
+ * wiring it to a live subscription is each screen's own ticket.
+ *
+ * Accessibility (accessibility-spec §4.3):
+ *  - `aria-live="polite"` region that announces ONCE on appearance — never
+ *    `assertive` (the reader is exploratory, not alerting), and it does not
+ *    re-announce on every retry (the message is stable per state).
+ *  - The Refresh button is keyboard-reachable and in the natural tab order.
+ *  - The banner NEVER auto-focuses — appearance must not steal focus or scroll.
+ *  - Color is redundant with text (never color-only).
+ *
+ * Motion is opacity-only via `.ambient-presence`, collapsing to instant under
+ * `prefers-reduced-motion` at the token layer (motion.css).
+ */
+export type StaleBannerState = "hidden" | "stale" | "reconnecting";
+
+const DEFAULT_MESSAGE: Record<Exclude<StaleBannerState, "hidden">, string> = {
+  stale: "Live updates paused — content may be out of date.",
+  reconnecting: "Reconnecting…",
+};
+
+export interface StaleContentBannerProps {
+  state?: StaleBannerState;
+  /** Override the default per-state copy. */
+  message?: string;
+  /** Manual re-fetch handler. The button is omitted while reconnecting. */
+  onRefresh?: () => void;
+  refreshLabel?: string;
+  className?: string;
+}
+
+export const StaleContentBanner = ({
+  state = "hidden",
+  message,
+  onRefresh,
+  refreshLabel = "Refresh",
+  className,
+}: StaleContentBannerProps) => {
+  const visible = state !== "hidden";
+  const text = message ?? (state === "hidden" ? "" : DEFAULT_MESSAGE[state]);
+
+  return (
+    // The live region is always present so it can announce when text appears.
+    // `aria-atomic` so the whole (short) message is read as one unit.
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className={cn(
+        "ambient-presence",
+        visible
+          ? "flex items-center justify-between gap-4 border-b border-border-muted bg-surface px-4 py-2 text-sm text-foreground-muted sm:px-6"
+          : "sr-only",
+        className,
+      )}
+    >
+      {visible ? (
+        <>
+          <span>{text}</span>
+          {state === "stale" && onRefresh ? (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={onRefresh}
+              className="shrink-0"
+            >
+              {refreshLabel}
+            </Button>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/ui/src/components/stale-content-banner.tsx
+++ b/packages/ui/src/components/stale-content-banner.tsx
@@ -28,23 +28,30 @@ const DEFAULT_MESSAGE: Record<Exclude<StaleBannerState, "hidden">, string> = {
   reconnecting: "Reconnecting…",
 };
 
-export interface StaleContentBannerProps {
-  state?: StaleBannerState;
+interface StaleContentBannerBaseProps {
   /** Override the default per-state copy. */
   message?: string;
-  /** Manual re-fetch handler. The button is omitted while reconnecting. */
-  onRefresh?: () => void;
   refreshLabel?: string;
   className?: string;
 }
 
-export const StaleContentBanner = ({
-  state = "hidden",
-  message,
-  onRefresh,
-  refreshLabel = "Refresh",
-  className,
-}: StaleContentBannerProps) => {
+/**
+ * Props are a discriminated union on `state` so the Refresh affordance can never
+ * be forgotten: `state="stale"` REQUIRES `onRefresh` at the type level (the
+ * keyboard-reachable Refresh control is part of the a11y/UX contract — see
+ * accessibility-spec §4.3). `hidden`/`reconnecting` don't render the button, so
+ * `onRefresh` stays optional there (the button is omitted while reconnecting).
+ */
+export type StaleContentBannerProps = StaleContentBannerBaseProps &
+  (
+    | { state: "stale"; onRefresh: () => void }
+    | { state?: "hidden" | "reconnecting"; onRefresh?: () => void }
+  );
+
+export const StaleContentBanner = (props: StaleContentBannerProps) => {
+  const { message, refreshLabel = "Refresh", className } = props;
+  const state = props.state ?? "hidden";
+  const onRefresh = props.onRefresh;
   const visible = state !== "hidden";
   const text = message ?? (state === "hidden" ? "" : DEFAULT_MESSAGE[state]);
 
@@ -58,7 +65,9 @@ export const StaleContentBanner = ({
       className={cn(
         "ambient-presence",
         visible
-          ? "flex items-center justify-between gap-4 border-b border-border-muted bg-surface px-4 py-2 text-sm text-foreground-muted sm:px-6"
+          ? // Pins directly below the sticky nav (`h-14`, `top-0`, `z-40`) so a
+            // connection-loss notice stays visible while the page scrolls.
+            "sticky top-14 z-30 flex items-center justify-between gap-4 border-b border-border-muted bg-surface px-4 py-2 text-sm text-foreground-muted sm:px-6"
           : "sr-only",
         className,
       )}

--- a/plan/feature-reader-app-shell-1.md
+++ b/plan/feature-reader-app-shell-1.md
@@ -1,0 +1,159 @@
+---
+goal: Public reader app shell + routing skeleton (screen 0) for apps/reader
+version: 1.1
+date_created: 2026-06-09
+last_updated: 2026-06-09
+owner: Reader app track (Phase 8 — Public Reader App, milestone #9)
+status: "Completed"
+tags: [feature, frontend, reader, accessibility, app-shell]
+---
+
+# Introduction
+
+![Status: Completed](https://img.shields.io/badge/status-Completed-brightgreen)
+
+> **Completed 2026-06-09.** Shell shipped: `@repo/ui` `reader-*` composites
+> (nav, footer, live-dot, stale-content banner, skip-link) + 25 unit tests; the
+> `apps/reader` shell wrapper, anon Realtime provider, and Explore/Stories/Search
+> routing skeleton. Placement decision recorded in
+> [ADR-0033](../docs/adr/adr-0033-reader-shell-composites-in-ui-package.md); the
+> app-shell mid-fidelity spec carries an "Implemented (#258)" pointer. The full
+> `pnpm verify` gate passes, and the reader builds static with no Supabase env.
+> Open follow-ups: sub-640px hamburger focus-trap (#171), live-dot/banner final
+> visual treatment (#172).
+
+This plan implements GitHub issue **#258 — Public reader app shell + routing skeleton (screen 0)**. It builds the persistent reader chrome (top nav, brand/home, footer, skip-to-content link, single Sign-in deep-link, `ambient-presence` live-dot slot, and a reusable stale-content banner primitive) that wraps every `apps/reader` route. The shell is theme-fixed dark-only (ADR-0023), consumes `@repo/ui` design tokens + the #255 motion classes, and must **never** import or share the admin navigation `Shell` (ADR-0030 / ADR-0031). The scaffold (#254) is already complete; this plan composes the shell on top of it and lands a routing skeleton of placeholder routes so the shell can be verified across navigations. It blocks every other reader screen ticket.
+
+## 1. Requirements & Constraints
+
+- **REQ-001**: Root layout for `apps/reader` renders persistent chrome on every route: top nav (`Explore` / `Stories` / `Search`), brand/home affordance, footer, and skip-to-content link.
+- **REQ-002**: Top-nav destinations are exactly three — `Explore` (`/explore`), `Stories` (`/stories`), `Search` (`/search`, stubbed). No Periods/Characters/Events in global nav (`docs/design/public/06-mid-fidelity/00-app-shell.md` annotation 2).
+- **REQ-003**: A single, low-emphasis, right-aligned "Sign in" affordance deep-links **out** to the admin/auth surface (`apps/admin` auth route). It gates nothing and triggers no auth flow in the reader.
+- **REQ-004**: Landmark structure is `banner` (nav bar), `navigation` (top nav), `main` (content, with a programmatically-focusable `h1`), `contentinfo` (footer) — per accessibility-spec §2.3.
+- **REQ-005**: Skip-to-content link is the **first focusable element**, visible only on focus, and targets the `main` landmark (accessibility-spec §2.3; 00-app-shell annotation 5).
+- **REQ-006**: On route navigation, focus moves to the destination screen's `main` `h1`, made focusable via `tabindex="-1"` (accessibility-spec §2.2).
+- **REQ-007**: Stale-content banner primitive: `aria-live="polite"` region, pinned below the nav bar, with a keyboard-reachable Refresh/reconnect affordance in tab order, **no auto-focus**, announces once on appearance (accessibility-spec §4.3; motion-spec §3). Reused by each data screen.
+- **REQ-008**: `ambient-presence` live-dot slot near the brand: hidden (idle) / subscribed / update / paused states; opacity-only motion ≤200ms, never pulse/blink (00-app-shell Motion; motion.css `.ambient-presence`).
+- **REQ-009**: Realtime/SSR provider wiring exposes the **anon** Supabase client from `@repo/services` (browser client) to the reader tree. No service-role key.
+- **SEC-001**: Reader uses the anon key only. No `SUPABASE_SERVICE_ROLE_KEY` in any reader env, server module, or bundle.
+- **CON-001**: Theme is fixed dark-only — no theme toggle (ADR-0023). `color-scheme: dark` already set by `@repo/ui` globals.
+- **CON-002**: **No import of the admin navigation shell** (`@repo/ui/components/shell`) or any `apps/admin` route/component. The reader chrome is a separate composition (ADR-0030 / ADR-0031).
+- **CON-003**: Reduced-motion is enforced at the token layer (motion.css `@media (prefers-reduced-motion: reduce)`); shell components must rely on the `.ambient-presence` / `.enter-exit` classes rather than hand-rolled durations, so reduced-motion collapses to instant automatically (ADR-0032 IMP-002).
+- **CON-004**: Strict TypeScript (`strict`, `strictNullChecks`, `noUncheckedIndexedAccess`); zero-warnings lint (`eslint --max-warnings 0`); ESM only.
+- **CON-005**: Coverage threshold is 80% (`pnpm test:coverage`, enforced by the husky pre-push hook). New testable units in this plan live in `@repo/ui` (which has Vitest); `apps/reader` has no test runner.
+- **GUD-001**: Run `pnpm format` before staging (husky pre-commit runs `format:check`).
+- **GUD-002**: Mirror existing `apps/admin` conventions for fonts/metadata/providers; reuse `@repo/ui` primitives (`button`, `alert`, `skeleton`) rather than introducing new dependencies.
+- **PAT-001**: Server Component layout renders static chrome; a thin `"use client"` wrapper owns `usePathname()` for active-route state + focus-on-navigation, mirroring `apps/admin/app/(protected)/_components/protected-shell.tsx`.
+- **PAT-002**: Shared, reusable reader composites (nav, footer, stale banner, live dot) are authored in `@repo/ui/components/reader-*` so they are unit-testable and reusable by later screen tickets; `apps/reader` only wires Next-specific adapters (Link, pathname, env).
+
+## 2. Implementation Steps
+
+### Implementation Phase 1
+
+- GOAL-001: Author the reusable, framework-agnostic reader-shell composites in `@repo/ui` (nav, footer, live dot, stale-content banner, skip link), unit-tested and a11y-correct, with no Next.js coupling.
+
+| Task     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Completed | Date |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
+| TASK-001 | Create `packages/ui/src/components/reader-nav.tsx`: a `ReaderNav` presentational component rendering `<header role="banner">` with brand/home, a `<nav aria-label="Primary">` containing `Explore`/`Stories`/`Search`, the `ambient-presence` live-dot slot, and the Sign-in deep-link. Props: `currentPath: string`, `signInHref: string`, `LinkComponent` (generic link adapter, typed like `apps/admin/components/shell-link.tsx`), `liveState: "hidden" \| "subscribed" \| "update" \| "paused"`. Active item gets `aria-current="page"` + underline accent; uses `--color-foreground-muted` default / `--color-foreground` active per 00-app-shell token callouts. |           |      |
+| TASK-002 | Create `packages/ui/src/components/reader-footer.tsx`: a `ReaderFooter` rendering `<footer role="contentinfo">` with brand line + About / Sign in / Legal links via the same `LinkComponent` prop. Body S muted links, top hairline `--color-border-muted` (00-app-shell annotation 7).                                                                                                                                                                                                                                                                                                                                                                                 |           |      |
+| TASK-003 | Create `packages/ui/src/components/reader-live-dot.tsx`: a 6px `LiveDot` consuming the `.ambient-presence` class; `hidden` → not rendered/opacity 0, `subscribed` → `--color-foreground-subtle`, `update` → brief opacity rise to `--color-foreground-muted`, `paused` → static. Opacity-only, no pulse/blink (00-app-shell §Live dot; motion.css).                                                                                                                                                                                                                                                                                                                     |           |      |
+| TASK-004 | Create `packages/ui/src/components/stale-content-banner.tsx`: a `StaleContentBanner` primitive. Renders an `aria-live="polite"` region (`role="status"`) using the `.ambient-presence` class, pinned-below-bar styling, banner **text** (never color-only), and a Refresh button (reuse `@repo/ui/components/button`) in tab order. Props: `state: "hidden" \| "stale" \| "reconnecting"`, `message: string`, `onRefresh: () => void`. **No auto-focus**; announces once on appearance.                                                                                                                                                                                 |           |      |
+| TASK-005 | Create `packages/ui/src/components/skip-link.tsx`: a `SkipLink` rendering an anchor to `#main-content`, visually hidden until `:focus-visible`, then revealed. First-focusable contract documented in the component.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |           |      |
+| TASK-006 | Add Vitest unit tests next to each component: `reader-nav.test.tsx` (active-route `aria-current`, three nav items, Sign-in href, banner landmark role), `reader-footer.test.tsx` (contentinfo role + links), `stale-content-banner.test.tsx` (`aria-live="polite"`, Refresh in tab order, no focus stealing on appearance, hidden state renders nothing), `reader-live-dot.test.tsx` (state→class mapping), `skip-link.test.tsx` (href target + hidden-until-focus). Keep `@repo/ui` coverage ≥80%.                                                                                                                                                                     |           |      |
+
+### Implementation Phase 2
+
+- GOAL-002: Compose the shell in `apps/reader` — wire the Next.js root layout, the client shell wrapper (pathname + focus-on-nav), the anon Supabase Realtime/SSR provider, and the routing skeleton of placeholder routes.
+
+| Task     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Completed | Date |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | ---- |
+| TASK-007 | Create `apps/reader/components/reader-link.tsx`: a Next.js `Link` adapter matching the `LinkComponent` prop contract used by the `@repo/ui` reader composites (mirror `apps/admin/components/shell-link.tsx`).                                                                                                                                                                                                                                                                       |           |      |
+| TASK-008 | Create `apps/reader/lib/nav.ts`: export `READER_NAV_ITEMS` (`Explore`→`/explore`, `Stories`→`/stories`, `Search`→`/search`) and `SIGN_IN_HREF` (deep-link to the admin auth surface; derive from an env var `NEXT_PUBLIC_ADMIN_URL` with a sane fallback, e.g. `http://localhost:3000/auth/login`). Add `NEXT_PUBLIC_ADMIN_URL` to `.env.local.example`.                                                                                                                             |           |      |
+| TASK-009 | Create `apps/reader/app/_components/reader-shell.tsx` (`"use client"`): reads `usePathname()`, mounts `ReaderNav` + `StaleContentBanner` (hidden by default at this stage) + `<main id="main-content" tabIndex={-1}>{children}</main>` + `ReaderFooter`. On pathname change, move focus to the destination `h1` (or the `main` landmark) per REQ-006, independent of motion. Pass `READER_NAV_ITEMS`, `SIGN_IN_HREF`, `ReaderLink`. Does **not** import `@repo/ui/components/shell`. |           |      |
+| TASK-010 | Update `apps/reader/app/layout.tsx`: keep fonts + metadata; wrap `{children}` in `Providers` then `ReaderShell`, so chrome persists on every route. Ensure `<html lang="en">` retains the font CSS variables and dark register (already set).                                                                                                                                                                                                                                        |           |      |
+| TASK-011 | Update `apps/reader/app/providers.tsx`: keep `QueryClientProvider`; add a `ReaderRealtimeProvider` (new `apps/reader/app/_components/realtime-provider.tsx`, `"use client"`) that instantiates the anon **browser** Supabase client via `@repo/services` `supabase/client` and exposes it through context for screen-level subscriptions. No subscriptions started here (each screen owns its own — issue Non-Goals).                                                                |           |      |
+| TASK-012 | Update `apps/reader/app/page.tsx`: strip the scaffold placeholder card; render a minimal landing `main` body with a focusable `<h1 tabIndex={-1}>` so the shell + focus-on-nav are demonstrable. (Full landing screen is a separate ticket.)                                                                                                                                                                                                                                         |           |      |
+| TASK-013 | Create routing-skeleton placeholder routes so navigation across the persistent shell is verifiable: `apps/reader/app/explore/page.tsx`, `apps/reader/app/stories/page.tsx`, `apps/reader/app/search/page.tsx`. Each exports a server component with a single focusable `<h1 tabIndex={-1}>` and a one-line "coming soon" body. `Search` notes it is stubbed (00-app-shell annotation 2; screen-inventory §3 row 10).                                                                 |           |      |
+| TASK-014 | Verify `apps/reader/app/not-found.tsx` renders inside the shell with a focusable `h1`; adjust the existing `<main>` so it does not double-wrap the shell's `main` landmark (it should render shell-`main` content, not its own `role="main"`).                                                                                                                                                                                                                                       |           |      |
+
+### Implementation Phase 3
+
+- GOAL-003: Validate accessibility, reduced-motion, anon-only access, and the full `pnpm verify` gate; document the shell.
+
+| Task     | Description                                                                                                                                                                                                                                                                                                         | Completed | Date |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
+| TASK-015 | Manual a11y pass: tab order is skip-link → brand → Explore → Stories → Search → Sign in → main → footer (accessibility-spec §2.1 / 00-app-shell §Accessibility row 1). Skip-link reveals on first Tab and jumps to `main`. Focus lands on destination `h1` on navigation.                                           |           |      |
+| TASK-016 | Manual reduced-motion pass: enable OS `prefers-reduced-motion: reduce`; confirm live-dot updates and stale-banner appearance are instant (no transition), via the token-layer collapse in motion.css.                                                                                                               |           |      |
+| TASK-017 | Confirm anon-only: grep the reader workspace for `SERVICE_ROLE`; confirm none present, `.env.local.example` carries only `NEXT_PUBLIC_SUPABASE_URL` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` (+ `NEXT_PUBLIC_ADMIN_URL`). Confirm no import path resolves into `apps/admin` or `@repo/ui/components/shell` (grep imports). |           |      |
+| TASK-018 | Run `pnpm format`, then `pnpm run check-types`, `pnpm run lint`, `pnpm run test:coverage`, `pnpm run build` (or `pnpm verify`). All must pass with the reader workspace included.                                                                                                                                   |           |      |
+| TASK-019 | Update `apps/reader/README.md` with a short "App shell" section: landmark map, the reusable `@repo/ui/components/reader-*` + `stale-content-banner` primitives, and the "never import the admin shell" rule.                                                                                                        |           |      |
+
+## 3. Alternatives
+
+- **ALT-001**: Author the nav/footer/banner directly inside `apps/reader/app` (no `@repo/ui` composites). Rejected: later reader screen tickets reuse the stale-content banner and live dot, and `apps/reader` has no Vitest runner — putting the logic in `@repo/ui` makes it reusable and unit-testable (CON-005, PAT-002).
+- **ALT-002**: Reuse the admin `Shell` (`@repo/ui/components/shell`) with reader props. Rejected outright — violates ADR-0030 / ADR-0031 and issue acceptance criterion "No import of the admin navigation shell." The reader chrome is a distinct composition (no sidebar, breadcrumb, or authoring affordances).
+- **ALT-003**: Implement the mobile hamburger focus-trap menu now. Deferred: exact mobile-menu focus-trap + Escape behavior is owned by #171 (00-app-shell open questions); this ticket provides responsive structure but the trap detail is out of scope. Build the breakpoint structure; leave the trap to #171.
+- **ALT-004**: Start a Realtime subscription in the shell provider. Rejected per issue Non-Goals — each screen owns its own subscription; this ticket only provides the anon client provider + the banner primitive.
+
+## 4. Dependencies
+
+- **DEP-001**: #254 (apps/reader scaffold) — **complete** (closed); provides package, fonts, providers, globals, tsconfig.
+- **DEP-002**: #255 (motion tokens + classes) — **complete** (merged, commits 01f0d0d / 9bbe783); provides `packages/ui/src/styles/motion.css` (`.ambient-presence`, `.enter-exit`, reduced-motion collapse) consumed via `@repo/ui/styles/globals.css`.
+- **DEP-003**: `@repo/services` anon Supabase clients — `packages/services/src/supabase/client.ts` (browser) and `server.ts` (SSR), both anon-key only.
+- **DEP-004**: `@repo/ui` primitives — `components/button.tsx`, `components/alert.tsx`, `components/skeleton.tsx`, `styles/tokens.css`, `styles/motion.css`.
+- **DEP-005**: ADR-0023 (dark-only), ADR-0030 (reader app placement), ADR-0031 (reader design divergence), ADR-0032 (motion tokens / reduced-motion contract).
+- **DEP-006**: `@tanstack/react-query` (already a reader dependency) for the QueryClientProvider.
+
+## 5. Files
+
+- **FILE-001**: `packages/ui/src/components/reader-nav.tsx` — new; `banner`/`navigation` chrome, brand, three nav items, Sign-in deep-link, live-dot slot.
+- **FILE-002**: `packages/ui/src/components/reader-footer.tsx` — new; `contentinfo` footer.
+- **FILE-003**: `packages/ui/src/components/reader-live-dot.tsx` — new; `ambient-presence` live dot.
+- **FILE-004**: `packages/ui/src/components/stale-content-banner.tsx` — new; reusable `aria-live="polite"` stale-content banner primitive.
+- **FILE-005**: `packages/ui/src/components/skip-link.tsx` — new; first-focusable skip-to-content link.
+- **FILE-006**: `packages/ui/src/components/{reader-nav,reader-footer,reader-live-dot,stale-content-banner,skip-link}.test.tsx` — new; Vitest unit tests.
+- **FILE-007**: `apps/reader/components/reader-link.tsx` — new; Next.js Link adapter.
+- **FILE-008**: `apps/reader/lib/nav.ts` — new; `READER_NAV_ITEMS` + `SIGN_IN_HREF`.
+- **FILE-009**: `apps/reader/app/_components/reader-shell.tsx` — new; client shell wrapper (pathname + focus-on-nav).
+- **FILE-010**: `apps/reader/app/_components/realtime-provider.tsx` — new; anon browser-client context provider.
+- **FILE-011**: `apps/reader/app/layout.tsx` — modify; wrap children in Providers + ReaderShell.
+- **FILE-012**: `apps/reader/app/providers.tsx` — modify; add ReaderRealtimeProvider.
+- **FILE-013**: `apps/reader/app/page.tsx` — modify; minimal landing with focusable `h1`.
+- **FILE-014**: `apps/reader/app/explore/page.tsx`, `apps/reader/app/stories/page.tsx`, `apps/reader/app/search/page.tsx` — new; routing-skeleton placeholders.
+- **FILE-015**: `apps/reader/app/not-found.tsx` — modify; render inside shell, single `main` landmark.
+- **FILE-016**: `apps/reader/.env.local.example` (or repo root `.env.local.example`) — modify; add `NEXT_PUBLIC_ADMIN_URL`.
+- **FILE-017**: `apps/reader/README.md` — modify; App shell documentation.
+
+## 6. Testing
+
+- **TEST-001**: `reader-nav.test.tsx` — renders `banner` + `navigation` landmarks; exactly three nav items; active route gets `aria-current="page"`; Sign-in renders the provided `signInHref`.
+- **TEST-002**: `stale-content-banner.test.tsx` — region is `aria-live="polite"`; Refresh button is keyboard-reachable and in tab order; appearance does **not** move focus; `hidden` state renders no live content; banner text present (never color-only).
+- **TEST-003**: `reader-footer.test.tsx` — `contentinfo` role; About/Sign in/Legal links resolve via `LinkComponent`.
+- **TEST-004**: `reader-live-dot.test.tsx` — state→class/color mapping (`hidden`/`subscribed`/`update`/`paused`); uses `.ambient-presence`; no pulse/blink animation declared.
+- **TEST-005**: `skip-link.test.tsx` — targets `#main-content`; hidden until focus; is first in DOM order.
+- **TEST-006**: Coverage — `pnpm test:coverage` stays ≥80% across `@repo/ui`.
+- **TEST-007** (manual): Navigate `/` → `/explore` → `/stories` → `/search`; shell persists, skip-link works, focus lands on each `h1`.
+- **TEST-008** (manual): OS reduced-motion on — banner/live-dot transitions are instant.
+- **TEST-009** (CI gate): `pnpm verify` (format / lint / check-types / test:coverage / build) green with `apps/reader` included.
+
+## 7. Risks & Assumptions
+
+- **RISK-001**: Focus-on-navigation in the App Router can fire before the destination `h1` mounts, or steal focus from in-page anchors. Mitigation: move focus in an effect keyed on `pathname`, target `main`/`h1` only, and guard against re-running on same-path renders.
+- **RISK-002**: Double `main` landmark — placeholder pages currently use their own `<main>`; the shell now owns `main`. Mitigation: pages render heading/content only; shell provides the single `main` (TASK-014).
+- **RISK-003**: `apps/reader` has no Vitest runner, so reader-local components are untested. Mitigation: put testable logic in `@repo/ui` (PAT-002); keep reader files as thin adapters.
+- **RISK-004**: Sign-in deep-link target may differ between local/prod admin URLs. Mitigation: drive from `NEXT_PUBLIC_ADMIN_URL` env with a documented fallback (TASK-008).
+- **ASSUMPTION-001**: The motion classes from #255 (`.ambient-presence`, reduced-motion token collapse) are available to `apps/reader` because its `globals.css` imports `@repo/ui/styles/globals.css`, which imports `motion.css`. (Verified in `packages/ui/src/styles/globals.css`.)
+- **ASSUMPTION-002**: The mobile hamburger focus-trap full behavior is deferred to #171; this ticket lands the responsive structure and breakpoints only.
+- **ASSUMPTION-003**: The `ambient-presence` live-dot is wired as a presentational slot driven by a prop; no Realtime subscription is started in the shell (Non-Goals) — the dot stays `hidden` until a screen drives it.
+
+## 8. Related Specifications / Further Reading
+
+- GitHub issue #258 — Public reader app shell + routing skeleton (screen 0)
+- GitHub issue #254 — Scaffold apps/reader (foundation); #255 — motion tokens; #171/#172 — deferred mobile-menu + live-dot detail
+- `docs/design/public/06-mid-fidelity/00-app-shell.md` — mid-fidelity app-shell spec (tokens, states, motion, a11y)
+- `docs/design/public/04-wireframes/00-app-shell.md` — app-shell wireframe + annotations
+- `docs/design/public/06-mid-fidelity/accessibility-spec.md` — focus order, landmarks, live-region verbosity, reduced-motion catalog
+- `docs/design/public/02-screen-inventory.md` §3 — system states incl. connection-loss / stale-content banner scope
+- `docs/design/public/06-mid-fidelity/motion-spec.md` §2.5/§3/§5 — `ambient-presence` + reduced-motion contract
+- ADR-0023 (dark-mode-only), ADR-0030 (reader app placement), ADR-0031 (reader design divergence), ADR-0032 (reader motion tokens)
+- Reference implementation pattern: `apps/admin/app/(protected)/_components/protected-shell.tsx`, `apps/admin/components/shell-link.tsx`


### PR DESCRIPTION
## Summary

Builds the persistent public-reader chrome (**screen 0**) that wraps every `apps/reader` route — the host every other reader screen mounts into. Closes #258.

- **Top nav** (Explore / Stories / Search), brand/home, footer, skip-to-content link, and a quiet **Sign in** affordance that deep-links **out** to admin/auth (gates nothing).
- **Dark-only** (ADR-0023); consumes `@repo/ui` tokens + the #255 motion classes. **Never imports the admin `Shell`** (ADR-0030 / ADR-0031).
- **Landmarks**: `banner` / `navigation` / `main` (focusable `h1`) / `contentinfo`; focus moves to the destination `h1` on navigation.
- **Stale-content banner primitive** — reusable `aria-live="polite"` region, Refresh in tab order, no auto-focus — plus an `ambient-presence` live-dot slot.
- **Anon Realtime/SSR provider** wired from `@repo/services` (anon key only).

## Architecture

Shell composites live in `@repo/ui` as framework-agnostic `reader-*` components (unit-tested; reused by later screen tickets #65–#69); `apps/reader` holds only the Next glue (link adapter, pathname + focus-on-nav wrapper, anon provider, nav model, routes). Rationale recorded in **[ADR-0033](../blob/feat/reader-app-shell-258/docs/adr/adr-0033-reader-shell-composites-in-ui-package.md)**.

The anon Supabase client is created **lazily after mount** (dynamic import in an effect) so the module's env-guard never runs during prerender — the static landing route builds with **no Supabase env**. Reader access is **anon-only**; no service-role key in any reader env or bundle.

## Changes

| Area | Files |
| --- | --- |
| `@repo/ui` composites + tests | `reader-nav`, `reader-footer`, `reader-live-dot`, `stale-content-banner`, `skip-link`, `reader-link` (+ 25 tests) |
| `apps/reader` glue | `reader-shell`, `realtime-provider`, `reader-link` adapter, `lib/nav`, layout/providers wiring, `/explore` `/stories` `/search` routes, anon-only `.env.local.example` |
| Docs | ADR-0033 + index row; "Implemented (#258)" pointer on the app-shell mid-fidelity spec; implementation plan |

## Verification

- [x] `pnpm verify` (format / lint / check-types / test:coverage / build) — green
- [x] Reader builds **5 static routes with no Supabase env**
- [x] Audit: no `SERVICE_ROLE` anywhere in `apps/reader`; no admin-shell import
- [x] `@repo/ui` coverage 95.6% (≥80% gate)
- [x] Manual: tab order (skip-link first → nav → main → footer); focus lands on `h1` on navigation; OS reduced-motion makes banner/live-dot instant

## Deferred (existing tickets, per the design spec)

- Sub-640px hamburger **focus-trap** → #171
- Live-dot / banner **final visual treatment** → #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)