### PR TITLE
test(db): regression coverage for storage INSERT policy fix (#290)

### DIFF
--- a/supabase/migrations/00024_fix_storage_insert_policies.sql
+++ b/supabase/migrations/00024_fix_storage_insert_policies.sql
@@ -2,7 +2,7 @@
 -- 00024_fix_storage_insert_policies.sql
 --
 -- Fix broken (metadata->>'size')::bigint <= 5242880 check in Storage INSERT
--- policies (issue #293).
+-- policies (issue #290).
 --
 -- Root cause: Supabase Storage API v1.60+ inserts the storage.objects row
 -- before populating the metadata column. The WITH CHECK fires on INSERT and
@@ -15,7 +15,7 @@
 -- broken. Removing it from INSERT policies restores authenticated uploads.
 --
 -- Workaround applied in code: none needed after this migration.
--- See issue #293 and ADR-0009 (storage) for context.
+-- See issue #290 and ADR-0009 (storage) for context.
 -- ============================================================================
 
 -- media bucket

--- a/supabase/tests/database/00009_storage_buckets_and_policies_test.sql
+++ b/supabase/tests/database/00009_storage_buckets_and_policies_test.sql
@@ -2,7 +2,7 @@
 begin;
 create extension if not exists pgtap with schema extensions;
 
-select plan(20);
+select plan(17);
 
 -- ============================================================================
 -- Buckets exist with correct public/private + 5MB size limit
@@ -67,28 +67,12 @@ select is(
   'storage.objects has RLS enabled (Supabase default)'
 );
 
--- Verify INSERT policies contain the 5MB size check (literal pattern match)
-select ok(
-  (select qual is null and with_check like '%5242880%'
-    from pg_policies
-    where schemaname='storage' and tablename='objects'
-      and policyname='media_insert'),
-  'media_insert policy enforces 5MB limit in WITH CHECK'
-);
-select ok(
-  (select with_check like '%5242880%'
-    from pg_policies
-    where schemaname='storage' and tablename='objects'
-      and policyname='avatars_insert'),
-  'avatars_insert policy enforces 5MB limit in WITH CHECK'
-);
-select ok(
-  (select with_check like '%5242880%'
-    from pg_policies
-    where schemaname='storage' and tablename='objects'
-      and policyname='exports_insert'),
-  'exports_insert policy enforces 5MB limit in WITH CHECK'
-);
+-- NOTE: The per-policy (metadata->>'size')::bigint <= 5242880 WITH CHECK that
+-- 00009 originally placed on the INSERT policies was removed by migration 00024
+-- (it broke ALL authenticated uploads under Storage API v1.60+ — see issue #290).
+-- The 5MB limit is now enforced solely by the bucket-level file_size_limit
+-- asserted above (HTTP 413 before the row is written). Regression coverage that
+-- the broken check stays gone lives in 00024_fix_storage_insert_policies_test.sql.
 
 -- Verify public-read policies have NULL `roles` filter or include public
 -- (i.e., not restricted to authenticated only)
@@ -149,13 +133,14 @@ select ok(
 );
 
 -- INSERT policies have NULL `qual` (only WITH CHECK applies to INSERT)
--- and the WITH CHECK references the bucket_id and metadata->>'size'
+-- and the WITH CHECK references the bucket_id (metadata size check removed in
+-- 00024 — see issue #290).
 select ok(
-  (select with_check like '%bucket_id%' and with_check like '%metadata%'
+  (select qual is null and with_check like '%bucket_id%'
     from pg_policies
     where schemaname='storage' and tablename='objects'
       and policyname='media_insert'),
-  'media_insert WITH CHECK references bucket_id + metadata'
+  'media_insert WITH CHECK references bucket_id'
 );
 
 select * from finish();

--- a/supabase/tests/database/00024_fix_storage_insert_policies_test.sql
+++ b/supabase/tests/database/00024_fix_storage_insert_policies_test.sql
@@ -1,0 +1,130 @@
+-- pgTAP tests for 00024_fix_storage_insert_policies.sql (issue #290 — Storage
+-- INSERT policies block all authenticated uploads under Storage API v1.60+).
+--
+-- Background: 00009 put a (metadata->>'size')::bigint <= 5242880 WITH CHECK on
+-- the three INSERT policies. Storage API v1.60+ inserts the storage.objects row
+-- with metadata = NULL and populates size afterward, so the check fired on
+-- INSERT against NULL metadata, evaluated to NULL (not true), and rejected ALL
+-- authenticated uploads with 403. 00024 drops the size check; the bucket-level
+-- file_size_limit = 5242880 remains the real (HTTP 413) enforcement.
+--
+-- This test guards the fix two ways:
+--   1. STRUCTURAL — the broken metadata/size check is gone and stays gone.
+--   2. BEHAVIORAL — an authenticated INSERT with metadata = NULL (the exact
+--      v1.60+ scenario) succeeds.
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(10);
+
+-- ============================================================================
+-- STRUCTURAL: the (metadata->>'size') <= 5242880 check is gone from all three
+-- INSERT policies and must not reappear.
+-- ============================================================================
+
+select ok(
+  (select with_check not like '%5242880%' and with_check not like '%metadata%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='media_insert'),
+  'media_insert WITH CHECK no longer references metadata or the 5MB literal'
+);
+select ok(
+  (select with_check not like '%5242880%' and with_check not like '%metadata%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='avatars_insert'),
+  'avatars_insert WITH CHECK no longer references metadata or the 5MB literal'
+);
+select ok(
+  (select with_check not like '%5242880%' and with_check not like '%metadata%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='exports_insert'),
+  'exports_insert WITH CHECK no longer references metadata or the 5MB literal'
+);
+
+-- media / avatars INSERT now gate on bucket_id alone.
+select ok(
+  (select qual is null and with_check like '%bucket_id%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='media_insert'),
+  'media_insert gates on bucket_id only'
+);
+select ok(
+  (select qual is null and with_check like '%bucket_id%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='avatars_insert'),
+  'avatars_insert gates on bucket_id only'
+);
+
+-- exports INSERT retains its owner-prefix guard ((foldername(name))[1] = uid).
+select ok(
+  (select with_check like '%foldername%' and with_check like '%auth.uid()%'
+    from pg_policies
+    where schemaname='storage' and tablename='objects'
+      and policyname='exports_insert'),
+  'exports_insert retains the owner-prefix guard (foldername + auth.uid())'
+);
+
+-- ============================================================================
+-- The real enforcement after 00024: bucket-level file_size_limit stays at 5MB
+-- (the Storage API returns HTTP 413 before the row is ever written).
+-- ============================================================================
+
+select is(
+  (select count(*)::bigint from storage.buckets
+    where id in ('media','avatars','exports') and file_size_limit = 5242880),
+  3::bigint,
+  'all 3 buckets still enforce the 5MB file_size_limit (real HTTP-413 guard)'
+);
+
+-- ============================================================================
+-- BEHAVIORAL: reproduce the v1.60+ scenario. As an authenticated user, an
+-- INSERT into storage.objects with metadata = NULL must succeed. Before 00024
+-- this raised "new row violates row-level security policy" (403).
+-- ============================================================================
+
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role,
+                        raw_user_meta_data)
+values
+  ('11111111-1111-1111-1111-111111111111'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'uploader@local', '', now(), now(), now(), 'authenticated', 'authenticated',
+   '{"first_name":"Uploader","last_name":"User"}'::jsonb);
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+
+-- media bucket: gated on bucket_id only, so a NULL-metadata insert must pass.
+select lives_ok(
+  $$insert into storage.objects (bucket_id, name, owner_id, metadata)
+    values ('media', 'regression-290-media.png',
+            '11111111-1111-1111-1111-111111111111', NULL)$$,
+  'authenticated INSERT into media with NULL metadata succeeds (v1.60+ #290)'
+);
+
+-- avatars bucket: same gate.
+select lives_ok(
+  $$insert into storage.objects (bucket_id, name, owner_id, metadata)
+    values ('avatars', 'regression-290-avatar.png',
+            '11111111-1111-1111-1111-111111111111', NULL)$$,
+  'authenticated INSERT into avatars with NULL metadata succeeds (v1.60+ #290)'
+);
+
+-- exports bucket: owner-prefix guard means the path must start with the uid.
+select lives_ok(
+  $$insert into storage.objects (bucket_id, name, owner_id, metadata)
+    values ('exports',
+            '11111111-1111-1111-1111-111111111111/regression-290-export.json',
+            '11111111-1111-1111-1111-111111111111', NULL)$$,
+  'authenticated INSERT into exports (owner prefix, NULL metadata) succeeds (#290)'
+);
+
+reset role; reset request.jwt.claims;
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Closes the loose ends on **#290**. The fix migration `00024_fix_storage_insert_policies.sql` (commit 945138e) already removed the broken `WITH CHECK (metadata->>'size')::bigint <= 5242880` from the Storage INSERT policies — but two gaps let the bug silently return:

1. **The pgTAP suite was red on `main`.** `00009`'s test still asserted the old metadata/size check on the INSERT policies (`Failed tests: 10-12, 20`).
2. **No regression test guarded `00024`** — the broken check could be reintroduced without turning the suite red.

## Background

Storage API v1.60+ inserts the `storage.objects` row with `metadata = NULL` and populates size in a later step. The old `WITH CHECK` fired on INSERT against NULL metadata, evaluated to `NULL` (not `true`), and rejected **all** authenticated uploads with 403. The bucket-level `file_size_limit = 5242880` is the real enforcement (HTTP 413 before the row is written), so the per-policy check was both redundant and broken.

## Changes

- **`00009` test** — drop the stale `5242880`/`metadata` INSERT assertions (size enforcement is the bucket-level `file_size_limit`, still asserted), expect `media_insert` to gate on `bucket_id` only, and fix the plan count (`20` → `17`).
- **`00024` test** (new) — guards the fix two ways:
  - *Structural*: the metadata/size check is gone from all three INSERT policies and stays gone; `exports_insert` keeps its owner-prefix guard; all buckets keep the 5MB `file_size_limit`.
  - *Behavioral*: an `authenticated` INSERT with `metadata = NULL` succeeds on all three buckets — reproducing the exact v1.60+ scenario that previously 403'd.
- **`00024` migration header** — correct the issue reference (`#293` → `#290`). Comment-only; no DDL change.

## Verification

- `pnpm run db:reset` + `pnpm exec supabase test db` → **all 417 tests pass** from a clean migration apply.
- **Proved the new test bites**: temporarily re-added the broken check to the live `media_insert` policy → 00024 test failed on *both* the structural assertion (test 1) and the behavioral NULL-metadata insert (test 8); then reverted.

## Out of scope

Noticed but not touched: a test-file numbering drift — `00021_fix_stories_rls_recursion_test.sql` should be `00022_*` (matches migration 00022). Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)