### PR TITLE
fix(ui): default border color to --color-border in dark theme

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -17,6 +17,20 @@
 @source "../**/*.{ts,tsx}";
 
 @layer base {
+  /* Default border color. Tailwind v4 resolves the bare `border` utility to
+   * `currentColor` (v3 defaulted to gray-200), which in this dark theme is the
+   * near-white foreground — producing harsh white borders on any element that
+   * doesn't set an explicit border color. Reset the default to our subdued
+   * `--color-border` token (zinc-800). Explicit utilities like `border-input`
+   * and `border-destructive/30` live in the utilities layer and still win. */
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-border);
+  }
+
   :root {
     color-scheme: dark;
   }


### PR DESCRIPTION
## Problem

Many components (dialogs, cards, selects, popovers, dropdowns, tooltips, alerts, badges, tables) render a harsh **near-white** border in the dark theme, while others render the correct subdued zinc-800 border.

**Root cause:** Tailwind v4 changed the bare `border` utility's default color from `gray-200` (v3) to `currentColor`. In this dark theme `currentColor` is the near-white foreground (`--color-foreground`, zinc-50), so any element with a bare `border` and no explicit color paints a glaring white line.

The standard shadcn/Tailwind-v4 base-layer rule that resets the default border color to the design token (`* { border-color: var(--color-border) }`) was **missing** from the shared design-system entry point. That's why borders were inconsistent: components hardcoding `border-border` / `border-input` / `border-destructive` looked right, while the ~11 primitives using a bare `border` fell through to the near-white default.

## Fix

Add the missing default-border-color rule to the `@layer base` block in `packages/ui/src/styles/globals.css`. One change covers all current primitives and any future components.

- Lives in the **base** layer, so explicit utilities (`border-input`, `border-destructive/30`, …) still override it.
- Only sets the *color* — it cannot add borders, so no new borders appear; only the color of already-bordered elements changes.
- Restores the standard shadcn/Tailwind-v4 baseline rather than introducing a novel pattern, so no ADR needed.

## Verification

- `pnpm verify` passes (format, lint, check-types, test:coverage, build).
- Visual check: dialogs, selects, cards, popovers, dropdowns, tooltips, badges, and alerts now show the subdued zinc-800 border; destructive panels and form inputs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)