### PR TITLE
feat(admin): move list-page filter rail to the right of content

### DIFF
--- a/apps/admin/app/(protected)/events/_components/event-list-client.tsx
+++ b/apps/admin/app/(protected)/events/_components/event-list-client.tsx
@@ -813,8 +813,6 @@ export function EventListClient() {
 
   return (
     <div className="flex h-full">
-      <FilterRail groups={filterGroups} onClearAll={handleClearAll} />
-
       <main className="flex flex-1 flex-col overflow-auto min-w-0">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-6 py-4 shrink-0">
@@ -996,6 +994,8 @@ export function EventListClient() {
           </div>
         )}
       </main>
+
+      <FilterRail groups={filterGroups} onClearAll={handleClearAll} />
     </div>
   );
 }

--- a/apps/admin/app/(protected)/timelines/_components/timeline-list-client.tsx
+++ b/apps/admin/app/(protected)/timelines/_components/timeline-list-client.tsx
@@ -630,8 +630,6 @@ export function TimelineListClient() {
 
   return (
     <div className="flex h-full">
-      <FilterRail groups={filterGroups} onClearAll={handleClearAll} />
-
       <main className="flex flex-1 flex-col overflow-auto min-w-0">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-6 py-4 shrink-0">
@@ -805,6 +803,8 @@ export function TimelineListClient() {
           </div>
         )}
       </main>
+
+      <FilterRail groups={filterGroups} onClearAll={handleClearAll} />
     </div>
   );
 }

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,6 +72,7 @@ model); the next new ADR is the next free number (`0029` onward), per the
 | [0032](adr-0032-public-reader-motion-tokens.md)            | Public reader motion-token scale (durations, easing, reduced-motion contract)   | Accepted         | —                                          |
 | [0033](adr-0033-reader-shell-composites-in-ui-package.md)  | Reader shell composites live in `@repo/ui` (`reader-*`); apps/reader holds glue | Accepted         | —                                          |
 | [0034](adr-0034-api-role-table-grants.md)                  | Explicit table GRANTs for API roles (anon read, authenticated DML, svc all)     | Accepted         | —                                          |
+| [0035](adr-0035-list-filter-rail-placement.md)             | List-page filter rail on the right (nav → content → filters)                    | Accepted         | —                                          |
 
 † ADR `0006` supersedes the original event-to-event `parent_event_id` nesting
 approach, which was never given its own ADR; it is documented inside `0006` as

