### PR TITLE
feat: publish/unpublish workflow for timelines and events (#48)

### DIFF
--- a/apps/admin/app/(protected)/events/[slug]/_components/event-detail-client.tsx
+++ b/apps/admin/app/(protected)/events/[slug]/_components/event-detail-client.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
+import { toast } from "@repo/ui/components/sonner";
 import type { TemporalData } from "@repo/services/schemas/temporal";
 import { TemporalService } from "@repo/services/modules/temporal-service";
 import { getEventBySlug } from "@repo/services/event-service";
@@ -881,8 +882,16 @@ export function EventDetailClient({ slug }: { slug: string }) {
               published={event.published ?? false}
               entityLabel="event"
               canPublish={isOwner}
-              onPublish={() => publish.mutate(event.id)}
-              onUnpublish={() => unpublish.mutate(event.id)}
+              onPublish={() =>
+                publish.mutate(event.id, {
+                  onSuccess: () => toast.success("Event published."),
+                })
+              }
+              onUnpublish={() =>
+                unpublish.mutate(event.id, {
+                  onSuccess: () => toast.success("Event unpublished."),
+                })
+              }
             />
             {canEdit && (
               <Link

--- a/apps/admin/app/(protected)/events/_components/event-list-client.tsx
+++ b/apps/admin/app/(protected)/events/_components/event-list-client.tsx
@@ -2,16 +2,26 @@
 
 import * as React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@repo/ui/components/sonner";
 import { CornerDownRight, Plus } from "lucide-react";
 import type { Era, TemporalData } from "@repo/services/schemas/temporal";
-import type {
-  EventDetailScope,
-  EventFilters,
-  EventListRow,
-  EventType,
+import {
+  publishEvent,
+  unpublishEvent,
+  type EventDetailScope,
+  type EventFilters,
+  type EventListRow,
+  type EventType,
 } from "@repo/services/event-service";
+import { BulkActionBar } from "@repo/ui/components/bulk-action-bar";
 import { Button } from "@repo/ui/components/button";
-import { DataTable, type DataTableProps } from "@repo/ui/components/data-table";
+import {
+  DataTable,
+  createSelectColumn,
+  type DataTableProps,
+  type RowSelectionState,
+} from "@repo/ui/components/data-table";
 import {
   FilterRail,
   type FilterGroup,
@@ -20,7 +30,7 @@ import {
 import { Skeleton } from "@repo/ui/components/skeleton";
 import { StatusBadge } from "@repo/ui/components/status-badge";
 import { TemporalDisplay } from "@repo/ui/components/temporal-display";
-import { useEventsPage } from "@repo/ui/hooks/use-events";
+import { eventKeys, useEventsPage } from "@repo/ui/hooks/use-events";
 import { useTimelinesPage } from "@repo/ui/hooks/use-timelines";
 import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
 
@@ -306,6 +316,7 @@ function buildColumns(
   onOpenSubTimeline: (slug: string) => void,
 ): DataTableProps<EventListRow, unknown>["columns"] {
   return [
+    createSelectColumn<EventListRow>(),
     {
       id: "drilldown",
       header: "",
@@ -484,6 +495,25 @@ export function EventListClient() {
 
   const { data, isPending, isError, refetch } = useEventsPage(client, filters);
 
+  // Current user — used to gate bulk publish/unpublish to owner-owned rows
+  // (publishing is owner-only; the DB trigger from #48 re-checks server-side).
+  const { data: userId = "" } = useQuery({
+    queryKey: ["auth", "user-id"],
+    queryFn: async () => {
+      const {
+        data: { user },
+      } = await client.auth.getUser();
+      return user?.id ?? "";
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  const queryClient = useQueryClient();
+
+  // Row selection for the bulk-action bar, keyed by event id (getRowId).
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+  const [bulkBusy, setBulkBusy] = React.useState(false);
+
   // Timelines power both the "Timeline" filter options and the per-row
   // timeline-name/slug lookup. Fetched once at a large page size.
   //
@@ -514,9 +544,58 @@ export function EventListClient() {
     [timelines],
   );
 
-  const rows = (data?.rows ?? []) as EventListRow[];
+  const rows = React.useMemo(
+    () => (data?.rows ?? []) as EventListRow[],
+    [data],
+  );
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  // Selection lives on the current page only; reset it whenever the query
+  // (filters/sort/page) changes so stale ids never leak into a bulk action.
+  // Keyed on the stable URL string and done in render (not an effect), per the
+  // list's existing prevUrl pattern.
+  const filterKey = searchParams.toString();
+  const [prevFilterKey, setPrevFilterKey] = React.useState(filterKey);
+  if (filterKey !== prevFilterKey) {
+    setPrevFilterKey(filterKey);
+    setRowSelection({});
+  }
+
+  const selectedRows = React.useMemo(
+    () => rows.filter((r) => rowSelection[r.id]),
+    [rows, rowSelection],
+  );
+  // Publishing is owner-only — exclude shared/other-owned rows from the action
+  // and report them as skipped.
+  const ownedSelected = React.useMemo(
+    () => selectedRows.filter((r) => r.user_id === userId),
+    [selectedRows, userId],
+  );
+  const skippedCount = selectedRows.length - ownedSelected.length;
+
+  async function runBulk(action: "publish" | "unpublish") {
+    const ids = ownedSelected.map((r) => r.id);
+    if (ids.length === 0) return;
+    setBulkBusy(true);
+    const fn = action === "publish" ? publishEvent : unpublishEvent;
+    const results = await Promise.allSettled(ids.map((id) => fn(client, id)));
+    setBulkBusy(false);
+    await queryClient.invalidateQueries({ queryKey: eventKeys.all });
+    setRowSelection({});
+
+    const failed = results.filter((r) => r.status === "rejected").length;
+    const ok = ids.length - failed;
+    const verb = action === "publish" ? "Published" : "Unpublished";
+    const noun = (n: number) => `event${n !== 1 ? "s" : ""}`;
+    if (failed === 0) {
+      toast.success(`${verb} ${ok} ${noun(ok)}.`);
+    } else if (ok === 0) {
+      toast.error(`Couldn't ${action} ${failed} ${noun(failed)}. Try again.`);
+    } else {
+      toast.warning(`${verb} ${ok} ${noun(ok)}; ${failed} failed.`);
+    }
+  }
   const hasFilters =
     parsed.types.length > 0 ||
     parsed.eras.length > 0 ||
@@ -834,11 +913,25 @@ export function EventListClient() {
           )}
 
           {!isError && !isPending && total > 0 && (
-            <DataTable
-              columns={columns}
-              data={rows}
-              onRowClick={handleRowClick}
-            />
+            <div className="space-y-3">
+              <BulkActionBar
+                count={ownedSelected.length}
+                skippedCount={skippedCount}
+                entityLabel="event"
+                busy={bulkBusy}
+                onPublish={() => void runBulk("publish")}
+                onUnpublish={() => void runBulk("unpublish")}
+                onClear={() => setRowSelection({})}
+              />
+              <DataTable
+                columns={columns}
+                data={rows}
+                onRowClick={handleRowClick}
+                getRowId={(row) => row.id}
+                rowSelection={rowSelection}
+                onRowSelectionChange={setRowSelection}
+              />
+            </div>
           )}
         </div>
 

--- a/apps/admin/app/(protected)/timelines/[slug]/_components/timeline-detail-client.tsx
+++ b/apps/admin/app/(protected)/timelines/[slug]/_components/timeline-detail-client.tsx
@@ -17,11 +17,11 @@ import {
   X,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
+import { toast } from "@repo/ui/components/sonner";
 import type { TemporalData } from "@repo/services/schemas/temporal";
 import {
   getTimelineBySlug,
   getTimelineEventsUnion,
-  TimelinePublishError,
   type TimelineEventWithMembership,
 } from "@repo/services/timeline-service";
 import { getCharacterById } from "@repo/services/character-service";
@@ -1181,18 +1181,17 @@ export function TimelineDetailClient({ slug }: { slug: string }) {
               }
               onPublish={() =>
                 publish.mutate(timeline.id, {
-                  onError: (err) => {
-                    if (
-                      err instanceof TimelinePublishError &&
-                      err.code === "no_events"
-                    ) {
-                      // BLOCKED: no toast infrastructure yet — button is already disabled by publishDisabledReason
-                      console.error("Publish blocked: no linked events");
-                    }
-                  },
+                  onSuccess: () => toast.success("Timeline published."),
+                  // The no-linked-events precondition (#212) surfaces via the
+                  // global mutation-error toast (TimelinePublishError → guidance
+                  // copy); the publish button is also disabled in that state.
                 })
               }
-              onUnpublish={() => unpublish.mutate(timeline.id)}
+              onUnpublish={() =>
+                unpublish.mutate(timeline.id, {
+                  onSuccess: () => toast.success("Timeline unpublished."),
+                })
+              }
             />
             {canEdit && (
               <Link

--- a/apps/admin/app/(protected)/timelines/_components/timeline-list-client.tsx
+++ b/apps/admin/app/(protected)/timelines/_components/timeline-list-client.tsx
@@ -2,16 +2,28 @@
 
 import * as React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@repo/ui/components/sonner";
 import { Globe, Lock, Plus, Users } from "lucide-react";
 import type { TemporalData } from "@repo/services/schemas/temporal";
-import type { TimelineFilters } from "@repo/services/timeline-service";
+import {
+  publishTimeline,
+  unpublishTimeline,
+  type TimelineFilters,
+} from "@repo/services/timeline-service";
+import { BulkActionBar } from "@repo/ui/components/bulk-action-bar";
 import { Button } from "@repo/ui/components/button";
-import { DataTable, type DataTableProps } from "@repo/ui/components/data-table";
+import {
+  DataTable,
+  createSelectColumn,
+  type DataTableProps,
+  type RowSelectionState,
+} from "@repo/ui/components/data-table";
 import { FilterRail, type FilterGroup } from "@repo/ui/components/filter-rail";
 import { Skeleton } from "@repo/ui/components/skeleton";
 import { StatusBadge } from "@repo/ui/components/status-badge";
 import { TemporalDisplay } from "@repo/ui/components/temporal-display";
-import { useTimelinesPage } from "@repo/ui/hooks/use-timelines";
+import { timelineKeys, useTimelinesPage } from "@repo/ui/hooks/use-timelines";
 import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
 
 // ---------------------------------------------------------------------------
@@ -23,6 +35,7 @@ type Visibility = "private" | "public" | "shared";
 
 interface TimelineRow {
   id: string;
+  user_id: string;
   title: string;
   slug: string;
   timeline_type: TimelineType | null;
@@ -213,6 +226,7 @@ function buildColumns(
   onRowClick: (row: TimelineRow) => void,
 ): DataTableProps<TimelineRow, unknown>["columns"] {
   return [
+    createSelectColumn<TimelineRow>(),
     {
       accessorKey: "title",
       header: "Title",
@@ -375,9 +389,77 @@ export function TimelineListClient() {
     filters,
   );
 
-  const rows = (data?.rows ?? []) as unknown as TimelineRow[];
+  // Current user — bulk publish/unpublish is owner-only (the timelines RLS
+  // UPDATE policy is owner/admin, so non-owned rows are excluded here too).
+  const { data: userId = "" } = useQuery({
+    queryKey: ["auth", "user-id"],
+    queryFn: async () => {
+      const {
+        data: { user },
+      } = await client.auth.getUser();
+      return user?.id ?? "";
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  const queryClient = useQueryClient();
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+  const [bulkBusy, setBulkBusy] = React.useState(false);
+
+  const rows = React.useMemo(
+    () => (data?.rows ?? []) as unknown as TimelineRow[],
+    [data],
+  );
   const total = data?.total ?? 0;
   const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  // Reset selection whenever the query (filters/sort/page) changes. Keyed on the
+  // stable URL string — `filters` is a fresh object each render, so comparing it
+  // by reference would loop. Done in render per the list's prevUrlSearch pattern.
+  const filterKey = searchParams.toString();
+  const [prevFilterKey, setPrevFilterKey] = React.useState(filterKey);
+  if (filterKey !== prevFilterKey) {
+    setPrevFilterKey(filterKey);
+    setRowSelection({});
+  }
+
+  const selectedRows = React.useMemo(
+    () => rows.filter((r) => rowSelection[r.id]),
+    [rows, rowSelection],
+  );
+  const ownedSelected = React.useMemo(
+    () => selectedRows.filter((r) => r.user_id === userId),
+    [selectedRows, userId],
+  );
+  const skippedCount = selectedRows.length - ownedSelected.length;
+
+  async function runBulk(action: "publish" | "unpublish") {
+    const ids = ownedSelected.map((r) => r.id);
+    if (ids.length === 0) return;
+    setBulkBusy(true);
+    const fn = action === "publish" ? publishTimeline : unpublishTimeline;
+    const results = await Promise.allSettled(ids.map((id) => fn(client, id)));
+    setBulkBusy(false);
+    await queryClient.invalidateQueries({ queryKey: timelineKeys.all });
+    setRowSelection({});
+
+    const failed = results.filter((r) => r.status === "rejected").length;
+    const ok = ids.length - failed;
+    const verb = action === "publish" ? "Published" : "Unpublished";
+    const noun = (n: number) => `timeline${n !== 1 ? "s" : ""}`;
+    if (failed === 0) {
+      toast.success(`${verb} ${ok} ${noun(ok)}.`);
+    } else if (ok === 0) {
+      // Publish can fail the linked-events precondition (#212); surface it.
+      toast.error(
+        action === "publish"
+          ? `Couldn't publish ${failed} ${noun(failed)}. Each needs at least one linked event.`
+          : `Couldn't unpublish ${failed} ${noun(failed)}. Try again.`,
+      );
+    } else {
+      toast.warning(`${verb} ${ok} ${noun(ok)}; ${failed} failed.`);
+    }
+  }
   const hasFilters =
     types.length > 0 ||
     visibilities.length > 0 ||
@@ -641,11 +723,25 @@ export function TimelineListClient() {
           )}
 
           {!isError && !isPending && total > 0 && (
-            <DataTable
-              columns={columns}
-              data={rows}
-              onRowClick={handleRowClick}
-            />
+            <div className="space-y-3">
+              <BulkActionBar
+                count={ownedSelected.length}
+                skippedCount={skippedCount}
+                entityLabel="timeline"
+                busy={bulkBusy}
+                onPublish={() => void runBulk("publish")}
+                onUnpublish={() => void runBulk("unpublish")}
+                onClear={() => setRowSelection({})}
+              />
+              <DataTable
+                columns={columns}
+                data={rows}
+                onRowClick={handleRowClick}
+                getRowId={(row) => row.id}
+                rowSelection={rowSelection}
+                onRowSelectionChange={setRowSelection}
+              />
+            </div>
           )}
         </div>
 

--- a/apps/admin/app/providers.tsx
+++ b/apps/admin/app/providers.tsx
@@ -4,36 +4,60 @@ import {
   QueryClient,
   QueryClientProvider,
   QueryCache,
+  MutationCache,
 } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useState, type ReactNode } from "react";
+import { Toaster, toast } from "@repo/ui/components/sonner";
+import { TimelinePublishError } from "@repo/services/timeline-service";
+
+/**
+ * Maps a mutation error to a user-facing message. Centralized here so every
+ * failed mutation surfaces a single, consistent toast (no per-call-site
+ * duplication). Specific publish-workflow failures get tailored copy:
+ *  - timeline publish with no linked events (#212 guard, TimelinePublishError)
+ *  - event publish by a non-owner (#48 DB trigger — assertNoError wraps the
+ *    Postgres message rather than its 42501 code, so we match on the text)
+ */
+function mutationErrorMessage(error: unknown): string {
+  if (error instanceof TimelinePublishError && error.code === "no_events") {
+    return "Add at least one linked event before publishing this timeline.";
+  }
+  if (error instanceof Error && /publication state/i.test(error.message)) {
+    return "Only the owner can change publication state.";
+  }
+  return "Something went wrong. Please try again.";
+}
 
 /**
  * Global QueryClient defaults:
  * - 30s staleTime for list queries (overridden per-hook as needed)
  * - Retry once on failure (avoids hammering the API on transient errors)
- * - Log errors (queries and mutations) in development; swap for a toast handler once toast infra lands
+ * - Query errors log in development (lists render their own inline error +
+ *   Retry, so they are not toasted); mutation errors toast a friendly message.
  */
 function makeQueryClient() {
   return new QueryClient({
     queryCache: new QueryCache({
       onError: (error) => {
+        // Lists render their own inline error + Retry, so a failed/aborted
+        // query (e.g. a refetch cancelled during navigation) isn't fatal. Use
+        // console.warn, not console.error: Next 16's dev devtools intercept
+        // console.error and escalate it to the red error overlay.
         if (process.env.NODE_ENV === "development") {
-          console.error("[QueryClient] query error:", error);
+          console.warn("[QueryClient] query error:", error);
         }
+      },
+    }),
+    mutationCache: new MutationCache({
+      onError: (error) => {
+        toast.error(mutationErrorMessage(error));
       },
     }),
     defaultOptions: {
       queries: {
         staleTime: 30_000,
         retry: 1,
-      },
-      mutations: {
-        onError: (error: unknown) => {
-          if (process.env.NODE_ENV === "development") {
-            console.error("[QueryClient] mutation error:", error);
-          }
-        },
       },
     },
   });
@@ -47,7 +71,7 @@ interface ProvidersProps {
  * Root client providers for the admin app.
  * Wraps the app tree in a QueryClientProvider with a stable QueryClient
  * instance (created once per component mount, not on every render), plus
- * the ReactQueryDevtools panel in development.
+ * the Sonner toaster and the ReactQueryDevtools panel in development.
  */
 export function Providers({ children }: ProvidersProps) {
   // useState ensures the QueryClient is only created once per component
@@ -57,6 +81,7 @@ export function Providers({ children }: ProvidersProps) {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
+      <Toaster />
       {process.env.NODE_ENV === "development" && (
         <ReactQueryDevtools initialIsOpen={false} />
       )}

--- a/packages/ui/src/components/bulk-action-bar.stories.tsx
+++ b/packages/ui/src/components/bulk-action-bar.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { BulkActionBar } from "./bulk-action-bar";
+
+const meta = {
+  title: "Components/Bulk Action Bar",
+  component: BulkActionBar,
+  parameters: { layout: "padded" },
+  args: {
+    count: 4,
+    entityLabel: "event",
+    onClear: () => {},
+  },
+} satisfies Meta<typeof BulkActionBar>;
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SingleRow: Story = {
+  args: { count: 1 },
+};
+
+export const WithSkipped: Story = {
+  args: { count: 3, skippedCount: 2 },
+};
+
+export const Busy: Story = {
+  args: { busy: true },
+};
+
+export const Timelines: Story = {
+  args: { count: 2, entityLabel: "timeline" },
+};

--- a/packages/ui/src/components/bulk-action-bar.test.tsx
+++ b/packages/ui/src/components/bulk-action-bar.test.tsx
@@ -134,11 +134,12 @@ describe("BulkActionBar", () => {
     rerender(
       <BulkActionBar count={3} busy onPublish={onPublish} onClear={vi.fn()} />,
     );
-    await user.click(
-      within(screen.getByRole("dialog")).getByRole("button", {
-        name: "Publish",
-      }),
+    const confirmButton = within(screen.getByRole("dialog")).getByRole(
+      "button",
+      { name: "Publish" },
     );
+    expect(confirmButton).toBeDisabled();
+    await user.click(confirmButton);
     expect(onPublish).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/bulk-action-bar.test.tsx
+++ b/packages/ui/src/components/bulk-action-bar.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { BulkActionBar } from "./bulk-action-bar";
+
+describe("BulkActionBar", () => {
+  it("renders nothing when there is nothing to act on", () => {
+    const { container } = render(<BulkActionBar count={0} onClear={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the selected count and pluralizes the entity noun", async () => {
+    const onPublish = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BulkActionBar
+        count={4}
+        entityLabel="event"
+        onPublish={onPublish}
+        onClear={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("4 selected")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Publish" }));
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Publish 4 events?")).toBeInTheDocument();
+  });
+
+  it("uses the singular noun for a single row", async () => {
+    const user = userEvent.setup();
+    render(
+      <BulkActionBar count={1} entityLabel="timeline" onClear={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Unpublish" }));
+    expect(
+      within(screen.getByRole("dialog")).getByText("Unpublish 1 timeline?"),
+    ).toBeInTheDocument();
+  });
+
+  it("batches publish into a single confirm before firing the callback", async () => {
+    const onPublish = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BulkActionBar
+        count={3}
+        entityLabel="event"
+        onPublish={onPublish}
+        onClear={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Publish" }));
+    expect(onPublish).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Publish" }));
+    expect(onPublish).toHaveBeenCalledOnce();
+  });
+
+  it("fires onUnpublish from the unpublish confirm", async () => {
+    const onUnpublish = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BulkActionBar
+        count={2}
+        entityLabel="event"
+        onUnpublish={onUnpublish}
+        onClear={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Unpublish" }));
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Unpublish",
+      }),
+    );
+    expect(onUnpublish).toHaveBeenCalledOnce();
+  });
+
+  it("notes skipped rows the user does not own", () => {
+    render(<BulkActionBar count={3} skippedCount={2} onClear={vi.fn()} />);
+    expect(screen.getByText(/2 not yours/)).toBeInTheDocument();
+  });
+
+  it("clears the selection via Cancel", async () => {
+    const onClear = vi.fn();
+    const user = userEvent.setup();
+    render(<BulkActionBar count={2} onClear={onClear} />);
+
+    // The toolbar Cancel (not the dialog one).
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClear).toHaveBeenCalledOnce();
+  });
+
+  it("disables the action buttons while busy", () => {
+    render(<BulkActionBar count={2} busy onClear={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Publish" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Unpublish" })).toBeDisabled();
+  });
+});

--- a/packages/ui/src/components/bulk-action-bar.test.tsx
+++ b/packages/ui/src/components/bulk-action-bar.test.tsx
@@ -32,7 +32,12 @@ describe("BulkActionBar", () => {
   it("uses the singular noun for a single row", async () => {
     const user = userEvent.setup();
     render(
-      <BulkActionBar count={1} entityLabel="timeline" onClear={vi.fn()} />,
+      <BulkActionBar
+        count={1}
+        entityLabel="timeline"
+        onUnpublish={vi.fn()}
+        onClear={vi.fn()}
+      />,
     );
 
     await user.click(screen.getByRole("button", { name: "Unpublish" }));
@@ -98,8 +103,42 @@ describe("BulkActionBar", () => {
   });
 
   it("disables the action buttons while busy", () => {
-    render(<BulkActionBar count={2} busy onClear={vi.fn()} />);
+    render(
+      <BulkActionBar
+        count={2}
+        busy
+        onPublish={vi.fn()}
+        onUnpublish={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
     expect(screen.getByRole("button", { name: "Publish" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Unpublish" })).toBeDisabled();
+  });
+
+  it("disables an action whose callback is not provided", () => {
+    render(<BulkActionBar count={2} onPublish={vi.fn()} onClear={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Publish" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Unpublish" })).toBeDisabled();
+  });
+
+  it("does not re-fire the callback when confirming while busy", async () => {
+    const onPublish = vi.fn();
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <BulkActionBar count={3} onPublish={onPublish} onClear={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Publish" }));
+    // A transition kicks off (busy) before the user can confirm again.
+    rerender(
+      <BulkActionBar count={3} busy onPublish={onPublish} onClear={vi.fn()} />,
+    );
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Publish",
+      }),
+    );
+    expect(onPublish).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/bulk-action-bar.tsx
+++ b/packages/ui/src/components/bulk-action-bar.tsx
@@ -145,6 +145,7 @@ export function BulkActionBar({
               type="button"
               size="sm"
               variant={pending === "unpublish" ? "destructive" : "primary"}
+              disabled={busy}
               onClick={confirm}
             >
               {pending === "unpublish" ? "Unpublish" : "Publish"}

--- a/packages/ui/src/components/bulk-action-bar.tsx
+++ b/packages/ui/src/components/bulk-action-bar.tsx
@@ -64,6 +64,9 @@ export function BulkActionBar({
   const noun = count === 1 ? entityLabel : plural;
 
   const confirm = () => {
+    // State updates are async, so a rapid double-click could re-enter before
+    // the dialog closes; bail if a transition is already in flight.
+    if (busy) return;
     if (pending === "publish") onPublish?.();
     else if (pending === "unpublish") onUnpublish?.();
     setPending(null);
@@ -91,7 +94,7 @@ export function BulkActionBar({
           type="button"
           size="sm"
           variant="primary"
-          disabled={busy}
+          disabled={busy || !onPublish}
           onClick={() => setPending("publish")}
         >
           Publish
@@ -100,7 +103,7 @@ export function BulkActionBar({
           type="button"
           size="sm"
           variant="secondary"
-          disabled={busy}
+          disabled={busy || !onUnpublish}
           onClick={() => setPending("unpublish")}
         >
           Unpublish

--- a/packages/ui/src/components/bulk-action-bar.tsx
+++ b/packages/ui/src/components/bulk-action-bar.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@repo/ui/lib/utils";
+import { Button } from "./button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./dialog";
+
+/**
+ * BulkActionBar — the multi-select action bar for list pages (wireframe
+ * docs/design/admin/02-wireframes/16-publish-workflow.md §3).
+ *
+ * Shows "N selected · [Publish] [Unpublish] [Cancel]" for the currently
+ * selected rows and routes each transition through a single **batched** confirm
+ * dialog ("Publish 4 events?") rather than one dialog per row. `count` is the
+ * number of *actionable* (owner-owned) rows — the consumer filters out
+ * non-owned/shared rows before passing it, and passes the excluded total as
+ * `skippedCount` so the bar can note them. Renders nothing when there is
+ * nothing to act on.
+ */
+export interface BulkActionBarProps {
+  /** Number of selected rows the current user may publish/unpublish. */
+  count: number;
+  /** Singular noun for the entity, e.g. "event" or "timeline". */
+  entityLabel?: string;
+  /** Plural override; defaults to `entityLabel + "s"`. */
+  entityLabelPlural?: string;
+  onPublish?: () => void;
+  onUnpublish?: () => void;
+  /** Clear the selection (Cancel). */
+  onClear: () => void;
+  /** Selected rows excluded because the user does not own them. */
+  skippedCount?: number;
+  /** Disable actions while a transition is in flight. */
+  busy?: boolean;
+  className?: string;
+}
+
+type PendingAction = "publish" | "unpublish" | null;
+
+export function BulkActionBar({
+  count,
+  entityLabel = "item",
+  entityLabelPlural,
+  onPublish,
+  onUnpublish,
+  onClear,
+  skippedCount = 0,
+  busy = false,
+  className,
+}: BulkActionBarProps) {
+  const [pending, setPending] = React.useState<PendingAction>(null);
+
+  if (count <= 0) return null;
+
+  const plural = entityLabelPlural ?? `${entityLabel}s`;
+  const noun = count === 1 ? entityLabel : plural;
+
+  const confirm = () => {
+    if (pending === "publish") onPublish?.();
+    else if (pending === "unpublish") onUnpublish?.();
+    setPending(null);
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label="Bulk actions"
+      className={cn(
+        "flex flex-wrap items-center gap-3 rounded-md border border-border bg-surface px-4 py-2 text-sm",
+        className,
+      )}
+    >
+      <span className="font-medium">
+        {count} selected
+        {skippedCount > 0 && (
+          <span className="ml-1 text-foreground-muted">
+            ({skippedCount} not yours — skipped)
+          </span>
+        )}
+      </span>
+      <div className="ml-auto flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="primary"
+          disabled={busy}
+          onClick={() => setPending("publish")}
+        >
+          Publish
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          disabled={busy}
+          onClick={() => setPending("unpublish")}
+        >
+          Unpublish
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={onClear}>
+          Cancel
+        </Button>
+      </div>
+
+      <Dialog
+        open={pending !== null}
+        onOpenChange={(open) => {
+          if (!open) setPending(null);
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {pending === "unpublish"
+                ? `Unpublish ${count} ${noun}?`
+                : `Publish ${count} ${noun}?`}
+            </DialogTitle>
+            <DialogDescription>
+              {pending === "unpublish"
+                ? `They will revert to drafts and stop appearing in reader-facing views. Visibility is unchanged.`
+                : `They will appear to readers according to their visibility settings. You can unpublish at any time.`}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setPending(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={pending === "unpublish" ? "destructive" : "primary"}
+              onClick={confirm}
+            >
+              {pending === "unpublish" ? "Unpublish" : "Publish"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/packages/ui/src/components/data-table.test.tsx
+++ b/packages/ui/src/components/data-table.test.tsx
@@ -102,6 +102,46 @@ describe("DataTable", () => {
     expect(selectAll).toHaveAttribute("aria-checked", "true");
   });
 
+  it("lifts selection to the parent when controlled via rowSelection + getRowId", async () => {
+    const user = userEvent.setup();
+    const onRowSelectionChange = vi.fn();
+
+    render(
+      <DataTable
+        columns={COLUMNS}
+        data={ROWS}
+        getRowId={(row) => row.id}
+        rowSelection={{}}
+        onRowSelectionChange={onRowSelectionChange}
+      />,
+    );
+
+    const [firstRowCheckbox] = screen.getAllByRole("checkbox", {
+      name: /select row/i,
+    });
+
+    await user.click(firstRowCheckbox!);
+    expect(onRowSelectionChange).toHaveBeenCalled();
+  });
+
+  it("reflects controlled rowSelection state on the row checkboxes", () => {
+    render(
+      <DataTable
+        columns={COLUMNS}
+        data={ROWS}
+        getRowId={(row) => row.id}
+        rowSelection={{ "1": true }}
+        onRowSelectionChange={vi.fn()}
+      />,
+    );
+
+    // ROWS[1] has id "1" and name "Ada".
+    const adaRow = screen.getByText("Ada").closest("tr");
+    expect(
+      within(adaRow!).getByRole("checkbox", { name: /select row/i }),
+    ).toBeChecked();
+  });
+
   it("does not trigger onRowClick when clicking a row selection checkbox", async () => {
     const user = userEvent.setup();
     const onRowClick = vi.fn();

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -3,6 +3,8 @@
 import * as React from "react";
 import {
   type ColumnDef,
+  type OnChangeFn,
+  type RowSelectionState,
   type SortingState,
   flexRender,
   getCoreRowModel,
@@ -22,11 +24,27 @@ import {
 } from "@repo/ui/components/table";
 import { Checkbox } from "@repo/ui/components/checkbox";
 
+// Re-exported so consumers (e.g. apps that don't depend on @tanstack/react-table
+// directly) can type their controlled selection state.
+export type { RowSelectionState } from "@tanstack/react-table";
+
 export interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   onRowClick?: (row: TData) => void;
   className?: string;
+  /**
+   * Controlled row-selection state, keyed by `getRowId`. Pass together with
+   * `onRowSelectionChange` to lift selection to the parent (e.g. to drive a
+   * bulk-action bar). Omit both to keep the table's internal selection state.
+   */
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  /**
+   * Stable row identity used as the selection key — pass the entity id so the
+   * selection survives sorting/refetch. Defaults to the row index.
+   */
+  getRowId?: (row: TData, index: number) => string;
 }
 
 export function DataTable<TData, TValue>({
@@ -34,6 +52,9 @@ export function DataTable<TData, TValue>({
   data,
   onRowClick,
   className,
+  rowSelection,
+  onRowSelectionChange,
+  getRowId,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
 
@@ -44,7 +65,15 @@ export function DataTable<TData, TValue>({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     onSortingChange: setSorting,
-    state: { sorting },
+    // Only override the defaults when controlled — passing `undefined` for
+    // `onRowSelectionChange` would clobber TanStack's internal state updater and
+    // break the uncontrolled checkboxes.
+    ...(getRowId ? { getRowId } : {}),
+    ...(onRowSelectionChange ? { onRowSelectionChange } : {}),
+    state: {
+      sorting,
+      ...(rowSelection !== undefined ? { rowSelection } : {}),
+    },
   });
 
   return (

--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -8,7 +8,7 @@ import {
   TriangleAlert,
 } from "lucide-react";
 import { useTheme } from "next-themes";
-import { Toaster as Sonner } from "sonner";
+import { Toaster as Sonner, toast } from "sonner";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
@@ -42,4 +42,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   );
 };
 
-export { Toaster };
+export { Toaster, toast };

--- a/supabase/migrations/00021_events_publish_owner_guard.sql
+++ b/supabase/migrations/00021_events_publish_owner_guard.sql
@@ -15,6 +15,10 @@
 -- `published` or `published_at` unless the actor is the owner or an admin.
 -- Editors keep full edit rights on every other column.
 --
+-- A trigger-level WHEN clause restricts firing to updates that actually touch
+-- the publication columns, so ordinary content edits (the common case for
+-- collaborator-editors) never pay the PL/pgSQL call.
+--
 -- Timelines already have this guard for free — `update_timelines` is owner/admin
 -- only — so this is events-only.
 --
@@ -30,9 +34,9 @@ SECURITY INVOKER
 SET search_path = ''
 AS $$
 BEGIN
-  IF (NEW.published    IS DISTINCT FROM OLD.published
-      OR NEW.published_at IS DISTINCT FROM OLD.published_at)
-     AND auth.uid() IS NOT NULL
+  -- The WHEN clause already guarantees a publication-column change reached us;
+  -- here we only decide whether the actor is allowed to make it.
+  IF auth.uid() IS NOT NULL
      AND auth.uid() <> OLD.user_id
      AND NOT public.is_admin() THEN
     RAISE EXCEPTION 'Only the owner can change an event''s publication state'
@@ -44,4 +48,7 @@ $$;
 
 CREATE TRIGGER guard_event_publish
   BEFORE UPDATE ON public.events
-  FOR EACH ROW EXECUTE FUNCTION public.guard_event_publish_owner_only();
+  FOR EACH ROW
+  WHEN (NEW.published    IS DISTINCT FROM OLD.published
+        OR NEW.published_at IS DISTINCT FROM OLD.published_at)
+  EXECUTE FUNCTION public.guard_event_publish_owner_only();

--- a/supabase/migrations/00021_events_publish_owner_guard.sql
+++ b/supabase/migrations/00021_events_publish_owner_guard.sql
@@ -1,0 +1,47 @@
+-- ============================================================================
+-- 00021_events_publish_owner_guard.sql
+--
+-- Owner-only event publication (issue #48).
+--
+-- The `update_events` policy (00011) grants UPDATE to collaborator-editors
+-- (is_timeline_collab_editor) so they can edit an event's content. But the
+-- go-live decision — flipping `published` / `published_at` — is reserved to the
+-- row owner (or a global admin), per wireframe
+-- docs/design/admin/02-wireframes/16-publish-workflow.md ("Publishing is an
+-- editorial go-live decision reserved to ownership") and system-design §9.
+--
+-- RLS cannot express "editors may update every column except these two", so a
+-- BEFORE UPDATE trigger enforces the column-level rule: it rejects a change to
+-- `published` or `published_at` unless the actor is the owner or an admin.
+-- Editors keep full edit rights on every other column.
+--
+-- Timelines already have this guard for free — `update_timelines` is owner/admin
+-- only — so this is events-only.
+--
+-- auth.uid() IS NULL means there is no JWT (service_role / postgres, which
+-- bypass RLS for trusted server-side work); the guard does not apply there.
+-- Function is SECURITY INVOKER with a hardened empty search_path (#73).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.guard_event_publish_owner_only()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  IF (NEW.published    IS DISTINCT FROM OLD.published
+      OR NEW.published_at IS DISTINCT FROM OLD.published_at)
+     AND auth.uid() IS NOT NULL
+     AND auth.uid() <> OLD.user_id
+     AND NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Only the owner can change an event''s publication state'
+      USING ERRCODE = '42501';  -- insufficient_privilege
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER guard_event_publish
+  BEFORE UPDATE ON public.events
+  FOR EACH ROW EXECUTE FUNCTION public.guard_event_publish_owner_only();

--- a/supabase/tests/database/00021_events_publish_owner_guard_test.sql
+++ b/supabase/tests/database/00021_events_publish_owner_guard_test.sql
@@ -1,0 +1,121 @@
+-- pgTAP tests for 00021_events_publish_owner_guard.sql (issue #48 — owner-only
+-- event publication)
+--
+-- Strategy: seed an owner, an admin, and a collaborator-editor on a shared
+-- timeline that holds an owner-owned draft event. Impersonate each role via
+-- `SET LOCAL ROLE authenticated` + `SET LOCAL request.jwt.claims` and verify:
+--   - owner and admin may flip `published` / `published_at`
+--   - collaborator-editor may edit other columns but NOT the publish state
+--
+-- The collaborator-editor passes the update_events RLS USING clause, so the
+-- BEFORE UPDATE trigger RAISEs (42501) rather than RLS silently filtering — so
+-- these are throws_ok assertions.
+begin;
+create extension if not exists pgtap with schema extensions;
+
+-- ============================================================================
+-- Seed (runs as postgres, RLS bypassed)
+-- ============================================================================
+
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role,
+                        raw_user_meta_data)
+values
+  ('11111111-1111-1111-1111-111111111111'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'owner@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+   '{"first_name":"Owner","last_name":"User"}'::jsonb),
+  ('33333333-3333-3333-3333-333333333333'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'admin@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+   '{"first_name":"Admin","last_name":"User"}'::jsonb),
+  ('44444444-4444-4444-4444-444444444444'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'editor@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+   '{"first_name":"Editor","last_name":"User"}'::jsonb);
+
+update profiles set role = 'admin' where id = '33333333-3333-3333-3333-333333333333';
+
+insert into timelines (id, user_id, slug, title, temporal_data, published) values
+  ('aaaaaaaa-0001-0000-0000-000000000001'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'tl-shared', 'Shared Timeline',
+   '{"year":2000,"era":"CE"}'::jsonb, false);
+
+insert into timeline_collaborators (timeline_id, user_id, role) values
+  ('aaaaaaaa-0001-0000-0000-000000000001', '44444444-4444-4444-4444-444444444444', 'editor');
+
+-- Draft events owned by `owner`, one per transition under test.
+insert into events (id, user_id, slug, title, temporal_data, timeline_id, published) values
+  ('aaaaaaaa-0002-0000-0000-000000000001'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'ev-owner', 'Owner Event',
+   '{"year":2001,"era":"CE"}'::jsonb,
+   'aaaaaaaa-0001-0000-0000-000000000001', false),
+  ('aaaaaaaa-0002-0000-0000-000000000002'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'ev-admin', 'Admin Target Event',
+   '{"year":2002,"era":"CE"}'::jsonb,
+   'aaaaaaaa-0001-0000-0000-000000000001', false),
+  ('aaaaaaaa-0002-0000-0000-000000000003'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'ev-editor', 'Editor Target Event',
+   '{"year":2003,"era":"CE"}'::jsonb,
+   'aaaaaaaa-0001-0000-0000-000000000001', false);
+
+select plan(8);
+
+-- ============================================================================
+-- Trigger wiring exists
+-- ============================================================================
+select has_function('public', 'guard_event_publish_owner_only',
+  'guard_event_publish_owner_only() function exists');
+select has_trigger('events', 'guard_event_publish',
+  'guard_event_publish trigger exists on events');
+
+-- ============================================================================
+-- Owner may publish + unpublish own event
+-- ============================================================================
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+select lives_ok(
+  $$update events set published = true, published_at = now()
+      where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid$$,
+  'owner can PUBLISH own event');
+select lives_ok(
+  $$update events set published = false, published_at = null
+      where id = 'aaaaaaaa-0002-0000-0000-000000000001'::uuid$$,
+  'owner can UNPUBLISH own event');
+
+-- ============================================================================
+-- Admin may publish someone else's event
+-- ============================================================================
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"33333333-3333-3333-3333-333333333333"}';
+select lives_ok(
+  $$update events set published = true, published_at = now()
+      where id = 'aaaaaaaa-0002-0000-0000-000000000002'::uuid$$,
+  'admin can PUBLISH any event');
+
+-- ============================================================================
+-- Collaborator-editor: content edit OK, publish flip rejected
+-- ============================================================================
+reset role; reset request.jwt.claims;
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"44444444-4444-4444-4444-444444444444"}';
+select lives_ok(
+  $$update events set summary = 'edited by collab-editor'
+      where id = 'aaaaaaaa-0002-0000-0000-000000000003'::uuid$$,
+  'collaborator-editor can edit non-publish columns');
+select throws_ok(
+  $$update events set published = true, published_at = now()
+      where id = 'aaaaaaaa-0002-0000-0000-000000000003'::uuid$$,
+  '42501', null,
+  'collaborator-editor CANNOT publish an event');
+select throws_ok(
+  $$update events set published_at = now()
+      where id = 'aaaaaaaa-0002-0000-0000-000000000003'::uuid$$,
+  '42501', null,
+  'collaborator-editor CANNOT set published_at directly');
+
+reset role; reset request.jwt.claims;
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
Completes the publish/unpublish workflow for **timelines and events** (#48), building on the already-merged `PublishControl`, `StatusBadge`, publication filters, and the service+hook parity (PR #174).

Three remaining gaps closed:

### 1. Owner-only event publish — DB/service path
`update_events` RLS grants collaborator-editors UPDATE, so they could flip `published`/`published_at` via the service. New migration **`00021_events_publish_owner_guard.sql`** adds a `BEFORE UPDATE` trigger reserving publish-state changes to the owner/admin (editors keep all other edit rights; service-role exempt). Timelines were already owner-only. pgTAP coverage added (owner/admin publish OK; editor publish → `42501`).

### 2. Bulk multi-select publish/unpublish
- `DataTable` gains controlled row-selection props (backward-compatible; `createSelectColumn` already existed).
- New shared **`BulkActionBar`** — "N selected · Publish / Unpublish / Cancel" with a single **batched** confirm dialog.
- Wired into the events and timelines lists, **gated to owner-owned rows** (shared/other-owned rows are skipped and counted); selection resets on URL-query change.

### 3. Toast feedback
- Mounts the Sonner `Toaster` in admin providers.
- Detail headers toast publish/unpublish success; a global `MutationCache` handler maps `TimelinePublishError` (no-events, #212) and the new owner-guard error to friendly copy.
- Query-error logging switched to `console.warn` so Next 16 devtools don't escalate benign/aborted queries to the error overlay.

## Acceptance criteria (#48)
- [x] Timeline detail/list publish/unpublish consistent
- [x] Event detail/list publish/unpublish consistent
- [x] `published_at` set on publish, cleared on unpublish
- [x] Confirmation dialog for both actions (single batched confirm for bulk)
- [x] Published/draft badges on list rows, distinct from visibility
- [x] Publication-state filtering on relevant list pages
- [x] Owner-only gating enforced in UI **and** service/DB paths (collaborator-editor cannot publish)

## Validation
- `pnpm verify` green (format, lint, check-types, test:coverage 94.88%, build)
- `pnpm db:test` green — 383 assertions incl. 8 new for the owner guard

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)