### PR TITLE
fix(deps): pin single @tanstack/react-query version workspace-wide

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -61,7 +61,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@repo/services": "workspace:*",
-    "@tanstack/react-query": "^5.100.14",
+    "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@tanstack/react-query': ^5.101.0
+
 importers:
 
   .:
@@ -182,8 +185,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@tanstack/react-query':
-        specifier: ^5.100.14
-        version: 5.100.14(react@19.2.7)
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
       next:
         specifier: 16.2.9
         version: 16.2.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -348,8 +351,8 @@ importers:
         specifier: '>=2'
         version: 2.106.1
       '@tanstack/react-query':
-        specifier: ^5.100.14
-        version: 5.100.14(react@19.2.7)
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2391,9 +2394,6 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@tanstack/query-core@5.100.14':
-    resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
-
   '@tanstack/query-core@5.101.0':
     resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
 
@@ -2404,11 +2404,6 @@ packages:
     resolution: {integrity: sha512-cpZA0+WqKXwrwMfiWZEGGF6QrIWVQFbhBtxqDF5sQsAfrFf47HIE6fiPbQU3wyAUEN2+7UNqLCQe7oG6m3f93w==}
     peerDependencies:
       '@tanstack/react-query': ^5.101.0
-      react: ^18 || ^19
-
-  '@tanstack/react-query@5.100.14':
-    resolution: {integrity: sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==}
-    peerDependencies:
       react: ^18 || ^19
 
   '@tanstack/react-query@5.101.0':
@@ -5775,8 +5770,6 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0)
 
-  '@tanstack/query-core@5.100.14': {}
-
   '@tanstack/query-core@5.101.0': {}
 
   '@tanstack/query-devtools@5.101.0': {}
@@ -5785,11 +5778,6 @@ snapshots:
     dependencies:
       '@tanstack/query-devtools': 5.101.0
       '@tanstack/react-query': 5.101.0(react@19.2.7)
-      react: 19.2.7
-
-  '@tanstack/react-query@5.100.14(react@19.2.7)':
-    dependencies:
-      '@tanstack/query-core': 5.100.14
       react: 19.2.7
 
   '@tanstack/react-query@5.101.0(react@19.2.7)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,12 @@
 packages:
   - "apps/*"
   - "packages/*"
+# @tanstack/react-query stores its QueryClient in a module-scoped React context,
+# so two copies in one bundle = two unrelated contexts ("No QueryClient set").
+# Pin a single workspace-wide version so admin's QueryClientProvider and the
+# hooks in @repo/ui always resolve to the same instance.
+overrides:
+  "@tanstack/react-query": "^5.101.0"
 # Minimum age (in minutes) a package must be before it can be installed.
 # Protects against supply-chain attacks while not blocking packages older than 10 minutes.
 minimumReleaseAge: 10


### PR DESCRIPTION
## Summary

`@tanstack/react-query` stores its `QueryClient` in a module-scoped React context. If two copies of the package land in one bundle, they resolve to two unrelated contexts and the app throws **"No QueryClient set"** even when a `QueryClientProvider` is present.

This pins a single workspace-wide version so `admin`'s `QueryClientProvider` and the hooks in `@repo/ui` always share the same instance.

## Changes

- Add a `pnpm-workspace.yaml` override pinning `@tanstack/react-query` to `^5.101.0` (with an explanatory comment).
- Bump `@repo/ui`'s dependency to `^5.101.0` to match.
- Update `pnpm-lock.yaml` accordingly (dedupes `5.100.14` → `5.101.0`).

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run check-types`
- [x] `pnpm run test:coverage` (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)