### PR TITLE
fix(db): resolve duplicate migration version 00021

### DIFF
--- a/supabase/migrations/00022_fix_stories_rls_recursion.sql
+++ b/supabase/migrations/00022_fix_stories_rls_recursion.sql
@@ -1,5 +1,5 @@
 -- ============================================================================
--- 00021_fix_stories_rls_recursion.sql  (#276)
+-- 00022_fix_stories_rls_recursion.sql  (#276)
 --
 -- Fixes `infinite recursion detected in policy for relation "stories"`, raised
 -- on ANY read of `stories` — for anon AND authenticated callers alike (so the


### PR DESCRIPTION
Fixes #285.

## Problem

Two migrations shared the `00021` version prefix (both from #276), so `pnpm db:reset` aborted:

```
ERROR: duplicate key value violates unique constraint "schema_migrations_pkey"
Key (version)=(00021) already exists.
```

Supabase uses the numeric filename prefix as the `schema_migrations` primary key, so the second `00021` could never be recorded.

## Fix

Renumber the later of the two (`fix_stories_rls_recursion`, the second #276 commit) to `00022`:

```
00021_events_publish_owner_guard.sql
00022_fix_stories_rls_recursion.sql   # was 00021_…
```

Apply order is unchanged (it already sorted after `events_publish_owner_guard`), and the file's header comment was updated to match.

## Verification

- `pnpm db:reset` ✅ applies all migrations through `00022` cleanly (previously aborted at the second `00021`).

## Note

This is an infra/migration fix, independent of any feature work. `db:test` surfaces some pre-existing pgTAP failures that were masked while `db:reset` was broken — these are unrelated to this rename and are flagged in #285 for separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)