--- a/docs/adr/adr-0035-list-filter-rail-placement.md
+++ b/docs/adr/adr-0035-list-filter-rail-placement.md
@@ -1,0 +1,112 @@
+---
+title: "ADR-0035: List-page filter rail on the right"
+status: "Accepted"
+date: "2026-06-30"
+authors: "Admin design + frontend"
+tags: ["architecture", "decision", "design-system", "admin"]
+supersedes: ""
+superseded_by: ""
+amends: ""
+amended_by: ""
+---
+
+# ADR-0035: List-page filter rail on the right
+
+## Status
+
+**Accepted**
+
+## Context
+
+The admin app's entity-list screens (timelines, events, media — and the
+spec'd-but-unbuilt characters, periods, stories, categories) use a persistent
+`FilterRail` sidebar of grouped controls. Until now the rail rendered on the
+**left** of the content: the global navigation sidebar, then the filter rail,
+then the table. The fidelity-1 wireframes and
+[`03-aesthetic-notes.md`](../design/admin/03-aesthetic-notes.md) committed to a
+left rail as "conventional and discoverable."
+
+In use, the left placement reads as cramped: the table is wedged between two
+left-edge rails (nav + filters), the controls sit visually _upstream_ of the
+content they act on, and the content is pushed away from the primary nav. The
+design-system rule for the rail was load-bearing (it is referenced by five list
+wireframes plus the PRD), so changing the side is a cross-cutting,
+precedent-setting decision rather than a one-off CSS tweak — it warrants a
+record.
+
+## Decision
+
+Place the list-page filter rail on the **right** of the content pane, so the
+reading order is **nav → content → filters**. The `FilterRail` keeps its fixed
+`w-56` width; placement is controlled by DOM order in each list shell (`<main>`
+before `<FilterRail>`) rather than `flex-row-reverse`, so focus and screen-reader
+order naturally reach content before the filters. The rail's divider flips from
+`border-r` to `border-l`.
+
+This applies to all admin entity-list screens and to the `MediaFilterRail`
+adapter, which composes `FilterRail`.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Content sits directly against the primary nav and gets the wide
+  middle of the viewport, relieving the cramped two-left-rails layout.
+- **POS-002**: Filters read as a contextual sidebar _next to_ the content,
+  mirroring the editor's existing fixed right-hand metadata column
+  ([`05-character-editor.md`](../design/admin/02-wireframes/05-character-editor.md)).
+  "Contextual controls live on the right" now reads consistently across list and
+  editor surfaces.
+- **POS-003**: DOM-order (not `flex-row-reverse`) placement keeps tab and
+  screen-reader order as content-then-filters, satisfying the
+  accessibility-first language of [ADR-0024](adr-0024-accessibility-first-visual-language.md).
+
+### Negative
+
+- **NEG-001**: Diverges from the common left-facet convention (and from the
+  public reader's currently-spec'd left facet rail), so admin and reader filter
+  placement may differ until the reader is built and reconciled.
+- **NEG-002**: Required redrawing the ASCII wireframes and rewording the
+  aesthetic-notes rule — documentation churn with no functional payoff.
+
+## Alternatives Considered
+
+### Keep the left rail
+
+- **ALT-001**: **Description**: Leave the rail where it is; address the cramped
+  feeling with spacing/typography only.
+- **ALT-002**: **Rejection Reason**: Doesn't fix the structural problem — the
+  table stays wedged between two left rails and upstream of its own controls.
+
+### Collapsible / drawer filters
+
+- **ALT-003**: **Description**: Add an independent collapse toggle or a mobile
+  drawer for the rail.
+- **ALT-004**: **Rejection Reason**: Larger surface area and out of scope for
+  this change; the responsive-drawer gap is pre-existing and tracked separately.
+  The right-side swap neither introduces nor blocks it.
+
+## Implementation Notes
+
+- **IMP-001**: Code touch points — flip `border-r`→`border-l` in
+  [`packages/ui/src/components/filter-rail.tsx`](../../packages/ui/src/components/filter-rail.tsx);
+  render `<main>` before the rail in the timelines and events list clients and in
+  [`packages/ui/src/components/media-picker.tsx`](../../packages/ui/src/components/media-picker.tsx).
+  No change to filter state (URL params), TanStack Query hooks, or `MediaFilterRail`
+  facet logic.
+- **IMP-002**: Docs updated in lockstep — PRD §7.11.2, the five list wireframes,
+  the media-library wireframe, the aesthetic-notes density rule, and the
+  fidelity-2 plan's `FilterRail` line.
+- **IMP-003**: Public reader filter placement
+  ([`public/04-wireframes/02-explore.md`](../design/public/04-wireframes/02-explore.md),
+  `04-story-browser.md`) is intentionally **not** changed here; revisit when
+  `apps/reader` is scaffolded (#254) to decide whether to align the reader with
+  this rule or keep its left facet rail.
+
+## References
+
+- **REF-001**: [ADR-0024](adr-0024-accessibility-first-visual-language.md)
+  (accessibility-first visual language), [ADR-0025](adr-0025-shared-mediapicker-bespoke-tree.md)
+  (`MediaPicker` shared primitive).
+- **REF-002**: [`docs/design/admin/03-aesthetic-notes.md`](../design/admin/03-aesthetic-notes.md)
+  § Density and information rules; PRD-0001 §7.11.2.

--- a/docs/design/admin/02-wireframes/03-characters-list.md
+++ b/docs/design/admin/02-wireframes/03-characters-list.md
@@ -24,40 +24,40 @@
 │  Characters                                          [ + New character ]     │
 │  47 total · 12 shown                                                         │
 │                                                                              │
-│  ┌─────────────────┐  ┌────────────────────────────────────────────────────┐  │
-│  │ Filter          │  │ ⌕ Search by name or alias…                         │  │
-│  │                 │  │                                                    │  │
-│  │ Type            │  │ ┌──┬────────────────┬────────┬─────────────┬─────┐ │  │
-│  │ ☐ Human    23  │  │ │  │ Name           │ Type   │ Temporal    │ Pub │ │  │
-│  │ ☐ Animal    4  │  │ ├──┼────────────────┼────────┼─────────────┼─────┤ │  │
-│  │ ☐ Myth.     7  │  │ │● │ Marie Curie    │ Human  │ 1867–1934   │  ✓  │ │  │
-│  │ ☐ Fictional 3  │  │ │  │ ↳ M. Skłod… +1 │ ★★★★ │ CE          │     │ │  │
-│  │ ☐ Organiz.  5  │  │ │  │ 12 events · ⌶  │        │             │     │ │  │
-│  │ ☐ Divine    2  │  │ ├──┼────────────────┼────────┼─────────────┼─────┤ │  │
-│  │ ☐ Artifact  3  │  │ │● │ Pierre Curie   │ Human  │ 1859–1906   │  ✓  │ │  │
-│  │                 │  │ │  │ 8 events · ⌶  │ ★★★★   │ CE        │     │ │  │
-│  │ Significance    │  │ ├──┼────────────────┼────────┼─────────────┼─────┤ │  │
-│  │ ☐ Critical  4  │  │ │● │ Antoine Bec…   │ Human  │ 1852–1908   │  ─   │ │  │
-│  │ ☐ High     11  │  │ │  │ 3 events       │ ★★★    │ CE         │ draft│ │  │
-│  │ ☐ Medium   22  │  │ ├──┼────────────────┼─────────┼─────────────┼─────┤ │  │
-│  │ ☐ Low      10  │  │ │● │ Tyrannosaurus  │ Animal │ 68–66 MYA   │  ✓  │ │  │
-│  │                │  │ │  │ rex            │ ★★★★★  │ approximate │     │ │  │
-│  │ Status         │  │ │  │ 1 event        │         │             │     │ │  │
-│  │ ☐ Published 38 │  │ ├──┼────────────────┼────────┼─────────────┼─────┤ │  │
-│  │ ☐ Draft      9 │  │ │● │ Zeus           │ Divine │ —           │  ✓  │ │  │
-│  │                │  │ │  │ "Jupiter" +3   │ ★★★★  │             │     │ │  │
-│  │ Has media      │  │ │  │ 22 events · ⌶  │        │             │     │ │  │
-│  │ ☐ Yes      31  │  │ └──┴────────────────┴────────┴─────────────┴─────┘ │  │
-│  │ ☐ No       16  │  │                                                    │  │
-│  │                │  │ ⟨ 1  2  3  4  ⟩                       Sort: Name ▾  │  │
-│  │ Clear filters  │  │                                                    │  │
-│  └────────────────┘  └────────────────────────────────────────────────────┘  │
+│  ┌─────────────────────────────────────────────────────┐  ┌────────────────┐ │
+│  │ ⌕ Search by name or alias…                          │  │ Filter         │ │
+│  │                                                     │  │                │ │
+│  │ ┌──┬────────────────┬────────┬─────────────┬──────┐ │  │ Type           │ │
+│  │ │  │ Name           │ Type   │ Temporal    │ Pub  │ │  │ ☐ Human    23  │ │
+│  │ ├──┼────────────────┼────────┼─────────────┼──────┤ │  │ ☐ Animal    4  │ │
+│  │ │● │ Marie Curie    │ Human  │ 1867–1934   │  ✓   │ │  │ ☐ Myth.     7  │ │
+│  │ │  │ ↳ M. Skłod… +1 │ ★★★★   │ CE          │      │ │  │ ☐ Fictional 3  │ │
+│  │ │  │ 12 events · ⌶  │        │             │      │ │  │ ☐ Organiz.  5  │ │
+│  │ ├──┼────────────────┼────────┼─────────────┼──────┤ │  │ ☐ Divine    2  │ │
+│  │ │● │ Pierre Curie   │ Human  │ 1859–1906   │  ✓   │ │  │ ☐ Artifact  3  │ │
+│  │ │  │ 8 events · ⌶   │ ★★★★    │ CE         │      │ │  │                │ │
+│  │ ├──┼────────────────┼────────┼─────────────┼──────┤ │  │ Significance   │ │
+│  │ │● │ Antoine Bec…   │ Human  │ 1852–1908   │  ─   │ │  │ ☐ Critical  4  │ │
+│  │ │  │ 3 events       │ ★★★    │ CE          │ draft│ │  │ ☐ High     11  │ │
+│  │ ├──┼────────────────┼────────┼─────────────┼──────┤ │  │ ☐ Medium   22  │ │
+│  │ │● │ Tyrannosaurus  │ Animal │ 68–66 MYA   │  ✓   │ │  │ ☐ Low      10  │ │
+│  │ │  │ rex            │ ★★★★★  │ approximate │      │ │  │                │ │
+│  │ │  │ 1 event        │        │             │      │ │  │ Status         │ │
+│  │ ├──┼────────────────┼────────┼─────────────┼──────┤ │  │ ☐ Published 38 │ │
+│  │ │● │ Zeus           │ Divine │ —           │  ✓   │ │  │ ☐ Draft      9 │ │
+│  │ │  │ "Jupiter" +3   │ ★★★★   │             │      │ │  │                │ │
+│  │ │  │ 22 events · ⌶  │        │             │      │ │  │ Has media      │ │
+│  │ └──┴────────────────┴────────┴─────────────┴──────┘ │  │ ☐ Yes      31  │ │
+│  │                                                     │  │ ☐ No       16  │ │
+│  │ ⟨ 1  2  3  4  ⟩                       Sort: Name ▾  │  │                │ │
+│  │                                                     │  │ Clear filters  │ │
+│  └─────────────────────────────────────────────────────┘  └────────────────┘ │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Annotations
 
-1. **Left-rail filters with grouped counts.** Each filter group is a checkbox set with per-option counts. Multiple selections within a group are OR; across groups are AND. This is conventional and discoverable.
+1. **Right-rail filters with grouped counts.** The filter rail sits to the right of the table (after the content it filters), keeping the table adjacent to the primary nav and mirroring the editor's right-hand metadata column. Each filter group is a checkbox set with per-option counts. Multiple selections within a group are OR; across groups are AND. See ADR-0035.
 2. **Type badges should be visually distinct.** Color + label, not color alone. See [03-aesthetic-notes.md](../03-aesthetic-notes.md).
 3. **Row layout includes secondary info (aliases, event count) indented under the primary line.** This is the "two-line row" pattern from Linear/Notion lists. Saves columns without losing scanability.
 4. **Star icons (★) encode significance** — not a literal rating, just a sequential signal (low/medium/high/critical). The same `★★★★★` glyph means "critical" regardless of context.

--- a/docs/design/admin/02-wireframes/07-events-list.md
+++ b/docs/design/admin/02-wireframes/07-events-list.md
@@ -25,51 +25,51 @@
 │  Events                                                  [ + New event ]     │
 │  312 total · 48 shown                                                        │
 │                                                                              │
-│  ┌────────────────┐  ┌────────────────────────────────────────────────────┐  │
-│  │ Filter         │  │ ⌕ Search title, summary, detail…                   │  │
-│  │                │  │                                                    │  │
-│  │ Era            │  │ ┌────┬────────────────────────┬────────┬───┬─────┐ │  │
-│  │ ☐ BYA       1  │  │ │    │ Title                  │ Date   │ ★ │ Pub │ │  │
-│  │ ☐ MYA       4  │  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │
-│  │ ☐ KYA       8  │  │ │ ⌒  │ Big Bang               │ 14 BYA │ 10│  ✓  │ │  │
-│  │ ☐ BCE      31  │  │ │    │ root · cosmological · 0│        │   │     │ │  │
-│  │ ☐ CE      268  │  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │
-│  │                │  │ │ ⌒  │ K-Pg extinction        │ 66 MYA │  9│  ✓  │ │  │
-│  │ Type           │  │ │    │ root · destruction · 2 │ ±1M    │   │     │ │  │
-│  │ ☐ Milestone 84 │  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │
-│  │ ☐ Discovery 41 │  │ │ ↳  │ Discovery of polonium  │ 1898   │  8│  ✓  │ │  │
-│  │ ☐ Period   29  │  │ │    │ Radium research · disc.│        │   │     │ │  │
-│  │ ☐ Incident 22  │  │ │    │ · 2 chars · physics    │        │   │     │ │  │
-│  │ ☐ Creation 18  │  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │
-│  │ ☐ Destruct.  9 │  │ │ ↳  │ Discovery of radium    │ 1898   │  8│  ─  │ │  │
-│  │ ☐ Transform. 5 │  │ │    │ Radium research · disc.│        │   │draft│ │  │
-│  │ ☐ Migration  4 │  │ │    │ · 2 chars · physics    │        │   │     │ │  │
-│  │ ☐ Conflict  62 │  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │
-│  │ ☐ Ceremony  11 │  │ │ ⌒  │ Curies share Nobel     │ 1903   │  9│  ✓  │ │  │
-│  │ ☐ Migration 27 │  │ │    │ Physics · ceremony · 3 │        │   │     │ │  │
-│  │                │  │ │    │ chars · nobel, physics │        │   │     │ │  │
-│  │ Importance     │  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │
-│  │ [ 1 ●────● 10 ]│  │ │ ⌒  │ Pierre Curie killed    │ 1906   │ 10│  ✓  │ │  │
-│  │                │  │ │    │ Curie biography · inc. │        │   │     │ │  │
-│  │ Timeline       │  │ │    │ · 1 char               │        │   │     │ │  │
-│  │ ▾ Any timeline │  │ └────┴────────────────────────┴────────┴───┴─────┘ │  │
-│  │                │  │                                                    │  │
-│  │ Has chars      │  │ ⟨ 1  2  3  …  7  ⟩            Sort: Date ascending▾│  │
-│  │ ☐ Yes     247  │  │                                                    │  │
-│  │ ☐ No       65  │  │                                                    │  │
-│  │                │  │                                                    │  │
-│  │ Status         │  │                                                    │  │
-│  │ ☐ Published251 │  │                                                    │  │
-│  │ ☐ Draft    61  │  │                                                    │  │
-│  │                │  │                                                    │  │
-│  │ Clear filters  │  │                                                    │  │
-│  └────────────────┘  └────────────────────────────────────────────────────┘  │
+│  ┌────────────────────────────────────────────────────┐  ┌────────────────┐  │
+│  │ ⌕ Search title, summary, detail…                   │  │ Filter         │  │
+│  │                                                    │  │                │  │
+│  │ ┌────┬────────────────────────┬────────┬───┬─────┐ │  │ Era            │  │
+│  │ │    │ Title                  │ Date   │ ★ │ Pub │ │  │ ☐ BYA       1  │  │
+│  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │ ☐ MYA       4  │  │
+│  │ │ ⌒  │ Big Bang               │ 14 BYA │ 10│  ✓  │ │  │ ☐ KYA       8  │  │
+│  │ │    │ root · cosmological · 0│        │   │     │ │  │ ☐ BCE      31  │  │
+│  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │ ☐ CE      268  │  │
+│  │ │ ⌒  │ K-Pg extinction        │ 66 MYA │  9│  ✓  │ │  │                │  │
+│  │ │    │ root · destruction · 2 │ ±1M    │   │     │ │  │ Type           │  │
+│  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │ ☐ Milestone 84 │  │
+│  │ │ ↳  │ Discovery of polonium  │ 1898   │  8│  ✓  │ │  │ ☐ Discovery 41 │  │
+│  │ │    │ Radium research · disc.│        │   │     │ │  │ ☐ Period   29  │  │
+│  │ │    │ · 2 chars · physics    │        │   │     │ │  │ ☐ Incident 22  │  │
+│  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │ ☐ Creation 18  │  │
+│  │ │ ↳  │ Discovery of radium    │ 1898   │  8│  ─  │ │  │ ☐ Destruct.  9 │  │
+│  │ │    │ Radium research · disc.│        │   │draft│ │  │ ☐ Transform. 5 │  │
+│  │ │    │ · 2 chars · physics    │        │   │     │ │  │ ☐ Migration  4 │  │
+│  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │ ☐ Conflict  62 │  │
+│  │ │ ⌒  │ Curies share Nobel     │ 1903   │  9│  ✓  │ │  │ ☐ Ceremony  11 │  │
+│  │ │    │ Physics · ceremony · 3 │        │   │     │ │  │ ☐ Migration 27 │  │
+│  │ │    │ chars · nobel, physics │        │   │     │ │  │                │  │
+│  │ ├────┼────────────────────────┼────────┼───┼─────┤ │  │ Importance     │  │
+│  │ │ ⌒  │ Pierre Curie killed    │ 1906   │ 10│  ✓  │ │  │ [ 1 ●────● 10 ]│  │
+│  │ │    │ Curie biography · inc. │        │   │     │ │  │                │  │
+│  │ │    │ · 1 char               │        │   │     │ │  │ Timeline       │  │
+│  │ └────┴────────────────────────┴────────┴───┴─────┘ │  │ ▾ Any timeline │  │
+│  │                                                    │  │                │  │
+│  │ ⟨ 1  2  3  …  7  ⟩            Sort: Date ascending▾│  │ Has chars      │  │
+│  │                                                    │  │ ☐ Yes     247  │  │
+│  │                                                    │  │ ☐ No       65  │  │
+│  │                                                    │  │                │  │
+│  │                                                    │  │ Status         │  │
+│  │                                                    │  │ ☐ Published251 │  │
+│  │                                                    │  │ ☐ Draft    61  │  │
+│  │                                                    │  │                │  │
+│  │                                                    │  │ Clear filters  │  │
+│  └────────────────────────────────────────────────────┘  └────────────────┘  │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Annotations
 
-1. **Era filter is the most-used filter for this entity.** Pinned to the top of the filter rail.
+1. **Era filter is the most-used filter for this entity.** Pinned to the top of the filter rail. The rail sits to the **right** of the table (after the content it filters) — see the characters list ([03](03-characters-list.md)) and ADR-0035.
 2. **Importance filter is a range slider** (1–10), not a multi-select. The schema constrains importance to 1–10; users care about "show me importance 7+", not individual values.
 3. **Drill-down indicator in the first column.** `⤵` marks an event that **expands into a sub-timeline** (`detail_timeline_id` is set); blank otherwise. This is the only fractal signal a flat cross-timeline list can carry under the forward model ([#180](https://github.com/shaes-farm/time-traveler/issues/180)) — there is no root/child event nesting anymore. Clicking `⤵` opens that sub-timeline. _(The ASCII mock above still shows the legacy `⌒`/`↳` root/child glyphs; read the column as the `⤵` drill-down marker. Implemented in #45 now that [#177](https://github.com/shaes-farm/time-traveler/issues/177) has landed `detail_timeline_id`; the click target resolves only when the sub-timeline's slug is in the loaded set, otherwise the `⤵` shows as a static indicator.)_
 4. **Date column shows uncertainty inline.** "66 MYA ±1M" makes the precision visible without a dedicated column.

--- a/docs/design/admin/02-wireframes/11-timeline-list.md
+++ b/docs/design/admin/02-wireframes/11-timeline-list.md
@@ -26,37 +26,37 @@
 │  Timelines                                             [ + New timeline ]    │
 │  14 total · 9 shown                                                          │
 │                                                                              │
-│  ┌─────────────────┐  ┌────────────────────────────────────────────────────┐  │
-│  │ Filter          │  │ ⌕ Search title, summary, detail…                   │  │
-│  │                 │  │                                                    │  │
-│  │ Type            │  │ ┌──┬──────────────────────┬──────────┬──────┬────┐ │  │
-│  │ ☐ General    8 │  │ │  │ Title                │ Type     │ Vis. │Pub │ │  │
-│  │ ☐ Biographical 4│  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
-│  │ ☐ Comparative 2 │  │ │  │ Curie scientific…    │ Biograph.│ 🌐pub│ ✓  │ │  │
-│  │                 │  │ │  │ 1867–1934 CE · 24 ev…│          │      │    │ │  │
-│  │ Visibility      │  │ │  │ · 2 collaborators    │          │      │    │ │  │
-│  │ ☐ Private    9 │  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
-│  │ ☐ Public     3 │  │ │  │ Cosmic history       │ General  │ 🌐pub│ ✓  │ │  │
-│  │ ☐ Shared     2 │  │ │  │ 14 BYA–now · 312 ev… │          │      │    │ │  │
-│  │                 │  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
-│  │ Status          │  │ │  │ Origin of life       │ General  │ 🔒prv│ ─  │ │  │
-│  │ ☐ Published 11 │  │ │  │ 3.8–3.5 BYA · 9 ev…  │          │      │draft│ │  │
-│  │ ☐ Draft      3 │  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
-│  │                │  │ │  │ Mesozoic era         │ General  │ 🔒prv│ ─  │ │  │
-│  │ Clear filters  │  │ │  │ 252–66 MYA · 41 ev…  │          │      │draft│ │  │
-│  └────────────────┘  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │
-│                      │ │  │ Greek mythology      │ General  │ 👥shr│ ✓  │ │  │
-│                      │ │  │ cosmos–1200 BCE      │          │      │    │ │  │
-│                      │ └──┴──────────────────────┴──────────┴──────┴────┘ │  │
-│                      │                                                    │  │
-│                      │ ⟨ 1  2  ⟩                       Sort: Updated ▾    │  │
-│                      └────────────────────────────────────────────────────┘  │
+│  ┌────────────────────────────────────────────────────┐  ┌─────────────────┐ │
+│  │ ⌕ Search title, summary, detail…                   │  │ Filter          │ │
+│  │                                                    │  │                 │ │
+│  │ ┌──┬──────────────────────┬──────────┬──────┬────┐ │  │ Type            │ │
+│  │ │  │ Title                │ Type     │ Vis. │Pub │ │  │ ☐ General     8 │ │
+│  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │ ☐ Biographical 4│ │
+│  │ │  │ Curie scientific…    │ Biograph.│ 🌐pub│ ✓  │ │  │ ☐ Comparative 2 │ │
+│  │ │  │ 1867–1934 CE · 24 ev…│          │      │    │ │  │                 │ │
+│  │ │  │ · 2 collaborators    │          │      │    │ │  │ Visibility      │ │
+│  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │ ☐ Private     9 │ │
+│  │ │  │ Cosmic history       │ General  │ 🌐pub│ ✓  │ │  │ ☐ Public      3 │ │
+│  │ │  │ 14 BYA–now · 312 ev… │          │      │    │ │  │ ☐ Shared      2 │ │
+│  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │                 │ │
+│  │ │  │ Origin of life       │ General  │ 🔒prv│ ─  │ │  │ Status          │ │
+│  │ │  │ 3.8–3.5 BYA · 9 ev…  │          │      │draft│ │  │ ☐ Published 11 │ │
+│  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  │ ☐ Draft       3 │ │
+│  │ │  │ Mesozoic era         │ General  │ 🔒prv│ ─  │ │  │                 │ │
+│  │ │  │ 252–66 MYA · 41 ev…  │          │      │draft│ │  │ Clear filters  │ │
+│  │ ├──┼──────────────────────┼──────────┼──────┼────┤ │  └─────────────────┘ │
+│  │ │  │ Greek mythology      │ General  │ 👥shr│ ✓  │ │                      │
+│  │ │  │ cosmos–1200 BCE      │          │      │    │ │                      │
+│  │ └──┴──────────────────────┴──────────┴──────┴────┘ │                      │
+│  │                                                    │                      │
+│  │ ⟨ 1  2  ⟩                       Sort: Updated ▾    │                      │
+│  └────────────────────────────────────────────────────┘                      │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Annotations
 
-1. **Same left-rail filter pattern** as the characters and events lists ([03](03-characters-list.md), [07](07-events-list.md)) — grouped checkbox sets with per-option counts; OR within a group, AND across groups. Discoverability over novelty: a third list screen is not the place to invent a new filter idiom.
+1. **Same right-rail filter pattern** as the characters and events lists ([03](03-characters-list.md), [07](07-events-list.md)) — grouped checkbox sets on the right of the table with per-option counts; OR within a group, AND across groups. Discoverability over novelty: a third list screen is not the place to invent a new filter idiom. See ADR-0035.
 2. **`timeline_type` badge** — `general` / `biographical` / `comparative`. Color + label, not color alone (per [03-aesthetic-notes.md](../03-aesthetic-notes.md)). Biographical timelines carry a subject character (see annotation #6).
 3. **`visibility` and published are two independent axes — and the list shows both** (issue #42, #48). `visibility` (`private`/`public`/`shared`) controls _who can reach_ the timeline via RLS; `published` controls _whether it is live_. A timeline can be `public` + draft, or `private` + published. The Visibility column uses an icon+label (`🔒 private`, `🌐 public`, `👥 shared`); the Pub column uses the shared publish badge from [16-publish-workflow.md](16-publish-workflow.md). Do **not** collapse these into one column — conflating them is the single most common timeline-model mistake and the schema deliberately separates them.
 4. **Two-line row** (the established list pattern). Line 1: title. Line 2: temporal span + event count + collaborator count. Temporal span renders era explicitly for non-CE (`252–66 MYA`, `14 BYA–now`); CE spans render bare years.

--- a/docs/design/admin/02-wireframes/17-media-library.md
+++ b/docs/design/admin/02-wireframes/17-media-library.md
@@ -21,25 +21,25 @@ It has **two faces of the same data**:
 ```
   Media library                                              [ + Upload ]  [ + External URL ]
   ───────────────────────────────────────────────────────────────────────────────────────────
-  ┌── Filters ───────────┐   [ ⌕ Search alt text, caption, filename…            ]   ⌗ 248 items
-  │ Type                 │   ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
-  │  ☐ Image    (181)    │   │ [thumb]  │ │ [▶ thumb]│ │ [doc]    │ │ [thumb]  │
-  │  ☐ Video     (22)    │   │          │ │          │ │          │ │          │
-  │  ☐ Audio      (9)    │   │ Curie,   │ │ Newsreel │ │ Polonium │ │ Lab, '03 │
-  │  ☐ Document  (36)    │   │ 1898     │ │ 1911     │ │ paper    │ │          │
-  │                      │   │ img·3 ⛓  │ │ vid·1 ⛓  │ │ doc·0 ⚠  │ │ img·1 ⛓  │
-  │ Source               │   └──────────┘ └──────────┘ └──────────┘ └──────────┘
-  │  ☐ Uploaded (212)    │   ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
-  │  ☐ External  (36)    │   │   …      │ │   …      │ │   …      │ │   …      │
-  │                      │   └──────────┘ └──────────┘ └──────────┘ └──────────┘
-  │ Attached to          │
-  │  ☐ Events            │   « ‹  1 2 3 … 21  › »                    [ Grid ▦ | List ☰ ]
-  │  ☐ Characters        │
-  │  ☐ Timelines         │
-  │  ☐ Orphaned   (4) ⚠  │
-  │                      │
-  │ [ Clear filters ]    │
-  └──────────────────────┘
+  [ ⌕ Search alt text, caption, filename…       ]   ⌗ 248 items   ┌── Filters ───────────┐
+  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐             │ Type                 │
+  │ [thumb]  │ │ [▶ thumb]│ │ [doc]    │ │ [thumb]  │             │  ☐ Image    (181)    │
+  │          │ │          │ │          │ │          │             │  ☐ Video     (22)    │
+  │ Curie,   │ │ Newsreel │ │ Polonium │ │ Lab, '03 │             │  ☐ Audio      (9)    │
+  │ 1898     │ │ 1911     │ │ paper    │ │          │             │  ☐ Document  (36)    │
+  │ img·3 ⛓  │ │ vid·1 ⛓  │ │ doc·0 ⚠  │ │ img·1 ⛓  │             │                      │
+  └──────────┘ └──────────┘ └──────────┘ └──────────┘             │ Source               │
+  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐             │  ☐ Uploaded (212)    │
+  │   …      │ │   …      │ │   …      │ │   …      │             │  ☐ External  (36)    │
+  └──────────┘ └──────────┘ └──────────┘ └──────────┘             │                      │
+                                                                  │ Attached to          │
+  « ‹  1 2 3 … 21  › »              [ Grid ▦ | List ☰ ]           │  ☐ Events            │
+                                                                  │  ☐ Characters        │
+                                                                  │  ☐ Timelines         │
+                                                                  │  ☐ Orphaned   (4) ⚠  │
+                                                                  │                      │
+                                                                  │ [ Clear filters ]    │
+                                                                  └──────────────────────┘
 ```
 
 Selecting a card opens the **detail panel** (right drawer) without leaving the grid.
@@ -48,20 +48,20 @@ Selecting a card opens the **detail panel** (right drawer) without leaving the g
 
 ```
   ── Marie Curie in her laboratory, 1898 ──────────────────────────── [✕] ┐
-  │  ┌───────────────────────────┐                                       │
+  │  ┌───────────────────────────┐                                        │
   │  │        [ preview ]        │   uploaded · image · 1200×800          │
   │  │                           │   312 KB · image/jpeg                  │
-  │  └───────────────────────────┘   slug: marie-curie-lab-1898          │
+  │  └───────────────────────────┘   slug: marie-curie-lab-1898           │
   │                                                                       │
   │  Alt text   [ Marie Curie in her laboratory, 1898            ]        │
-  │  Caption    [ Source: Curie Museum archive                  ]        │
+  │  Caption    [ Source: Curie Museum archive                  ]         │
   │                                              [ Save changes ]         │
-  │  ─────────────────────────────────────────────────────────────────   │
+  │  ─────────────────────────────────────────────────────────────────    │
   │  Attached to (3)                                                      │
   │   • Character — Marie Curie            (primary)        [ Detach ]    │
-  │   • Event — Discovery of polonium                      [ Detach ]    │
-  │   • Timeline — Radioactivity research                 [ Detach ]    │
-  │  ─────────────────────────────────────────────────────────────────   │
+  │   • Event — Discovery of polonium                       [ Detach ]    │
+  │   • Timeline — Radioactivity research                   [ Detach ]    │
+  │  ─────────────────────────────────────────────────────────────────    │
   │  [ Open source ↗ ]                         [ Delete original… ] ⚠     │
   └───────────────────────────────────────────────────────────────────────┘
 ```
@@ -70,7 +70,7 @@ Selecting a card opens the **detail panel** (right drawer) without leaving the g
 
 ```
   ── Choose existing media ──────────────────────────────────────────────┐
-  │  [ ⌕ Search…              ]   Type ▾  Source ▾            ⌗ 248       │
+  │  [ ⌕ Search…              ]   Type ▾  Source ▾            ⌗ 248      │
   │  ──────────────────────────────────────────────────────────────────  │
   │  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐               │
   │  │[✓]   │ │      │ │      │ │[✓]   │ │      │ │      │               │
@@ -80,8 +80,8 @@ Selecting a card opens the **detail panel** (right drawer) without leaving the g
   │  │ …    │ │ …    │ │ …    │ │ …    │ │ …    │ │ …    │               │
   │  └──────┘ └──────┘ └──────┘ └──────┘ └──────┘ └──────┘               │
   │  ──────────────────────────────────────────────────────────────────  │
-  │  2 selected                          [ Cancel ]  [ Attach 2 items ]   │
-  └───────────────────────────────────────────────────────────────────────┘
+  │  2 selected                          [ Cancel ]  [ Attach 2 items ]  │
+  └──────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Annotations

--- a/docs/design/admin/02-wireframes/18-stories-list.md
+++ b/docs/design/admin/02-wireframes/18-stories-list.md
@@ -24,33 +24,33 @@
 │  Stories                                                  [ + New story ]    │
 │  9 total · 6 shown                                                           │
 │                                                                              │
-│  ┌─────────────────┐  ┌────────────────────────────────────────────────────┐  │
-│  │ Filter          │  │ ⌕ Search title, summary, detail…                   │  │
-│  │                 │  │                                                    │  │
-│  │ Narrator        │  │ ┌──────────────────────────┬───────────┬────┐     │  │
-│  │ ☐ First-person 3│  │ │ Title                    │ Narrator  │Pub │     │  │
-│  │ ☐ Third-person 4│  │ ├──────────────────────────┼───────────┼────┤     │  │
-│  │ ☐ Omniscient  2 │  │ │ The Curies' Quest        │ 3rd-person│ ✓  │     │  │
-│  │                 │  │ │ A radium love story      │           │    │     │  │
-│  │ Perspective     │  │ │ 👤 Marie Curie · 8 ev·3ch│           │    │     │  │
-│  │ ▾ Any character │  │ ├──────────────────────────┼───────────┼────┤     │  │
-│  │                 │  │ │ Fall of Rome             │ Omniscient│ ✓  │     │  │
-│  │ Status          │  │ │ 14 ev · 9 ch             │           │    │     │  │
-│  │ ☐ Published   6 │  │ │ tragedy · war            │           │    │     │  │
-│  │ ☐ Draft       3 │  │ ├──────────────────────────┼───────────┼────┤     │  │
-│  │                 │  │ │ My Grandfather's War     │ 1st-person│ ─  │     │  │
-│  │ Tags            │  │ │ 👤 Étienne (narrator)    │           │draft│    │  │
-│  │ [ war ×]        │  │ │ 5 ev · 2 ch              │           │    │     │  │
-│  │ [ + tag ]       │  │ └──────────────────────────┴───────────┴────┘     │  │
-│  │                 │  │                                                    │  │
-│  │ Clear filters   │  │ ⟨ 1  ⟩                          Sort: Updated ▾    │  │
-│  └─────────────────┘  └────────────────────────────────────────────────────┘  │
+│  ┌────────────────────────────────────────────────────┐  ┌─────────────────┐ │
+│  │ ⌕ Search title, summary, detail…                   │  │ Filter          │ │
+│  │                                                    │  │                 │ │
+│  │ ┌──────────────────────────┬───────────┬─────┐     │  │ Narrator        │ │
+│  │ │ Title                    │ Narrator  │Pub  │     │  │ ☐ First-person 3│ │
+│  │ ├──────────────────────────┼───────────┼─────┤     │  │ ☐ Third-person 4│ │
+│  │ │ The Curies' Quest        │ 3rd-person│ ✓   │     │  │ ☐ Omniscient  2 │ │
+│  │ │ A radium love story      │           │     │     │  │                 │ │
+│  │ │ 👤 Marie Curie · 8 ev·3ch│           │     │     │  │ Perspective     │ │
+│  │ ├──────────────────────────┼───────────┼─────┤     │  │ ▾ Any character │ │
+│  │ │ Fall of Rome             │ Omniscient│ ✓   │     │  │                 │ │
+│  │ │ 14 ev · 9 ch             │           │     │     │  │ Status          │ │
+│  │ │ tragedy · war            │           │     │     │  │ ☐ Published   6 │ │
+│  │ ├──────────────────────────┼───────────┼─────┤     │  │ ☐ Draft       3 │ │
+│  │ │ My Grandfather's War     │ 1st-person│ ─   │     │  │                 │ │
+│  │ │ 👤 Étienne (narrator)    │           │draft│     │  │ Tags            │ │
+│  │ │ 5 ev · 2 ch              │           │     │     │  │ [ war ×]        │ │
+│  │ └──────────────────────────┴───────────┴─────┘     │  │ [ + tag ]       │ │
+│  │                                                    │  │                 │ │
+│  │ ⟨ 1  ⟩                          Sort: Updated ▾    │  │ Clear filters   │ │
+│  └────────────────────────────────────────────────────┘  └─────────────────┘ │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Annotations
 
-1. **Same left-rail + two-line-row list pattern** as characters/events/timelines ([03](03-characters-list.md), [07](07-events-list.md), [11](11-timeline-list.md)). Don't reinvent a fourth list idiom.
+1. **Same right-rail + two-line-row list pattern** as characters/events/timelines ([03](03-characters-list.md), [07](07-events-list.md), [11](11-timeline-list.md)) — filter rail on the right of the table. Don't reinvent a fourth list idiom. See ADR-0035.
 2. **`narrator_type` is a column + filter**, three values (`first_person|third_person|omniscient`). It's identity-level for a story (the narrative voice), so it sits beside the title like character_type does for characters.
 3. **Perspective character renders with the finalized type identity** — the `perspective_character_id` shows as `👤 Name` using the character-type icon + tint from [03-aesthetic-notes.md](../03-aesthetic-notes.md) § _Character type as identity_. For `first_person` stories it carries a `(narrator)` qualifier. Stories with no perspective character (common for omniscient) omit the chip.
 4. **Counts on line 2** — `N ev · M ch` (events via `story_events`, characters via `story_characters`). Deferred-tolerant like the timelines list: render without them if the count contract isn't wired.

--- a/docs/design/admin/02-wireframes/21-periods-list.md
+++ b/docs/design/admin/02-wireframes/21-periods-list.md
@@ -24,35 +24,35 @@
 │  Periods                                                  [ + New period ]   │
 │  23 total · 18 shown                                                         │
 │                                                                              │
-│  ┌─────────────────┐  ┌────────────────────────────────────────────────────┐  │
-│  │ Filter          │  │ ⌕ Search by title…                                 │  │
-│  │                 │  │                                                    │  │
-│  │ Significance    │  │ ┌──┬──────────────────────┬────────────┬─────┐    │  │
-│  │ ☐ Critical    3 │  │ │  │ Title                │ Span       │ Sig │    │  │
-│  │ ☐ High        7 │  │ ├──┼──────────────────────┼────────────┼─────┤    │  │
-│  │ ☐ Medium     10 │  │ │⌒ │ Mesozoic Era         │ 252–66 MYA │ ███ │    │  │
-│  │ ☐ Low         3 │  │ │  │ reptiles · warm      │            │ crit│    │  │
-│  │                 │  │ ├──┼──────────────────────┼────────────┼─────┤    │  │
-│  │ Show            │  │ │↳ │ Triassic             │ 252–201 MYA│ ██  │    │  │
-│  │ ◉ All           │  │ │  │ in Mesozoic Era      │            │ high│    │  │
-│  │ ◯ Top-level     │  │ ├──┼──────────────────────┼────────────┼─────┤    │  │
-│  │ ◯ Nested        │  │ │↳ │ Jurassic             │ 201–145 MYA│ ██  │    │  │
-│  │                 │  │ │  │ in Mesozoic Era      │            │ high│    │  │
-│  │ Era             │  │ ├──┼──────────────────────┼────────────┼─────┤    │  │
-│  │ ☐ MYA   …       │  │ │⌒ │ Industrial Revolution│ 1760–1840  │ ███ │    │  │
-│  │ ☐ CE    …       │  │ │  │ steam · factories    │ CE         │ crit│    │  │
-│  │                 │  │ └──┴──────────────────────┴────────────┴─────┘    │  │
-│  │ Status          │  │                                                    │  │
-│  │ ☐ Published  20 │  │ ⟨ 1  2  ⟩                  Sort: Start date ▾      │  │
-│  │ ☐ Draft       3 │  │                                                    │  │
-│  │ Clear filters   │  │                                                    │  │
-│  └─────────────────┘  └────────────────────────────────────────────────────┘  │
+│  ┌────────────────────────────────────────────────────┐  ┌─────────────────┐ │
+│  │ ⌕ Search by title…                                 │  │ Filter          │ │
+│  │                                                    │  │                 │ │
+│  │ ┌──┬──────────────────────┬────────────┬─────┐     │  │ Significance    │ │
+│  │ │  │ Title                │ Span       │ Sig │     │  │ ☐ Critical    3 │ │
+│  │ ├──┼──────────────────────┼────────────┼─────┤     │  │ ☐ High        7 │ │
+│  │ │⌒ │ Mesozoic Era         │ 252–66 MYA │ ███ │     │  │ ☐ Medium     10 │ │
+│  │ │  │ reptiles · warm      │            │ crit│     │  │ ☐ Low         3 │ │
+│  │ ├──┼──────────────────────┼────────────┼─────┤     │  │                 │ │
+│  │ │↳ │ Triassic             │ 252–201 MYA│ ██  │     │  │ Show            │ │
+│  │ │  │ in Mesozoic Era      │            │ high│     │  │ ◉ All           │ │
+│  │ ├──┼──────────────────────┼────────────┼─────┤     │  │ ◯ Top-level     │ │
+│  │ │↳ │ Jurassic             │ 201–145 MYA│ ██  │     │  │ ◯ Nested        │ │
+│  │ │  │ in Mesozoic Era      │            │ high│     │  │                 │ │
+│  │ ├──┼──────────────────────┼────────────┼─────┤     │  │ Era             │ │
+│  │ │⌒ │ Industrial Revolution│ 1760–1840  │ ███ │     │  │ ☐ MYA   …       │ │
+│  │ │  │ steam · factories    │ CE         │ crit│     │  │ ☐ CE    …       │ │
+│  │ └──┴──────────────────────┴────────────┴─────┘     │  │                 │ │
+│  │                                                    │  │ Status          │ │
+│  │ ⟨ 1  2  ⟩                  Sort: Start date ▾      │  │ ☐ Published  20 │ │
+│  │                                                    │  │ ☐ Draft       3 │ │
+│  │                                                    │  │ Clear filters   │ │
+│  └────────────────────────────────────────────────────┘  └─────────────────┘ │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Annotations
 
-1. **Same left-rail + row pattern** as the other lists. Periods read most like the events list — temporally dense, era-aware — so it borrows that layout.
+1. **Same right-rail + row pattern** as the other lists — filter rail on the right of the table. Periods read most like the events list — temporally dense, era-aware — so it borrows that layout. See ADR-0035.
 2. **Span renders via the finalized `TemporalDisplay`** ([03-aesthetic-notes.md](../03-aesthetic-notes.md) § _Era palette_): era code + hue, era-aware formatting (`252–66 MYA`, `1760–1840 CE`). End is expected for periods (they're closed spans) but the schema allows open (`end_temporal_data` optional) — render a single start with an "open" affordance if unset.
 3. **`significance` uses the finalized sequential ramp** ([03-aesthetic-notes.md](../03-aesthetic-notes.md) § _Significance scale_) — the single-hue amber importance ramp reused for `low/medium/high/critical`. Shown as a 4-step bar + label, right-aligned. This is the same visual language as event importance, deliberately.
 4. **Nesting indicator + Show filter** mirror the events list's fractal-scope control, but for the **kept** `parent_period_id` hierarchy: `⌒` top-level, `↳` nested (one level of indentation; `in [Parent]` on line 2). `Show: All / Top-level only / Nested only` keys on `parent_period_id IS NULL`. Unlike events (where event-to-event nesting was retired, [#180](https://github.com/shaes-farm/time-traveler/issues/180)), **periods keep `parent_period_id`** — a period genuinely _is_ a span that contains sub-spans (Mesozoic ⊃ Jurassic), which is the natural hierarchy, not a fractal-zoom mechanism.

--- a/docs/design/admin/03-aesthetic-notes.md
+++ b/docs/design/admin/03-aesthetic-notes.md
@@ -118,7 +118,7 @@ This is an admin app, so motion serves **affordance** and **continuity**, not de
 
 - **Tables are the primary list pattern.** Cards are reserved for cases where a single visual element (face, image) dominates — character cards in pickers, media tiles.
 - **List rows show enough metadata to triage without clicking.** Examples in the wireframes: each row of the events table shows title, era + year, type, importance, participant count, published state.
-- **Filter rails over filter dropdowns.** When 4+ filter axes exist (events list has 6+), a left-rail filter pattern with grouped controls beats stuffing them into the toolbar.
+- **Filter rails over filter dropdowns.** When 4+ filter axes exist (events list has 6+), a side-rail filter pattern with grouped controls beats stuffing them into the toolbar. The rail sits on the **right**, after the content it filters — this keeps the content adjacent to the primary nav (rather than wedged between two rails) and mirrors the editor's right-hand metadata column, so "contextual controls live on the right" reads consistently across list and editor surfaces. See ADR-0035.
 - **Search is global and entity-scoped.** Topbar search is global (across all four searchable types). Each list view has its own scoped search.
 
 ## Components shopping list (preliminary)

--- a/docs/design/admin/fidelity-2-plan.md
+++ b/docs/design/admin/fidelity-2-plan.md
@@ -253,7 +253,7 @@ Originally Batch B. Two PRs.
 Originally Batch D.
 
 - `DataTable` wrapping shadcn `Table` + tanstack-table; row virtualization for events list
-- `FilterRail` — left-rail layout with grouped checkbox sets, range sliders, 3-state radios
+- `FilterRail` — right-rail layout (after the content it filters; see ADR-0035) with grouped checkbox sets, range sliders, 3-state radios
 - Row-layout patterns from wireframes: multi-line rows, era + uncertainty inline, importance as right-aligned tabular number
 - Composite stories: `Pages > Characters List`, `Pages > Events List` (mounted in the Shell)
 - Per the [wireframe decisions](02-wireframes/03-characters-list.md): hover-card thumbnails (no dedicated thumbnail column), labels-only filter chips this fidelity, no card view (per [#127](https://github.com/shaes-farm/time-traveler/issues/127))

--- a/docs/prd/PRD-0001-time-traveler-system.md
+++ b/docs/prd/PRD-0001-time-traveler-system.md
@@ -6614,7 +6614,8 @@ Buttons: [Cancel] [Delete Event]
 
 **Structure:**
 
-- Header with title, filters, search, create button
+- Header with title, search, create button
+- Right-hand filter rail with grouped controls, sitting **after** the content it filters (rather than between the nav and the table). This keeps the table adjacent to the primary nav and mirrors the editor's right-hand metadata column. See [`docs/design/admin/03-aesthetic-notes.md`](../design/admin/03-aesthetic-notes.md) and ADR-0035.
 - Table layout (see admin design wireframes for the canonical row patterns)
 - Pagination or infinite scroll footer
 

--- a/packages/ui/src/components/characters-list.stories.tsx
+++ b/packages/ui/src/components/characters-list.stories.tsx
@@ -261,7 +261,6 @@ function CharactersListPage() {
 
   return (
     <div className="flex h-full">
-      <FilterRail groups={groups} onClearAll={clearAll} />
       <main className="flex flex-1 flex-col overflow-auto">
         <div className="flex items-center justify-between border-b border-border px-6 py-4">
           <h1 className="font-display text-xl text-foreground">Characters</h1>
@@ -274,6 +273,7 @@ function CharactersListPage() {
           <DataTable columns={COLUMNS} data={filtered} />
         </div>
       </main>
+      <FilterRail groups={groups} onClearAll={clearAll} />
     </div>
   );
 }
@@ -374,14 +374,6 @@ export const TypeFiltered: Story = {
           breadcrumbs={[{ label: "Characters" }]}
         >
           <div className="flex h-full">
-            <FilterRail
-              groups={groups}
-              onClearAll={() => {
-                setTypeFilter([]);
-                setEraFilter([]);
-                setPublishedFilter("any");
-              }}
-            />
             <main className="flex flex-1 flex-col overflow-auto">
               <div className="flex items-center justify-between border-b border-border px-6 py-4">
                 <h1 className="font-display text-xl text-foreground">
@@ -396,6 +388,14 @@ export const TypeFiltered: Story = {
                 <DataTable columns={COLUMNS} data={filtered} />
               </div>
             </main>
+            <FilterRail
+              groups={groups}
+              onClearAll={() => {
+                setTypeFilter([]);
+                setEraFilter([]);
+                setPublishedFilter("any");
+              }}
+            />
           </div>
         </Shell>
       );

--- a/packages/ui/src/components/events-list.stories.tsx
+++ b/packages/ui/src/components/events-list.stories.tsx
@@ -293,7 +293,6 @@ function EventsListPage() {
 
   return (
     <div className="flex h-full">
-      <FilterRail groups={groups} onClearAll={clearAll} />
       <main className="flex flex-1 flex-col overflow-auto">
         <div className="flex items-center justify-between border-b border-border px-6 py-4">
           <h1 className="font-display text-xl text-foreground">Events</h1>
@@ -306,6 +305,7 @@ function EventsListPage() {
           <DataTable columns={COLUMNS} data={filtered} />
         </div>
       </main>
+      <FilterRail groups={groups} onClearAll={clearAll} />
     </div>
   );
 }
@@ -411,14 +411,6 @@ export const ImportanceFiltered: Story = {
           breadcrumbs={[{ label: "Events" }]}
         >
           <div className="flex h-full">
-            <FilterRail
-              groups={groups}
-              onClearAll={() => {
-                setTypeFilter([]);
-                setEraFilter([]);
-                setImportanceRange([1, 10]);
-              }}
-            />
             <main className="flex flex-1 flex-col overflow-auto">
               <div className="flex items-center justify-between border-b border-border px-6 py-4">
                 <h1 className="font-display text-xl text-foreground">Events</h1>
@@ -431,6 +423,14 @@ export const ImportanceFiltered: Story = {
                 <DataTable columns={COLUMNS} data={filtered} />
               </div>
             </main>
+            <FilterRail
+              groups={groups}
+              onClearAll={() => {
+                setTypeFilter([]);
+                setEraFilter([]);
+                setImportanceRange([1, 10]);
+              }}
+            />
           </div>
         </Shell>
       );

--- a/packages/ui/src/components/filter-rail.tsx
+++ b/packages/ui/src/components/filter-rail.tsx
@@ -155,7 +155,7 @@ export function FilterRail({ groups, onClearAll, className }: FilterRailProps) {
   return (
     <aside
       className={cn(
-        "flex w-56 shrink-0 flex-col gap-0 border-r border-border",
+        "flex w-56 shrink-0 flex-col gap-0 border-l border-border",
         className,
       )}
     >

--- a/packages/ui/src/components/media-picker.tsx
+++ b/packages/ui/src/components/media-picker.tsx
@@ -190,13 +190,6 @@ export function MediaPicker({
       )}
 
       <div className="flex min-h-0 flex-1">
-        <MediaFilterRail
-          counts={facetCounts}
-          selected={facets}
-          onChange={onFacetsChange}
-          onClearAll={onClearFilters}
-        />
-
         <main className="flex min-w-0 flex-1 flex-col gap-3 overflow-auto p-4">
           <div className="relative">
             <Search
@@ -259,6 +252,13 @@ export function MediaPicker({
             />
           )}
         </main>
+
+        <MediaFilterRail
+          counts={facetCounts}
+          selected={facets}
+          onChange={onFacetsChange}
+          onClearAll={onClearFilters}
+        />
       </div>
 
       {bulkSelectActive && selectedCount > 0 && (

--- a/packages/ui/src/components/timeline-list.stories.tsx
+++ b/packages/ui/src/components/timeline-list.stories.tsx
@@ -299,7 +299,6 @@ function TimelineListPage() {
 
   return (
     <div className="flex h-full">
-      <FilterRail groups={groups} onClearAll={clearAll} />
       <main className="flex flex-1 flex-col overflow-auto">
         <div className="flex items-center justify-between border-b border-border px-6 py-4">
           <div>
@@ -317,6 +316,7 @@ function TimelineListPage() {
           <DataTable columns={COLUMNS} data={filtered} />
         </div>
       </main>
+      <FilterRail groups={groups} onClearAll={clearAll} />
     </div>
   );
 }


### PR DESCRIPTION
## What & why

The admin entity-list filter rail rendered on the **left**, wedging the table between the global nav and the filters and placing the controls visually upstream of the content they act on — the layout felt cramped. This moves the rail to the **right**, so the reading order is **nav → content → filters**: the table sits against the primary nav and gets the wide middle of the viewport, and filters read as a contextual sidebar mirroring the editor's existing right-hand metadata column.

## Changes

**Code**
- `filter-rail.tsx` — divider flipped `border-r` → `border-l`.
- `timeline-list-client.tsx`, `event-list-client.tsx`, `media-picker.tsx` — render `<main>` before the rail. Placement is via **DOM order, not `flex-row-reverse`**, so focus/screen-reader order stays content-then-filters.
- No changes to filter state (URL params), TanStack Query hooks, or `MediaFilterRail` facet logic.

**Docs**
- PRD §7.11.2, the aesthetic-notes density rule, and the fidelity-2 plan reworded to "right rail."
- Five list wireframes + media-library wireframe redrawn (boxes swapped) with annotations updated.
- New **ADR-0035** records the decision (cites the editor's right metadata column as precedent) + index row.
- Public reader filter placement intentionally **unchanged** — deferred to when `apps/reader` is scaffolded (#254).

## Validation

`format:check`, `check-types`, `lint`, `test:coverage` (80% threshold held), and `build` all pass. Existing filter-rail tests assert behavior only, so they pass unchanged. Verified end-to-end in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)