### PR TITLE
feat(admin): attach existing media via picker pick mode (#295)

### DIFF
--- a/apps/admin/app/(protected)/_components/media/attach-media-dialog.test.tsx
+++ b/apps/admin/app/(protected)/_components/media/attach-media-dialog.test.tsx
@@ -8,7 +8,12 @@ const h = vi.hoisted(() => ({
   externalMutate: vi.fn(),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
+  toastWarning: vi.fn(),
+  getExistingMediaIds: vi.fn(),
   pending: false,
+  /** Ids the stub picker hands back when "confirm-pick" is clicked. */
+  pickSelection: [] as string[],
+  pickerProps: null as { busy?: boolean } | null,
 }));
 
 vi.mock("@repo/ui/hooks/use-media", () => ({
@@ -23,7 +28,41 @@ vi.mock("@repo/ui/hooks/use-media", () => ({
 }));
 
 vi.mock("@repo/ui/components/sonner", () => ({
-  toast: { success: h.toastSuccess, error: h.toastError },
+  toast: {
+    success: h.toastSuccess,
+    error: h.toastError,
+    warning: h.toastWarning,
+  },
+}));
+
+vi.mock("@repo/services/media-service", () => ({
+  getExistingMediaIds: (...args: unknown[]) => h.getExistingMediaIds(...args),
+}));
+
+// Stub the connected picker: two buttons drive the dialog's confirm/cancel
+// with a controllable selection, so these tests stay focused on the dialog's
+// revalidation + junction-dispatch logic (the picker has its own tests).
+vi.mock("./existing-media-picker", () => ({
+  ExistingMediaPicker: (props: {
+    busy?: boolean;
+    onConfirm: (ids: string[]) => void | Promise<void>;
+    onCancel: () => void;
+  }) => {
+    h.pickerProps = props;
+    return (
+      <div data-testid="existing-picker">
+        <button
+          type="button"
+          onClick={() => void props.onConfirm(h.pickSelection)}
+        >
+          confirm-pick
+        </button>
+        <button type="button" onClick={() => props.onCancel()}>
+          cancel-pick
+        </button>
+      </div>
+    );
+  },
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,6 +80,10 @@ beforeEach(() => {
   h.externalMutate.mockReset().mockResolvedValue({ id: "new-external-id" });
   h.toastSuccess.mockReset();
   h.toastError.mockReset();
+  h.toastWarning.mockReset();
+  h.getExistingMediaIds.mockReset();
+  h.pickSelection = [];
+  h.pickerProps = null;
   h.pending = false;
 });
 
@@ -389,6 +432,163 @@ describe("AttachMediaDialog — error handling & cancel", () => {
       within(dialog)
         .getAllByRole("button", { name: /Cancel/ })
         .at(-1)!,
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("AttachMediaDialog — Existing tab", () => {
+  it("shows the Existing tab only when attach variant + onAttachExisting are provided", async () => {
+    const { rerender } = render(
+      <AttachMediaDialog
+        open
+        onOpenChange={vi.fn()}
+        client={client}
+        onAttached={vi.fn()}
+        onAttachExisting={vi.fn()}
+      />,
+    );
+    let dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByRole("tab", { name: /Existing/ }),
+    ).toBeInTheDocument();
+
+    // Omitting onAttachExisting hides the tab.
+    rerender(
+      <AttachMediaDialog
+        open
+        onOpenChange={vi.fn()}
+        client={client}
+        onAttached={vi.fn()}
+      />,
+    );
+    dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).queryByRole("tab", { name: /Existing/ }),
+    ).not.toBeInTheDocument();
+
+    // The library variant never shows it, even with the callback present.
+    rerender(
+      <AttachMediaDialog
+        open
+        onOpenChange={vi.fn()}
+        client={client}
+        variant="library"
+        onAttached={vi.fn()}
+        onAttachExisting={vi.fn()}
+      />,
+    );
+    dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).queryByRole("tab", { name: /Existing/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("attaches the confirmed selection and closes on success", async () => {
+    const onAttachExisting = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+    h.pickSelection = ["m1", "m2"];
+    h.getExistingMediaIds.mockResolvedValue(new Set(["m1", "m2"]));
+
+    render(
+      <AttachMediaDialog
+        open
+        onOpenChange={onOpenChange}
+        client={client}
+        onAttached={vi.fn()}
+        onAttachExisting={onAttachExisting}
+      />,
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("tab", { name: /Existing/ }),
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "confirm-pick" }),
+    );
+
+    await waitFor(() =>
+      expect(onAttachExisting).toHaveBeenCalledWith(["m1", "m2"]),
+    );
+    expect(h.toastSuccess).toHaveBeenCalledWith("Media attached");
+    expect(h.toastWarning).not.toHaveBeenCalled();
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("drops ids that vanished, warns, and attaches only the survivors", async () => {
+    const onAttachExisting = vi.fn().mockResolvedValue(undefined);
+    h.pickSelection = ["m1", "gone", "m2"];
+    h.getExistingMediaIds.mockResolvedValue(new Set(["m1", "m2"]));
+
+    render(
+      <AttachMediaDialog
+        open
+        onOpenChange={vi.fn()}
+        client={client}
+        onAttached={vi.fn()}
+        onAttachExisting={onAttachExisting}
+      />,
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("tab", { name: /Existing/ }),
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "confirm-pick" }),
+    );
+
+    await waitFor(() =>
+      expect(onAttachExisting).toHaveBeenCalledWith(["m1", "m2"]),
+    );
+    expect(h.toastWarning).toHaveBeenCalledOnce();
+    expect(h.toastWarning.mock.calls[0]![0]).toMatch(/1 selected item was/i);
+  });
+
+  it("does not attach or close when every selected id has vanished", async () => {
+    const onAttachExisting = vi.fn();
+    const onOpenChange = vi.fn();
+    h.pickSelection = ["gone1", "gone2"];
+    h.getExistingMediaIds.mockResolvedValue(new Set<string>());
+
+    render(
+      <AttachMediaDialog
+        open
+        onOpenChange={onOpenChange}
+        client={client}
+        onAttached={vi.fn()}
+        onAttachExisting={onAttachExisting}
+      />,
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("tab", { name: /Existing/ }),
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "confirm-pick" }),
+    );
+
+    await waitFor(() => expect(h.toastWarning).toHaveBeenCalledOnce());
+    expect(onAttachExisting).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("Cancel from the picker closes the dialog", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <AttachMediaDialog
+        open
+        onOpenChange={onOpenChange}
+        client={client}
+        onAttached={vi.fn()}
+        onAttachExisting={vi.fn()}
+      />,
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("tab", { name: /Existing/ }),
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "cancel-pick" }),
     );
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });

--- a/apps/admin/app/(protected)/_components/media/attach-media-dialog.tsx
+++ b/apps/admin/app/(protected)/_components/media/attach-media-dialog.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { FolderOpen, Link2, UploadCloud } from "lucide-react";
+import { FolderOpen, Images, Link2, UploadCloud } from "lucide-react";
+import { getExistingMediaIds } from "@repo/services/media-service";
 import { toast } from "@repo/ui/components/sonner";
 import { Button } from "@repo/ui/components/button";
 import {
@@ -25,6 +26,7 @@ import {
   useCreateExternalMedia,
   useDeleteMedia,
 } from "@repo/ui/hooks/use-media";
+import { ExistingMediaPicker } from "./existing-media-picker";
 
 /** 5 MB — matches the Storage bucket `file_size_limit` and RLS WITH CHECK (00009). */
 export const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
@@ -81,6 +83,14 @@ export interface AttachMediaDialogProps {
   /** Which tab opens first. Lets the library's separate Upload / External URL
    * entry points land on the matching tab. */
   defaultTab?: "upload" | "external";
+  /**
+   * Attach one or more *existing* library media rows to the host entity. When
+   * provided (and `variant="attach"`), the dialog shows a third **Existing** tab
+   * that embeds the media picker; the host writes the junctions with its own
+   * ordering/primary rules and composite-PK dedup (screen-17 annotation #9).
+   * Omit it for the `library` variant — upload-to-orphan has no attach step.
+   */
+  onAttachExisting?: (mediaIds: string[]) => Promise<void> | void;
 }
 
 /** Per-variant copy: the library path creates an orphan, so it never says
@@ -95,6 +105,7 @@ const VARIANT_COPY = {
     externalCta: "Attach",
     externalBusy: "Attaching…",
     externalSuccess: "External media attached",
+    existingSuccess: "Media attached",
   },
   library: {
     title: "Add to library",
@@ -106,6 +117,8 @@ const VARIANT_COPY = {
     externalCta: "Add",
     externalBusy: "Adding…",
     externalSuccess: "External media added to library",
+    // Library variant never shows the Existing tab; present for shape symmetry.
+    existingSuccess: "Media attached",
   },
 } as const;
 
@@ -121,11 +134,18 @@ export function AttachMediaDialog({
   onAttached,
   variant = "attach",
   defaultTab = "upload",
+  onAttachExisting,
 }: AttachMediaDialogProps) {
   const copy = VARIANT_COPY[variant];
   const upload = useUploadMedia(client);
   const createExternal = useCreateExternalMedia(client);
   const deleteMedia = useDeleteMedia(client);
+
+  // The Existing tab is offered only on the attach-to-entity path, and only
+  // when the host supplies a junction writer. The library variant (upload to
+  // orphan) has no attach step.
+  const showExistingTab = variant === "attach" && Boolean(onAttachExisting);
+  const [attachingExisting, setAttachingExisting] = React.useState(false);
 
   // Upload tab state
   const [file, setFile] = React.useState<File | null>(null);
@@ -141,7 +161,10 @@ export function AttachMediaDialog({
   const [externalCaption, setExternalCaption] = React.useState("");
 
   const busy =
-    upload.isPending || createExternal.isPending || deleteMedia.isPending;
+    upload.isPending ||
+    createExternal.isPending ||
+    deleteMedia.isPending ||
+    attachingExisting;
 
   function reset() {
     setFile(null);
@@ -241,16 +264,57 @@ export function AttachMediaDialog({
     }
   }
 
+  async function handleAttachExisting(mediaIds: string[]) {
+    if (!onAttachExisting || mediaIds.length === 0) return;
+    setAttachingExisting(true);
+    let succeeded = false;
+    try {
+      // Media can be deleted while the picker is open — revalidate the
+      // selection against the live table and drop any that vanished before
+      // writing junctions (they would otherwise fail the media_id FK).
+      const alive = await getExistingMediaIds(client, mediaIds);
+      const survivors = mediaIds.filter((id) => alive.has(id));
+      const dropped = mediaIds.length - survivors.length;
+      if (dropped > 0) {
+        toast.warning(
+          `${dropped} selected item${dropped === 1 ? " was" : "s were"} removed and could not be attached.`,
+        );
+      }
+      if (survivors.length === 0) return;
+      await onAttachExisting(survivors);
+      toast.success(copy.existingSuccess);
+      succeeded = true;
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to attach media",
+      );
+    } finally {
+      setAttachingExisting(false);
+    }
+    // Close directly rather than via handleOpenChange — the `busy` it guards on
+    // is still true in this render's closure.
+    if (succeeded) {
+      reset();
+      onOpenChange(false);
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className={showExistingTab ? "max-w-3xl" : "max-w-lg"}>
         <DialogHeader>
           <DialogTitle>{copy.title}</DialogTitle>
           <DialogDescription>{copy.description}</DialogDescription>
         </DialogHeader>
 
         <Tabs defaultValue={defaultTab}>
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList
+            className={
+              showExistingTab
+                ? "grid w-full grid-cols-3"
+                : "grid w-full grid-cols-2"
+            }
+          >
             <TabsTrigger value="upload">
               <UploadCloud className="mr-1.5 h-4 w-4" />
               Upload
@@ -259,6 +323,12 @@ export function AttachMediaDialog({
               <Link2 className="mr-1.5 h-4 w-4" />
               External URL
             </TabsTrigger>
+            {showExistingTab && (
+              <TabsTrigger value="existing">
+                <Images className="mr-1.5 h-4 w-4" />
+                Existing
+              </TabsTrigger>
+            )}
           </TabsList>
 
           {/* Upload tab */}
@@ -405,6 +475,18 @@ export function AttachMediaDialog({
               </Button>
             </div>
           </TabsContent>
+
+          {/* Existing tab — reuse a media row already in the library */}
+          {showExistingTab && (
+            <TabsContent value="existing" className="pt-2">
+              <ExistingMediaPicker
+                client={client}
+                busy={busy}
+                onConfirm={handleAttachExisting}
+                onCancel={() => handleOpenChange(false)}
+              />
+            </TabsContent>
+          )}
         </Tabs>
       </DialogContent>
     </Dialog>

--- a/apps/admin/app/(protected)/_components/media/existing-media-picker.test.tsx
+++ b/apps/admin/app/(protected)/_components/media/existing-media-picker.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { MediaPickerProps } from "@repo/ui/components/media-picker";
+import { ExistingMediaPicker } from "./existing-media-picker";
+
+const h = vi.hoisted(() => ({
+  pickerProps: null as MediaPickerProps | null,
+  rows: [{ id: "m1" }, { id: "m2" }] as unknown[],
+}));
+
+vi.mock("@repo/ui/hooks/use-media", () => ({
+  useMediaLibrary: () => ({
+    data: { rows: h.rows, nextCursor: null, hasMore: false },
+    isPending: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+  useMediaFacetCounts: () => ({ data: undefined }),
+}));
+
+vi.mock("@repo/ui/components/media-picker", () => ({
+  MediaPicker: (props: MediaPickerProps) => {
+    h.pickerProps = props;
+    return <div data-testid="picker" />;
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const client = {} as any;
+
+beforeEach(() => {
+  h.pickerProps = null;
+});
+
+describe("ExistingMediaPicker", () => {
+  it("mounts the picker in pick mode with the library rows and facet defaults", () => {
+    render(
+      <ExistingMediaPicker
+        client={client}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(h.pickerProps?.mode).toBe("pick");
+    expect(h.pickerProps?.items).toEqual(h.rows);
+    // Falls back to empty counts when the facet query has no data yet.
+    expect(h.pickerProps?.facetCounts.type.image).toBe(0);
+  });
+
+  it("propagates onConfirm and onCancel to the picker", () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <ExistingMediaPicker
+        client={client}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    h.pickerProps?.onConfirm?.(["m1", "m2"]);
+    h.pickerProps?.onCancel?.();
+    expect(onConfirm).toHaveBeenCalledWith(["m1", "m2"]);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("disables confirm while busy by withholding onConfirm", () => {
+    render(
+      <ExistingMediaPicker
+        client={client}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+        busy
+      />,
+    );
+    expect(h.pickerProps?.onConfirm).toBeUndefined();
+  });
+});

--- a/apps/admin/app/(protected)/_components/media/existing-media-picker.tsx
+++ b/apps/admin/app/(protected)/_components/media/existing-media-picker.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import { MediaPicker } from "@repo/ui/components/media-picker";
+import { useMediaLibraryBrowser } from "./use-media-library-browser";
+
+type ServiceClient = Parameters<typeof useMediaLibraryBrowser>[0];
+
+export interface ExistingMediaPickerProps {
+  client: ServiceClient;
+  /** Selected `media_id`s to attach. The host writes the junctions. */
+  onConfirm: (mediaIds: string[]) => void | Promise<void>;
+  onCancel: () => void;
+  /** True while the host is writing junctions — disables the confirm action. */
+  busy?: boolean;
+}
+
+/**
+ * Connected `MediaPicker mode="pick"` — the "choose from existing" surface for
+ * the Attach dialog's Existing tab (and future editor media sections). Owns the
+ * shared library query wiring (search / facets / keyset paging) via
+ * {@link useMediaLibraryBrowser}; the picker itself owns the multi-select set
+ * and hands the chosen ids back through `onConfirm`. It writes no junction —
+ * that is the host's job (screen-17 annotation #9).
+ */
+export function ExistingMediaPicker({
+  client,
+  onConfirm,
+  onCancel,
+  busy = false,
+}: ExistingMediaPickerProps) {
+  const browser = useMediaLibraryBrowser(client);
+
+  return (
+    <div className="flex max-h-[60vh] min-h-[24rem] flex-col overflow-hidden rounded-md border border-border">
+      <MediaPicker
+        mode="pick"
+        items={browser.items}
+        facetCounts={browser.facetCounts}
+        search={browser.search}
+        onSearchChange={browser.setSearch}
+        facets={browser.facets}
+        onFacetsChange={browser.setFacets}
+        onClearFilters={browser.clearFilters}
+        view={browser.view}
+        onViewChange={browser.setView}
+        pager={browser.pager}
+        isPending={browser.isPending}
+        isError={browser.isError}
+        onRetry={browser.refetch}
+        onConfirm={busy ? undefined : onConfirm}
+        onCancel={onCancel}
+      />
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/_components/media/media-library.tsx
+++ b/apps/admin/app/(protected)/_components/media/media-library.tsx
@@ -3,46 +3,15 @@
 import * as React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { MediaLibraryRow } from "@repo/services/media-service";
-import type {
-  MediaFacetCounts,
-  MediaLibraryFilters,
-} from "@repo/services/schemas/media";
 import {
   MediaPicker,
   MediaDetailDrawer,
   type MediaFacetSelection,
-  type MediaView,
 } from "@repo/ui/components/media-picker";
-import {
-  mediaKeys,
-  useMediaLibrary,
-  useMediaFacetCounts,
-  useDeleteMediaBulk,
-} from "@repo/ui/hooks/use-media";
+import { mediaKeys, useDeleteMediaBulk } from "@repo/ui/hooks/use-media";
 import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
 import { AttachMediaDialog } from "./attach-media-dialog";
-
-const EMPTY_FACETS: MediaFacetSelection = {
-  mediaTypes: [],
-  sources: [],
-  attachedTo: [],
-};
-
-const EMPTY_COUNTS: MediaFacetCounts = {
-  type: { image: 0, video: 0, audio: 0, document: 0 },
-  source: { upload: 0, external: 0 },
-  attachedTo: { events: 0, characters: 0, timelines: 0, orphaned: 0 },
-};
-
-/** Debounce a fast-changing value (the search box) before it drives a query. */
-function useDebouncedValue<T>(value: T, delayMs: number): T {
-  const [debounced, setDebounced] = React.useState(value);
-  React.useEffect(() => {
-    const id = setTimeout(() => setDebounced(value), delayMs);
-    return () => clearTimeout(id);
-  }, [value, delayMs]);
-  return debounced;
-}
+import { useMediaLibraryBrowser } from "./use-media-library-browser";
 
 export interface MediaLibraryProps {
   /** Pre-selected facets from the URL (e.g. dashboard "orphaned" deep-link). */
@@ -53,24 +22,12 @@ export interface MediaLibraryProps {
  * The cross-entity Media Library route (screen 17): mounts `MediaPicker` in
  * browse mode + the `MediaDetailDrawer`, wires keyset pagination, the
  * upload-to-orphan entry points, and orphan bulk cleanup. The picker and drawer
- * are pure primitives — all interaction state and data wiring live here.
+ * are pure primitives — all interaction state and data wiring live here (the
+ * shared query wiring lives in `useMediaLibraryBrowser`).
  */
 export function MediaLibrary({ initialFacets }: MediaLibraryProps) {
   const client = React.useMemo(() => getBrowserSupabaseClient(), []);
   const queryClient = useQueryClient();
-
-  const [search, setSearch] = React.useState("");
-  const debouncedSearch = useDebouncedValue(search, 250);
-  const [facets, setFacets] = React.useState<MediaFacetSelection>(
-    initialFacets ?? EMPTY_FACETS,
-  );
-  const [view, setView] = React.useState<MediaView>("grid");
-
-  // Keyset pager: the cursor for the current page sits on top of the stack
-  // (undefined = first page). Next pushes the page's nextCursor; Prev pops.
-  const [cursorStack, setCursorStack] = React.useState<(string | undefined)[]>([
-    undefined,
-  ]);
 
   const [selected, setSelected] = React.useState<MediaLibraryRow | null>(null);
   const [bulkIds, setBulkIds] = React.useState<Set<string>>(() => new Set());
@@ -78,55 +35,21 @@ export function MediaLibrary({ initialFacets }: MediaLibraryProps) {
     null | "upload" | "external"
   >(null);
 
+  const browser = useMediaLibraryBrowser(client, {
+    initialFacets,
+    // A filter/search change re-anchors the page, so drop the orphan selection.
+    onFiltersReset: () => setBulkIds(new Set()),
+  });
+
+  const rows = browser.items;
+
   // Bulk select (Delete selected) is offered only when filtered to exactly
   // Orphaned — those rows are `⛓ 0`, so deletion is friction-free (edge case).
   const orphanOnly =
-    facets.attachedTo.length === 1 && facets.attachedTo[0] === "orphaned";
+    browser.facets.attachedTo.length === 1 &&
+    browser.facets.attachedTo[0] === "orphaned";
 
-  const baseFilters: MediaLibraryFilters = {
-    search: debouncedSearch || undefined,
-    mediaTypes: facets.mediaTypes as MediaLibraryFilters["mediaTypes"],
-    sources: facets.sources as MediaLibraryFilters["sources"],
-    attachedTo: facets.attachedTo as MediaLibraryFilters["attachedTo"],
-  };
-
-  const page = useMediaLibrary(client, {
-    ...baseFilters,
-    cursor: cursorStack[cursorStack.length - 1],
-  });
-  const counts = useMediaFacetCounts(client, baseFilters);
   const bulkDelete = useDeleteMediaBulk(client);
-
-  const rows = page.data?.rows ?? [];
-
-  // Any change to search or facets invalidates the keyset cursor (it anchors a
-  // different result set) and the orphan selection. Reset both during render via
-  // the "adjust state when inputs change" pattern (mirrors the list pages), so
-  // the next query already uses the fresh cursor. Initial render is a no-op
-  // because prevFilterKey starts equal to filterKey.
-  const filterKey = JSON.stringify([debouncedSearch, facets]);
-  const [prevFilterKey, setPrevFilterKey] = React.useState(filterKey);
-  if (filterKey !== prevFilterKey) {
-    setPrevFilterKey(filterKey);
-    setCursorStack([undefined]);
-    setBulkIds(new Set());
-  }
-
-  function handleClearFilters() {
-    setSearch("");
-    setFacets(EMPTY_FACETS);
-  }
-
-  function handleNext() {
-    const nextCursor = page.data?.nextCursor;
-    if (nextCursor) {
-      setCursorStack((stack) => [...stack, nextCursor]);
-    }
-  }
-
-  function handlePrev() {
-    setCursorStack((stack) => (stack.length > 1 ? stack.slice(0, -1) : stack));
-  }
 
   function handleDeleteSelected() {
     bulkDelete.mutate([...bulkIds], {
@@ -146,23 +69,18 @@ export function MediaLibrary({ initialFacets }: MediaLibraryProps) {
       <MediaPicker
         mode="browse"
         items={rows}
-        facetCounts={counts.data ?? EMPTY_COUNTS}
-        search={search}
-        onSearchChange={setSearch}
-        facets={facets}
-        onFacetsChange={setFacets}
-        onClearFilters={handleClearFilters}
-        view={view}
-        onViewChange={setView}
-        pager={{
-          hasPrev: cursorStack.length > 1,
-          hasNext: page.data?.hasMore ?? false,
-          onPrev: handlePrev,
-          onNext: handleNext,
-        }}
-        isPending={page.isPending}
-        isError={page.isError}
-        onRetry={() => void page.refetch()}
+        facetCounts={browser.facetCounts}
+        search={browser.search}
+        onSearchChange={browser.setSearch}
+        facets={browser.facets}
+        onFacetsChange={browser.setFacets}
+        onClearFilters={browser.clearFilters}
+        view={browser.view}
+        onViewChange={browser.setView}
+        pager={browser.pager}
+        isPending={browser.isPending}
+        isError={browser.isError}
+        onRetry={browser.refetch}
         onOpen={(id) => setSelected(rows.find((r) => r.id === id) ?? null)}
         onUpload={() => setUploadKind("upload")}
         onAddExternal={() => setUploadKind("external")}

--- a/apps/admin/app/(protected)/_components/media/media-section.test.tsx
+++ b/apps/admin/app/(protected)/_components/media/media-section.test.tsx
@@ -482,4 +482,24 @@ describe("MediaSection — attach", () => {
       within(dialog).getByRole("tab", { name: /External URL/ }),
     ).toBeInTheDocument();
   });
+
+  it("forwards onAttachExisting so the dialog offers the Existing tab", async () => {
+    render(
+      <MediaSection {...baseProps({ items: [], onAttachExisting: vi.fn() })} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Attach media/ }));
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByRole("tab", { name: /Existing/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the Existing tab when onAttachExisting is not provided", async () => {
+    render(<MediaSection {...baseProps({ items: [] })} />);
+    await userEvent.click(screen.getByRole("button", { name: /Attach media/ }));
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).queryByRole("tab", { name: /Existing/ }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/admin/app/(protected)/_components/media/media-section.tsx
+++ b/apps/admin/app/(protected)/_components/media/media-section.tsx
@@ -66,6 +66,18 @@ export interface MediaSectionProps {
   ordering: "sort" | "primary";
   /** Persist a new junction row for the newly-created media id. */
   onAttach: (mediaId: string) => Promise<void> | void;
+  /**
+   * Attach one or more *existing* library media rows. When provided, the Attach
+   * dialog gains an **Existing** tab (choose-from-library). The host writes the
+   * junctions with its own ordering (`ordering="sort"`) / primary
+   * (`ordering="primary"`) rules; dedup makes a re-attach a no-op.
+   *
+   * BLOCKED (character host): no character detail/editor mounts this component
+   * yet (#56/#57 render a placeholder). Character attach-from-existing is wired
+   * through here + `addMediaToCharacter` and lights up when a character host
+   * mounts `MediaSection` with `ordering="primary"`.
+   */
+  onAttachExisting?: (mediaIds: string[]) => Promise<void> | void;
   /** Remove the junction row (media survives). */
   onDetach: (mediaId: string) => Promise<void> | void;
   /** Persist sort_order for an item (ordering="sort" only). */
@@ -113,6 +125,7 @@ export function MediaSection({
   canEdit,
   ordering,
   onAttach,
+  onAttachExisting,
   onDetach,
   onReorder,
   onSetPrimary,
@@ -334,6 +347,7 @@ export function MediaSection({
         onOpenChange={setAttachOpen}
         client={client}
         onAttached={onAttach}
+        onAttachExisting={onAttachExisting}
       />
 
       {/* Edit caption / alt dialog */}

--- a/apps/admin/app/(protected)/_components/media/use-media-library-browser.test.tsx
+++ b/apps/admin/app/(protected)/_components/media/use-media-library-browser.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useMediaLibraryBrowser } from "./use-media-library-browser";
+
+const h = vi.hoisted(() => ({
+  libraryCalls: [] as Record<string, unknown>[],
+  facetCalls: [] as Record<string, unknown>[],
+  rows: [{ id: "m1" }, { id: "m2" }] as unknown[],
+  nextCursor: "CURSOR_2" as string | null,
+  hasMore: true,
+  refetch: vi.fn(),
+}));
+
+vi.mock("@repo/ui/hooks/use-media", () => ({
+  useMediaLibrary: (_client: unknown, filters: Record<string, unknown>) => {
+    h.libraryCalls.push(filters);
+    return {
+      data: { rows: h.rows, nextCursor: h.nextCursor, hasMore: h.hasMore },
+      isPending: false,
+      isError: false,
+      refetch: h.refetch,
+    };
+  },
+  useMediaFacetCounts: (_client: unknown, filters: Record<string, unknown>) => {
+    h.facetCalls.push(filters);
+    return { data: undefined };
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const client = {} as any;
+
+const lastLibraryCall = () => h.libraryCalls[h.libraryCalls.length - 1]!;
+
+beforeEach(() => {
+  h.libraryCalls = [];
+  h.facetCalls = [];
+  h.nextCursor = "CURSOR_2";
+  h.hasMore = true;
+  h.refetch.mockReset();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useMediaLibraryBrowser", () => {
+  it("debounces the search box before it drives the query", () => {
+    const { result } = renderHook(() => useMediaLibraryBrowser(client));
+    expect(lastLibraryCall().search).toBeUndefined();
+
+    act(() => result.current.setSearch("cats"));
+    // Not yet — still within the debounce window.
+    expect(lastLibraryCall().search).toBeUndefined();
+
+    act(() => vi.advanceTimersByTime(250));
+    expect(lastLibraryCall().search).toBe("cats");
+  });
+
+  it("advances and rewinds the keyset cursor via the pager", () => {
+    const { result } = renderHook(() => useMediaLibraryBrowser(client));
+    expect(lastLibraryCall().cursor).toBeUndefined();
+    expect(result.current.pager.hasPrev).toBe(false);
+    expect(result.current.pager.hasNext).toBe(true);
+
+    act(() => result.current.pager.onNext());
+    expect(lastLibraryCall().cursor).toBe("CURSOR_2");
+    expect(result.current.pager.hasPrev).toBe(true);
+
+    act(() => result.current.pager.onPrev());
+    expect(lastLibraryCall().cursor).toBeUndefined();
+    expect(result.current.pager.hasPrev).toBe(false);
+  });
+
+  it("resets the cursor and fires onFiltersReset when facets change", () => {
+    const onFiltersReset = vi.fn();
+    const { result } = renderHook(() =>
+      useMediaLibraryBrowser(client, { onFiltersReset }),
+    );
+
+    act(() => result.current.pager.onNext());
+    expect(result.current.pager.hasPrev).toBe(true);
+
+    act(() =>
+      result.current.setFacets({
+        mediaTypes: ["image"],
+        sources: [],
+        attachedTo: [],
+      }),
+    );
+
+    expect(result.current.pager.hasPrev).toBe(false);
+    expect(lastLibraryCall().cursor).toBeUndefined();
+    expect(lastLibraryCall().mediaTypes).toEqual(["image"]);
+    expect(onFiltersReset).toHaveBeenCalled();
+  });
+
+  it("clearFilters empties search and facets", () => {
+    const { result } = renderHook(() =>
+      useMediaLibraryBrowser(client, {
+        initialFacets: {
+          mediaTypes: ["video"],
+          sources: ["external"],
+          attachedTo: [],
+        },
+      }),
+    );
+    expect(lastLibraryCall().mediaTypes).toEqual(["video"]);
+
+    act(() => result.current.clearFilters());
+    act(() => vi.advanceTimersByTime(250));
+
+    expect(result.current.search).toBe("");
+    expect(result.current.facets.mediaTypes).toEqual([]);
+    expect(lastLibraryCall().mediaTypes).toEqual([]);
+  });
+});

--- a/apps/admin/app/(protected)/_components/media/use-media-library-browser.ts
+++ b/apps/admin/app/(protected)/_components/media/use-media-library-browser.ts
@@ -1,0 +1,155 @@
+"use client";
+
+import * as React from "react";
+import type { MediaLibraryRow } from "@repo/services/media-service";
+import type {
+  MediaFacetCounts,
+  MediaLibraryFilters,
+} from "@repo/services/schemas/media";
+import type {
+  MediaFacetSelection,
+  MediaView,
+  MediaPager,
+} from "@repo/ui/components/media-picker";
+import { useMediaLibrary, useMediaFacetCounts } from "@repo/ui/hooks/use-media";
+
+type ServiceClient = Parameters<typeof useMediaLibrary>[0];
+
+const EMPTY_FACETS: MediaFacetSelection = {
+  mediaTypes: [],
+  sources: [],
+  attachedTo: [],
+};
+
+const EMPTY_COUNTS: MediaFacetCounts = {
+  type: { image: 0, video: 0, audio: 0, document: 0 },
+  source: { upload: 0, external: 0 },
+  attachedTo: { events: 0, characters: 0, timelines: 0, orphaned: 0 },
+};
+
+export { EMPTY_FACETS, EMPTY_COUNTS };
+
+/** Debounce a fast-changing value (the search box) before it drives a query. */
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = React.useState(value);
+  React.useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+export interface UseMediaLibraryBrowserOptions {
+  /** Pre-selected facets (e.g. dashboard "orphaned" deep-link). */
+  initialFacets?: MediaFacetSelection;
+  /** Called during render whenever search/facets change (the result set is
+   * re-anchored). Lets a consumer clear selection tied to the old page. */
+  onFiltersReset?: () => void;
+}
+
+export interface MediaLibraryBrowser {
+  search: string;
+  setSearch: (search: string) => void;
+  facets: MediaFacetSelection;
+  setFacets: React.Dispatch<React.SetStateAction<MediaFacetSelection>>;
+  clearFilters: () => void;
+  view: MediaView;
+  setView: React.Dispatch<React.SetStateAction<MediaView>>;
+  items: MediaLibraryRow[];
+  facetCounts: MediaFacetCounts;
+  pager: MediaPager;
+  isPending: boolean;
+  isError: boolean;
+  refetch: () => void;
+  /** Filters flattened for the query layer (sans cursor). */
+  baseFilters: MediaLibraryFilters;
+}
+
+/**
+ * Shared browse wiring for the cross-entity media library: debounced search,
+ * faceted filter state, keyset cursor pagination, and the library + facet-count
+ * queries. Consumed by both the `/media` route (browse mode) and the Attach
+ * dialog's Existing tab (pick mode) so their grid, facets, and paging behave
+ * identically. The bulk-select / drawer / upload chrome stays with each
+ * consumer — only the query wiring is shared here.
+ */
+export function useMediaLibraryBrowser(
+  client: ServiceClient,
+  { initialFacets, onFiltersReset }: UseMediaLibraryBrowserOptions = {},
+): MediaLibraryBrowser {
+  const [search, setSearch] = React.useState("");
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const [facets, setFacets] = React.useState<MediaFacetSelection>(
+    initialFacets ?? EMPTY_FACETS,
+  );
+  const [view, setView] = React.useState<MediaView>("grid");
+
+  // Keyset pager: the cursor for the current page sits on top of the stack
+  // (undefined = first page). Next pushes the page's nextCursor; Prev pops.
+  const [cursorStack, setCursorStack] = React.useState<(string | undefined)[]>([
+    undefined,
+  ]);
+
+  const baseFilters: MediaLibraryFilters = {
+    search: debouncedSearch || undefined,
+    mediaTypes: facets.mediaTypes as MediaLibraryFilters["mediaTypes"],
+    sources: facets.sources as MediaLibraryFilters["sources"],
+    attachedTo: facets.attachedTo as MediaLibraryFilters["attachedTo"],
+  };
+
+  const page = useMediaLibrary(client, {
+    ...baseFilters,
+    cursor: cursorStack[cursorStack.length - 1],
+  });
+  const counts = useMediaFacetCounts(client, baseFilters);
+
+  // Any change to search or facets invalidates the keyset cursor (it anchors a
+  // different result set). Reset it during render via the "adjust state when
+  // inputs change" pattern, so the next query already uses the fresh cursor.
+  // Initial render is a no-op because prevFilterKey starts equal to filterKey.
+  const filterKey = JSON.stringify([debouncedSearch, facets]);
+  const [prevFilterKey, setPrevFilterKey] = React.useState(filterKey);
+  if (filterKey !== prevFilterKey) {
+    setPrevFilterKey(filterKey);
+    setCursorStack([undefined]);
+    onFiltersReset?.();
+  }
+
+  function clearFilters() {
+    setSearch("");
+    setFacets(EMPTY_FACETS);
+  }
+
+  function handleNext() {
+    const nextCursor = page.data?.nextCursor;
+    if (nextCursor) {
+      setCursorStack((stack) => [...stack, nextCursor]);
+    }
+  }
+
+  function handlePrev() {
+    setCursorStack((stack) => (stack.length > 1 ? stack.slice(0, -1) : stack));
+  }
+
+  return {
+    search,
+    setSearch,
+    facets,
+    setFacets,
+    clearFilters,
+    view,
+    setView,
+    items: page.data?.rows ?? [],
+    facetCounts: counts.data ?? EMPTY_COUNTS,
+    pager: {
+      hasPrev: cursorStack.length > 1,
+      hasNext: page.data?.hasMore ?? false,
+      onPrev: handlePrev,
+      onNext: handleNext,
+    },
+    isPending: page.isPending,
+    isError: page.isError,
+    refetch: () => void page.refetch(),
+    baseFilters,
+  };
+}

--- a/apps/admin/app/(protected)/events/[slug]/_components/event-detail-client.tsx
+++ b/apps/admin/app/(protected)/events/[slug]/_components/event-detail-client.tsx
@@ -739,6 +739,23 @@ export function EventDetailClient({ slug }: { slug: string }) {
     [addMedia, eventId, mediaItems.length, refreshMedia],
   );
 
+  // Attach several existing library rows in one action, appending each after
+  // the current list. `addMediaToEvent` dedups on the composite PK, so an
+  // already-attached row is a silent no-op.
+  const handleAttachExistingMedia = React.useCallback(
+    async (mediaIds: string[]) => {
+      if (!eventId) return;
+      const base = mediaItems.length;
+      await Promise.all(
+        mediaIds.map((mediaId, i) =>
+          addMedia.mutateAsync({ eventId, mediaId, sortOrder: base + i }),
+        ),
+      );
+      await refreshMedia();
+    },
+    [addMedia, eventId, mediaItems.length, refreshMedia],
+  );
+
   const handleDetachMedia = React.useCallback(
     async (mediaId: string) => {
       if (!eventId) return;
@@ -1008,6 +1025,7 @@ export function EventDetailClient({ slug }: { slug: string }) {
             canEdit={canEdit}
             ordering="sort"
             onAttach={handleAttachMedia}
+            onAttachExisting={handleAttachExistingMedia}
             onDetach={handleDetachMedia}
             onReorder={handleReorderMedia}
             onChanged={refreshMedia}

--- a/apps/admin/app/(protected)/timelines/[slug]/_components/timeline-detail-client.tsx
+++ b/apps/admin/app/(protected)/timelines/[slug]/_components/timeline-detail-client.tsx
@@ -963,6 +963,24 @@ export function TimelineDetailClient({ slug }: { slug: string }) {
     await refreshMedia();
   }
 
+  // Attach several existing library rows in one action, appending each after
+  // the current list. `addMediaToTimeline` dedups on the composite PK, so an
+  // already-attached row is a silent no-op.
+  async function handleAttachExistingMedia(mediaIds: string[]) {
+    if (!timeline) return;
+    const base = mediaItems.length;
+    await Promise.all(
+      mediaIds.map((mediaId, i) =>
+        addMedia.mutateAsync({
+          timelineId: timeline.id,
+          mediaId,
+          sortOrder: base + i,
+        }),
+      ),
+    );
+    await refreshMedia();
+  }
+
   async function handleDetachMedia(mediaId: string) {
     if (!timeline) return;
     await removeMedia.mutateAsync({ timelineId: timeline.id, mediaId });
@@ -1200,6 +1218,7 @@ export function TimelineDetailClient({ slug }: { slug: string }) {
             canEdit={canEdit}
             ordering="sort"
             onAttach={handleAttachMedia}
+            onAttachExisting={handleAttachExistingMedia}
             onDetach={handleDetachMedia}
             onReorder={handleReorderMedia}
             onChanged={refreshMedia}

--- a/packages/services/src/modules/character-service.test.ts
+++ b/packages/services/src/modules/character-service.test.ts
@@ -25,6 +25,7 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
   const builder = {
     select: vi.fn().mockReturnThis(),
     insert: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
     update: vi.fn().mockReturnThis(),
     delete: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
@@ -32,6 +33,7 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
     range: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     single: terminal,
+    maybeSingle: terminal,
     then: (resolve: (v: unknown) => unknown) =>
       Promise.resolve(result).then(resolve),
   };
@@ -840,7 +842,7 @@ describe("getCharacterEvents", () => {
 // ---------------------------------------------------------------------------
 
 describe("addMediaToCharacter", () => {
-  it("inserts and returns the junction row", async () => {
+  it("upserts and returns the junction row", async () => {
     const client = makeClient({
       fromResult: { data: sampleMedia, error: null },
     });
@@ -848,7 +850,7 @@ describe("addMediaToCharacter", () => {
     expect(result).toEqual(sampleMedia);
   });
 
-  it("passes is_primary=true when specified", async () => {
+  it("passes is_primary=true when specified, ignoring duplicates on the composite PK", async () => {
     const primaryMedia = { ...sampleMedia, is_primary: true };
     const client = makeClient({
       fromResult: { data: primaryMedia, error: null },
@@ -857,11 +859,10 @@ describe("addMediaToCharacter", () => {
     expect(result).toEqual(primaryMedia);
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
-    expect(builder.insert).toHaveBeenCalledWith({
-      character_id: "char-1",
-      media_id: "media-1",
-      is_primary: true,
-    });
+    expect(builder.upsert).toHaveBeenCalledWith(
+      { character_id: "char-1", media_id: "media-1", is_primary: true },
+      { onConflict: "character_id,media_id", ignoreDuplicates: true },
+    );
   });
 
   it("defaults is_primary to false", async () => {
@@ -871,11 +872,16 @@ describe("addMediaToCharacter", () => {
     await addMediaToCharacter(client, "char-1", "media-1");
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
-    expect(builder.insert).toHaveBeenCalledWith({
-      character_id: "char-1",
-      media_id: "media-1",
-      is_primary: false,
-    });
+    expect(builder.upsert).toHaveBeenCalledWith(
+      { character_id: "char-1", media_id: "media-1", is_primary: false },
+      { onConflict: "character_id,media_id", ignoreDuplicates: true },
+    );
+  });
+
+  it("returns null when the pair already exists (dedup no-op)", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    const result = await addMediaToCharacter(client, "char-1", "media-1");
+    expect(result).toBeNull();
   });
 
   it("throws on Supabase error", async () => {

--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -382,16 +382,23 @@ export async function addMediaToCharacter(
   characterId: string,
   mediaId: string,
   isPrimary = false,
-): Promise<CharacterMediaRow> {
+): Promise<CharacterMediaRow | null> {
+  // Idempotent: re-attaching an already-linked (character_id, media_id) pair is
+  // a no-op via the composite PK. `ignoreDuplicates` leaves the existing row's
+  // is_primary untouched and returns no row, so this resolves to `null` rather
+  // than throwing 23505. Lets the same media be reused across entities.
   const { data, error } = await client
     .from("character_media")
-    .insert({
-      character_id: characterId,
-      media_id: mediaId,
-      is_primary: isPrimary,
-    })
+    .upsert(
+      {
+        character_id: characterId,
+        media_id: mediaId,
+        is_primary: isPrimary,
+      },
+      { onConflict: "character_id,media_id", ignoreDuplicates: true },
+    )
     .select()
-    .single();
+    .maybeSingle();
 
   assertNoError(error, "addMediaToCharacter");
   return data;

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -37,6 +37,7 @@ function makeBuilder(result: {
   const builder = {
     select: vi.fn().mockReturnThis(),
     insert: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockReturnThis(),
     update: vi.fn().mockReturnThis(),
     delete: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
@@ -50,6 +51,7 @@ function makeBuilder(result: {
     range: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     single: terminal,
+    maybeSingle: terminal,
     then: (resolve: (v: unknown) => unknown) =>
       Promise.resolve(result).then(resolve),
   };
@@ -1153,7 +1155,7 @@ describe("removeCategoryFromEvent", () => {
 // ---------------------------------------------------------------------------
 
 describe("addMediaToEvent", () => {
-  it("inserts with default sort_order=0", async () => {
+  it("upserts with default sort_order=0, ignoring duplicates on the composite PK", async () => {
     const client = makeClient({
       fromResult: { data: sampleMedia, error: null },
     });
@@ -1161,11 +1163,10 @@ describe("addMediaToEvent", () => {
     expect(result).toEqual(sampleMedia);
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
-    expect(builder.insert).toHaveBeenCalledWith({
-      event_id: "event-1",
-      media_id: "media-1",
-      sort_order: 0,
-    });
+    expect(builder.upsert).toHaveBeenCalledWith(
+      { event_id: "event-1", media_id: "media-1", sort_order: 0 },
+      { onConflict: "event_id,media_id", ignoreDuplicates: true },
+    );
   });
 
   it("accepts a custom sort_order", async () => {
@@ -1175,11 +1176,16 @@ describe("addMediaToEvent", () => {
     await addMediaToEvent(client, "event-1", "media-1", 5);
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
-    expect(builder.insert).toHaveBeenCalledWith({
-      event_id: "event-1",
-      media_id: "media-1",
-      sort_order: 5,
-    });
+    expect(builder.upsert).toHaveBeenCalledWith(
+      { event_id: "event-1", media_id: "media-1", sort_order: 5 },
+      { onConflict: "event_id,media_id", ignoreDuplicates: true },
+    );
+  });
+
+  it("returns null when the pair already exists (dedup no-op)", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    const result = await addMediaToEvent(client, "event-1", "media-1");
+    expect(result).toBeNull();
   });
 
   it("throws on Supabase error", async () => {

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -889,12 +889,19 @@ export async function addMediaToEvent(
   eventId: string,
   mediaId: string,
   sortOrder = 0,
-): Promise<EventMediaRow> {
+): Promise<EventMediaRow | null> {
+  // Idempotent: re-attaching an already-linked (event_id, media_id) pair is a
+  // no-op via the composite PK. `ignoreDuplicates` leaves the existing row's
+  // sort_order untouched and returns no row, so this resolves to `null` rather
+  // than throwing 23505. Lets the same media be reused across entities.
   const { data, error } = await client
     .from("event_media")
-    .insert({ event_id: eventId, media_id: mediaId, sort_order: sortOrder })
+    .upsert(
+      { event_id: eventId, media_id: mediaId, sort_order: sortOrder },
+      { onConflict: "event_id,media_id", ignoreDuplicates: true },
+    )
     .select()
-    .single();
+    .maybeSingle();
 
   assertNoError(error, "addMediaToEvent");
   return data;

--- a/packages/services/src/modules/media-service.test.ts
+++ b/packages/services/src/modules/media-service.test.ts
@@ -14,6 +14,7 @@ import {
   getMediaAttachments,
   getMediaAttachmentsBulk,
   getOrphanMediaIds,
+  getExistingMediaIds,
 } from "./media-service";
 import { mediaInsertSchema } from "../schemas/media";
 
@@ -29,6 +30,7 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
     update: vi.fn().mockReturnThis(),
     delete: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
     range: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     single: terminal,
@@ -1296,5 +1298,33 @@ describe("getOrphanMediaIds", () => {
     const { client, from } = makeLibraryClient({});
     expect(await getOrphanMediaIds(client, [])).toEqual([]);
     expect(from).not.toHaveBeenCalled();
+  });
+});
+
+describe("getExistingMediaIds", () => {
+  it("returns the subset of ids whose media row still exists", async () => {
+    const client = makeClient({
+      fromResult: { data: [{ id: "m1" }, { id: "m3" }], error: null },
+    });
+    const alive = await getExistingMediaIds(client, ["m1", "m2", "m3"]);
+    expect(alive).toEqual(new Set(["m1", "m3"]));
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.in).toHaveBeenCalledWith("id", ["m1", "m2", "m3"]);
+  });
+
+  it("returns an empty set for empty input without a round-trip", async () => {
+    const client = makeClient({});
+    expect(await getExistingMediaIds(client, [])).toEqual(new Set());
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "select failed" } },
+    });
+    await expect(getExistingMediaIds(client, ["m1"])).rejects.toThrow(
+      "select failed",
+    );
   });
 });

--- a/packages/services/src/modules/media-service.ts
+++ b/packages/services/src/modules/media-service.ts
@@ -946,3 +946,26 @@ export async function getOrphanMediaIds(
   const map = await getMediaAttachmentsBulk(client, mediaIds);
   return mediaIds.filter((id) => (map[id] ?? []).length === 0);
 }
+
+/**
+ * Return the subset of `mediaIds` whose `media` row still exists. Used by the
+ * attach flow to drop ids that were deleted while a picker was open before
+ * writing junctions (a stale selection would otherwise fail the media_id FK).
+ * Returns an empty set for empty input without any round-trip.
+ */
+export async function getExistingMediaIds(
+  client: SupabaseClient<Database>,
+  mediaIds: string[],
+): Promise<Set<string>> {
+  if (mediaIds.length === 0) {
+    return new Set();
+  }
+
+  const { data, error } = await client
+    .from("media")
+    .select("id")
+    .in("id", mediaIds);
+
+  assertNoError(error, "getExistingMediaIds");
+  return new Set((data ?? []).map((row) => row.id));
+}

--- a/packages/services/src/modules/timeline-service.test.ts
+++ b/packages/services/src/modules/timeline-service.test.ts
@@ -55,6 +55,7 @@ function makeBuilder(result: {
     range: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     single: terminal,
+    maybeSingle: terminal,
     then: (resolve: (v: unknown) => unknown) =>
       Promise.resolve(result).then(resolve),
   };
@@ -1134,7 +1135,7 @@ describe("setTimelineEventSortOrder", () => {
 // ---------------------------------------------------------------------------
 
 describe("addMediaToTimeline", () => {
-  it("returns the new junction row with default sort_order=0", async () => {
+  it("upserts the new junction row with default sort_order=0, ignoring duplicates on the composite PK", async () => {
     const row = {
       timeline_id: "timeline-1",
       media_id: "media-1",
@@ -1143,6 +1144,12 @@ describe("addMediaToTimeline", () => {
     const client = makeClient({ fromResult: { data: row, error: null } });
     const result = await addMediaToTimeline(client, "timeline-1", "media-1");
     expect(result).toEqual(row);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.upsert).toHaveBeenCalledWith(
+      { timeline_id: "timeline-1", media_id: "media-1", sort_order: 0 },
+      { onConflict: "timeline_id,media_id", ignoreDuplicates: true },
+    );
   });
 
   it("accepts an explicit sort_order", async () => {
@@ -1153,7 +1160,13 @@ describe("addMediaToTimeline", () => {
     };
     const client = makeClient({ fromResult: { data: row, error: null } });
     const result = await addMediaToTimeline(client, "timeline-1", "media-1", 5);
-    expect(result.sort_order).toBe(5);
+    expect(result?.sort_order).toBe(5);
+  });
+
+  it("returns null when the pair already exists (dedup no-op)", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    const result = await addMediaToTimeline(client, "timeline-1", "media-1");
+    expect(result).toBeNull();
   });
 
   it("throws on Supabase error", async () => {

--- a/packages/services/src/modules/timeline-service.ts
+++ b/packages/services/src/modules/timeline-service.ts
@@ -632,16 +632,23 @@ export async function addMediaToTimeline(
   timelineId: string,
   mediaId: string,
   sortOrder = 0,
-): Promise<TimelineMediaRow> {
+): Promise<TimelineMediaRow | null> {
+  // Idempotent: re-attaching an already-linked (timeline_id, media_id) pair is a
+  // no-op via the composite PK. `ignoreDuplicates` leaves the existing row's
+  // sort_order untouched and returns no row, so this resolves to `null` rather
+  // than throwing 23505. Lets the same media be reused across entities.
   const { data, error } = await client
     .from("timeline_media")
-    .insert({
-      timeline_id: timelineId,
-      media_id: mediaId,
-      sort_order: sortOrder,
-    })
+    .upsert(
+      {
+        timeline_id: timelineId,
+        media_id: mediaId,
+        sort_order: sortOrder,
+      },
+      { onConflict: "timeline_id,media_id", ignoreDuplicates: true },
+    )
     .select()
-    .single();
+    .maybeSingle();
 
   assertNoError(error, "addMediaToTimeline");
   return data;

--- a/plan/feature-media-attach-existing-picker-1.md
+++ b/plan/feature-media-attach-existing-picker-1.md
@@ -1,0 +1,162 @@
+---
+goal: Attach-dialog Existing tab + editor media-section picker — reuse existing media via MediaPicker pick mode (#295)
+version: 1.0
+date_created: 2026-07-02
+last_updated: 2026-07-02
+owner: apps/admin (Time Traveler)
+status: "Planned"
+tags: [feature, frontend, admin, media]
+---
+
+# Introduction
+
+![Status: Planned](https://img.shields.io/badge/status-Planned-blue)
+
+Wire the **"choose from existing"** path so one `media` row can be reused across many entities instead of re-uploaded. Add an **Existing** tab to `AttachMediaDialog` (alongside Upload / External URL) that embeds `MediaPicker` in `pick` mode, and mount the same connected picker from the entity media sections. The picker returns `media_id`s; the **dialog/host** (not the picker) writes the correct junction (`event_media` / `character_media` / `timeline_media`) with its own ordering/primary rules and composite-PK dedup, so a re-attach is a silent **no-op**, not an error ([screen-17 annotation #9](../docs/design/admin/02-wireframes/17-media-library.md#annotations)).
+
+This is the **consumer half** of [fidelity-2-plan § Batch I](../docs/design/admin/fidelity-2-plan.md#batch-i--media-library--picker) and the last open issue in epic #297. Every primitive it needs is already built and merged: the `MediaPicker` pick mode + library hooks (#292), the library query layer (#291), and the `AttachMediaDialog` + junction services (#49).
+
+## What already exists (reuse — do not rebuild)
+
+- **`MediaPicker` pick mode** — [`packages/ui/src/components/media-picker.tsx`](../packages/ui/src/components/media-picker.tsx). Pure primitive; `mode="pick"` renders multi-select checkboxes + an `Attach N items` footer and calls `onConfirm(mediaIds: string[])` / `onCancel()`. Owns its own selection set internally. Needs library query wiring (search/facets/pager) supplied by the consumer.
+- **Library query wiring reference** — [`apps/admin/app/(protected)/_components/media/media-library.tsx`](<../apps/admin/app/(protected)/_components/media/media-library.tsx>) already wires `useMediaLibrary` + `useMediaFacetCounts` + debounced search + keyset cursor stack + facet reset for **browse** mode. The **Existing** tab needs the same wiring for **pick** mode.
+- **`AttachMediaDialog`** — [`attach-media-dialog.tsx`](<../apps/admin/app/(protected)/_components/media/attach-media-dialog.tsx>). Two tabs (Upload / External URL), `variant: "attach" | "library"`, `onAttached(mediaId)` single-id callback. Add a **third** tab, gated to the `attach` variant.
+- **`MediaSection`** — [`media-section.tsx`](<../apps/admin/app/(protected)/_components/media/media-section.tsx>). Renders the attached list + mounts `AttachMediaDialog` with `onAttached={onAttach}`. Used by **event detail** and **timeline detail** clients (ordering `"sort"`).
+- **Junction add services + hooks** — `addMediaToEvent` / `addMediaToTimeline` / `addMediaToCharacter` (`packages/services/src/modules/*-service.ts`) and `useAddMediaToEvent` / `useAddMediaToTimeline` / `useAddMediaToCharacter`. **Currently use plain `.insert()`** — a duplicate composite PK throws `23505`, so they are **not yet idempotent**.
+
+## 1. Requirements & Constraints
+
+- **REQ-001**: `AttachMediaDialog` (attach variant) exposes three tabs: Upload / External URL / **Existing**.
+- **REQ-002**: The Existing tab embeds `MediaPicker mode="pick"` with full faceted search + keyset pagination, and multi-select.
+- **REQ-003**: On **Attach N items**, the **host** (not the picker) writes one junction per selected id into its own junction table with its own ordering (`sort_order` for events/timelines) / primary (`is_primary=false` for characters) rules.
+- **REQ-004**: Re-attaching an already-attached row is a **no-op** ("already attached", not an error), realized via composite-PK dedup. The existing row's `sort_order`/`is_primary` MUST NOT be clobbered.
+- **REQ-005**: On Attach, revalidate selected ids against the live `media` table; drop any id that vanished (deleted while the picker was open), attach the survivors, and surface a non-blocking notice naming the drop count.
+- **REQ-006**: Entity media sections can attach from existing media (event detail + timeline detail wired now; character editor deferred — see CON-002).
+- **REQ-007**: The Existing tab MUST NOT appear in the `library` variant (upload-to-orphan has no attach step — [annotation #11](../docs/design/admin/02-wireframes/17-media-library.md#annotations)).
+- **SEC-001**: External-URL validation semantics in the dialog are unchanged; the Existing path only references pre-existing `media` rows already subject to RLS (`authenticated` writes junctions; `anon` never reaches this dialog).
+- **CON-001**: Strict TypeScript (`strictNullChecks`, `noUncheckedIndexedAccess`), ESM only, zero-warnings lint. `pnpm run check-types`, `lint`, `build`, and `test:coverage` (80% threshold) must pass.
+- **CON-002**: The character editor/detail is a **placeholder** ([`characters/[slug]/edit/page.tsx`](<../apps/admin/app/(protected)/characters/[slug]/edit/page.tsx>) renders `PlaceholderPage`) — no character host mounts `MediaSection` yet. Character attach-from-existing is therefore **wired at the `MediaSection`/service layer** (so it works the moment a character host lands) but **cannot be mounted end-to-end** in this issue.
+- **GUD-001**: Keep primitives pure — all library query wiring lives in `apps/admin` connected wrappers, never in `packages/ui`.
+- **PAT-001**: Follow the browse-mode wiring in `media-library.tsx` (debounced search, `cursorStack`, `filterKey` reset-during-render) verbatim for the pick wrapper.
+- **PAT-002**: Follow the existing host handler pattern (`handleAttachMedia` computes `sort_order` from `mediaItems.length`, then `refreshMedia()`), extended to a batch that increments per item.
+
+## 2. Implementation Steps
+
+### Implementation Phase 1 — Idempotent junction writes + stale-id revalidation (service layer)
+
+- GOAL-001: Make junction `add` writes dedup-tolerant and add a helper to filter selected ids down to those that still exist, so a re-attach is a no-op and a mid-session delete cannot orphan a junction write.
+
+| Task     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Completed | Date |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
+| TASK-001 | In [`packages/services/src/modules/event-service.ts`](../packages/services/src/modules/event-service.ts) `addMediaToEvent`, change `.insert(...).select().single()` → `.upsert({ event_id, media_id, sort_order }, { onConflict: "event_id,media_id", ignoreDuplicates: true }).select().maybeSingle()`. Return type becomes `EventMediaRow \| null` (null = row already existed, dedup no-op). Update the JSDoc to state re-attach is idempotent and does NOT overwrite the existing `sort_order`. |           |      |
+| TASK-002 | Same change in [`timeline-service.ts`](../packages/services/src/modules/timeline-service.ts) `addMediaToTimeline` (`onConflict: "timeline_id,media_id"`) and [`character-service.ts`](../packages/services/src/modules/character-service.ts) `addMediaToCharacter` (`onConflict: "character_id,media_id"`, do not clobber `is_primary`). Both return `<Row> \| null`.                                                                                                                               |           |      |
+| TASK-003 | Add `getExistingMediaIds(client, ids: string[]): Promise<Set<string>>` to [`media-service.ts`](../packages/services/src/modules/media-service.ts): `if (ids.length === 0) return new Set();` else `select("id").in("id", ids)`, `assertNoError`, return `new Set(data.map((r) => r.id))`. Used by the dialog to drop vanished ids (REQ-005).                                                                                                                                                        |           |      |
+| TASK-004 | Update the three `useAddMediaTo*` hooks (`use-events.tsx`, `use-timelines.tsx`, `use-characters.tsx`) only if their generics assume a non-null return; the mutation body is unchanged (still calls the service). No signature change to callers.                                                                                                                                                                                                                                                    |           |      |
+| TASK-005 | Add a `useExistingMediaIds`-free path: expose `getExistingMediaIds` for direct call from the dialog handler (no hook needed — it is a one-shot on Attach, not a cached query). Confirm it is re-exported via `@repo/services/media-service`.                                                                                                                                                                                                                                                        |           |      |
+
+### Implementation Phase 2 — Connected pick-mode picker wrapper (apps/admin)
+
+- GOAL-002: Extract a reusable connected `MediaPicker mode="pick"` wrapper that owns the library query wiring, so both the Existing tab and (future) editor sections mount identical behavior and can never diverge.
+
+| Task     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Completed | Date |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
+| TASK-006 | Create [`apps/admin/app/(protected)/_components/media/existing-media-picker.tsx`](<../apps/admin/app/(protected)/_components/media/existing-media-picker.tsx>) (`"use client"`). Props: `{ client: ServiceClient; onConfirm: (mediaIds: string[]) => void \| Promise<void>; onCancel: () => void; busy?: boolean }`.                                                                                                                                                                                                                     |           |      |
+| TASK-007 | Port the browse wiring from `media-library.tsx` (debounced search via `useDebouncedValue`, `facets` state, `EMPTY_FACETS`/`EMPTY_COUNTS`, `cursorStack`, `handleNext`/`handlePrev`, `filterKey` reset-during-render, `useMediaLibrary` + `useMediaFacetCounts`) into the wrapper. Render `<MediaPicker mode="pick" ... onConfirm={onConfirm} onCancel={onCancel} />`. Do NOT include `bulkSelectable`/delete/drawer/upload props (browse-only).                                                                                          |           |      |
+| TASK-008 | Refactor `media-library.tsx` and the new wrapper to share the browse wiring via a small `useMediaLibraryBrowser(client, initialFacets?)` hook in a sibling file (`use-media-library-browser.ts`) returning `{ items, facetCounts, search, setSearch, facets, setFacets, clearFilters, pager, isPending, isError, refetch }`. Both `MediaLibrary` (browse) and `ExistingMediaPicker` (pick) consume it. (If the extraction risks regressing #294, keep the wrapper self-contained and leave `media-library.tsx` untouched — see ALT-002.) |           |      |
+| TASK-009 | Constrain the picker to a bounded, scrollable height suitable for a dialog body (e.g. wrap in a `max-h-[60vh] min-h-0 overflow-hidden` container) so the sticky pick footer stays visible.                                                                                                                                                                                                                                                                                                                                               |           |      |
+
+### Implementation Phase 3 — Existing tab in AttachMediaDialog
+
+- GOAL-003: Add the third tab and the multi-attach + revalidation handler; keep Upload/External untouched.
+
+| Task     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Completed | Date |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
+| TASK-010 | In `attach-media-dialog.tsx`, add optional prop `onAttachExisting?: (mediaIds: string[]) => Promise<void> \| void` to `AttachMediaDialogProps`. The Existing tab renders only when `variant === "attach" && onAttachExisting` is provided.                                                                                                                                                                                                                                                                  |           |      |
+| TASK-011 | Widen `TabsList` to `grid-cols-3` **only** when the Existing tab is shown (keep `grid-cols-2` otherwise). Add a `<TabsTrigger value="existing">` with a library/images icon (`ImageIcon` or `Library` from lucide-react) and label "Existing".                                                                                                                                                                                                                                                              |           |      |
+| TASK-012 | Add `<TabsContent value="existing">` rendering `<ExistingMediaPicker client={client} onConfirm={handleAttachExisting} onCancel={() => handleOpenChange(false)} busy={busy} />`.                                                                                                                                                                                                                                                                                                                             |           |      |
+| TASK-013 | Implement `handleAttachExisting(ids)`: (1) `const alive = await getExistingMediaIds(client, ids);` (2) `const survivors = ids.filter((id) => alive.has(id));` (3) if `survivors.length < ids.length`, `toast(`{dropped} item(s) were removed and could not be attached`)` (info/warning, not error); (4) if `survivors.length === 0`, return without closing; (5) `await onAttachExisting(survivors);` (6) `toast.success(...)`; (7) `handleOpenChange(false)`. Wrap in try/catch mirroring `handleUpload`. |           |      |
+| TASK-014 | Extend `VARIANT_COPY.attach` with `existingSuccess: "Media attached"` (library variant needs no key — tab hidden there).                                                                                                                                                                                                                                                                                                                                                                                    |           |      |
+
+### Implementation Phase 4 — MediaSection pass-through + host wiring
+
+- GOAL-004: Surface the Existing tab from the entity media sections and implement the per-host batch junction writer.
+
+| Task     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Completed | Date |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
+| TASK-015 | In `media-section.tsx`, add optional prop `onAttachExisting?: (mediaIds: string[]) => Promise<void> \| void` and forward it to `<AttachMediaDialog onAttachExisting={onAttachExisting} />`. No behavior change when omitted.                                                                                                                                                                                                                                  |           |      |
+| TASK-016 | In [`event-detail-client.tsx`](<../apps/admin/app/(protected)/events/[slug]/_components/event-detail-client.tsx>), add `handleAttachExistingMedia(ids)`: for each `id` at index `i`, `await addMedia.mutateAsync({ eventId, mediaId: id, sortOrder: mediaItems.length + i })`; then `await refreshMedia()`. Pass to `<MediaSection onAttachExisting={handleAttachExistingMedia} />`. Sequential or `Promise.all` — dedup no-op means a duplicate is harmless. |           |      |
+| TASK-017 | In [`timeline-detail-client.tsx`](<../apps/admin/app/(protected)/timelines/[slug]/_components/timeline-detail-client.tsx>), mirror TASK-016 with `addMedia.mutateAsync({ timelineId, mediaId, sortOrder: mediaItems.length + i })` and pass `onAttachExisting` to its `<MediaSection>`.                                                                                                                                                                       |           |      |
+| TASK-018 | Character host: no mount point exists (CON-002). Add a `// BLOCKED: character editor is a placeholder (#56/#57); attach-from-existing is wired at MediaSection + addMediaToCharacter and will light up when a character host mounts MediaSection with ordering="primary".` note near the character `MediaSection` contract in `media-section.tsx`. Do not fabricate a character host.                                                                         |           |      |
+
+### Implementation Phase 5 — Tests + validation
+
+- GOAL-005: Cover junction dispatch, dedup no-op, and stale-id revalidation; keep coverage ≥ 80%.
+
+| Task     | Description                                                                                                                                                                                                                                                                                                                                                                                     | Completed | Date |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ---- |
+| TASK-019 | Service tests: `media-service.test.ts` for `getExistingMediaIds` (empty input → empty set, filters to live ids). `event-service` / `timeline-service` / `character-service` tests for the upsert-with-`ignoreDuplicates` path returning `null` on conflict and not overwriting existing order/primary.                                                                                          |           |      |
+| TASK-020 | `attach-media-dialog.test.tsx`: Existing tab present in `attach` variant + `onAttachExisting` provided; absent in `library` variant. Mock `ExistingMediaPicker` (or `getExistingMediaIds` via `@repo/services/media-service`) to drive `onConfirm`. Assert `onAttachExisting` called with survivor ids; stale-id case drops vanished ids + shows notice; empty-survivor case keeps dialog open. |           |      |
+| TASK-021 | `media-section.test.tsx`: `onAttachExisting` forwarded to the dialog; omission is safe (tab hidden / no crash).                                                                                                                                                                                                                                                                                 |           |      |
+| TASK-022 | New `existing-media-picker.test.tsx` (+ `use-media-library-browser` test if extracted): search debounce, facet change resets cursor, `onConfirm` receives the picker's selected ids, `onCancel` fires.                                                                                                                                                                                          |           |      |
+| TASK-023 | Run in order: `pnpm run format` → `pnpm run check-types` → `pnpm run lint` → `pnpm run test:coverage` → `pnpm run build`. All must pass.                                                                                                                                                                                                                                                        |           |      |
+
+## 3. Alternatives
+
+- **ALT-001** (dedup): Catch PostgREST `23505` in each host handler and swallow it as "already attached", leaving `.insert()` untouched. **Rejected** — scatters conflict handling across every call site and is brittle to error-shape changes; `upsert … ignoreDuplicates` centralizes dedup in the service (matches REQ-004 "via composite-PK dedup") and also hardens existing single-attach callers.
+- **ALT-002** (wrapper extraction): Do **not** extract `useMediaLibraryBrowser`; copy the browse wiring into `ExistingMediaPicker` and leave `media-library.tsx` as-is. Acceptable fallback if the shared-hook refactor threatens to regress #294; costs ~130 duplicated lines and a divergence risk (GUD-001 discourages, but self-containment is safe).
+- **ALT-003** (multi-attach API): Loop the existing single `onAttached(mediaId)` inside the dialog instead of adding `onAttachExisting`. **Rejected** — host handlers capture `mediaItems.length` in a `useCallback` dep and don't update mid-loop, so every looped attach would collide on the same `sort_order`. A dedicated batch handler computes `length + i` correctly.
+- **ALT-004** (revalidation): Skip stale-id revalidation and rely on the FK to reject a vanished id. **Rejected** — REQ-005 requires a user-facing notice and graceful survivor-attach, not a raw FK error toast.
+
+## 4. Dependencies
+
+- **DEP-001**: #292 — `MediaPicker` pick mode + library hooks (`useMediaLibrary`, `useMediaFacetCounts`). **Merged.**
+- **DEP-002**: #291 — media-service library query layer (`getMediaLibraryPage`, `getMediaFacetCounts`). **Merged.**
+- **DEP-003**: #49 — `AttachMediaDialog` + `addMediaTo*` junction services/hooks. **Merged.**
+- **DEP-004**: #294 — Media Library route (source of the browse-mode wiring reference; touched only if TASK-008 shares the hook). **Merged.**
+- **DEP-005**: (soft) character host / editor (#56, #57) — required only to mount the character attach-from-existing path end-to-end; not a blocker for this issue's service + `MediaSection` wiring (CON-002).
+
+## 5. Files
+
+- **FILE-001**: `packages/services/src/modules/event-service.ts` — `addMediaToEvent` → idempotent upsert (TASK-001).
+- **FILE-002**: `packages/services/src/modules/timeline-service.ts` — `addMediaToTimeline` → idempotent upsert (TASK-002).
+- **FILE-003**: `packages/services/src/modules/character-service.ts` — `addMediaToCharacter` → idempotent upsert (TASK-002).
+- **FILE-004**: `packages/services/src/modules/media-service.ts` — add `getExistingMediaIds` (TASK-003, TASK-005).
+- **FILE-005**: `apps/admin/app/(protected)/_components/media/existing-media-picker.tsx` — **new** connected pick wrapper (TASK-006/007/009).
+- **FILE-006**: `apps/admin/app/(protected)/_components/media/use-media-library-browser.ts` — **new** shared browse-wiring hook (TASK-008; optional per ALT-002).
+- **FILE-007**: `apps/admin/app/(protected)/_components/media/media-library.tsx` — consume shared hook (TASK-008; only if extracted).
+- **FILE-008**: `apps/admin/app/(protected)/_components/media/attach-media-dialog.tsx` — third tab + `handleAttachExisting` + `onAttachExisting` prop (TASK-010–014).
+- **FILE-009**: `apps/admin/app/(protected)/_components/media/media-section.tsx` — forward `onAttachExisting` + character-host BLOCKED note (TASK-015, TASK-018).
+- **FILE-010**: `apps/admin/app/(protected)/events/[slug]/_components/event-detail-client.tsx` — `handleAttachExistingMedia` + wire (TASK-016).
+- **FILE-011**: `apps/admin/app/(protected)/timelines/[slug]/_components/timeline-detail-client.tsx` — `handleAttachExistingMedia` + wire (TASK-017).
+- **FILE-012**: Test files: `attach-media-dialog.test.tsx`, `media-section.test.tsx`, new `existing-media-picker.test.tsx`, and `*-service.test.ts` (TASK-019–022).
+
+## 6. Testing
+
+- **TEST-001**: `getExistingMediaIds` — empty input returns empty set; filters a mixed input down to only live ids.
+- **TEST-002**: `addMediaToEvent/Timeline/Character` — re-adding an existing pair resolves without throwing, returns `null`, and does not overwrite existing `sort_order`/`is_primary`.
+- **TEST-003**: Dialog — Existing tab renders in `attach` variant with `onAttachExisting`; hidden in `library` variant and when `onAttachExisting` is omitted.
+- **TEST-004**: Dialog — confirming a pick selection calls `onAttachExisting` with exactly the selected ids and closes on success.
+- **TEST-005**: Dialog — when some selected ids no longer exist, only survivors are passed to `onAttachExisting` and a drop notice is shown; when none survive, the dialog stays open and `onAttachExisting` is not called.
+- **TEST-006**: `MediaSection` — `onAttachExisting` is forwarded to `AttachMediaDialog`; omission does not crash.
+- **TEST-007**: `ExistingMediaPicker` — search debounce feeds the query; a facet change resets the cursor stack; `onConfirm`/`onCancel` propagate.
+- **TEST-008**: Host handler (event/timeline) assigns `sort_order = base + i` across a multi-id attach (unit-level on the handler if extractable, else covered by the service dedup test + manual verification).
+
+## 7. Risks & Assumptions
+
+- **RISK-001**: `.upsert(..., { ignoreDuplicates: true }).select().maybeSingle()` returns `null` on conflict; any caller that dereferences the returned row unconditionally will break. **Mitigation** — audit the three `useAddMediaTo*` call sites (they use the result only for cache invalidation) and the pgTAP/unit expectations before merge.
+- **RISK-002**: Extracting `useMediaLibraryBrowser` (TASK-008) could regress the shipped #294 route. **Mitigation** — cover both consumers with the existing `media-library.test.tsx` + new picker test; fall back to ALT-002 (no extraction) if risk is non-trivial.
+- **RISK-003**: `onConflict` column lists must exactly match each junction's composite PK (`event_id,media_id`, `timeline_id,media_id`, `character_id,media_id`). A wrong list silently disables dedup. **Mitigation** — TEST-002 asserts the no-op path.
+- **ASSUMPTION-001**: The three junctions' composite PK is `(entity_id, media_id)` with no surrogate key (per `00002_relationships_junctions.sql` and CLAUDE.md junction convention) — confirm before writing `onConflict`.
+- **ASSUMPTION-002**: `MediaPicker mode="pick"` selection state and `onConfirm` semantics are stable and need no change; only consumer wiring is added.
+- **ASSUMPTION-003**: apps/admin Vitest runner (`apps/admin/vitest.config.ts`) executes these `.test.tsx` files in CI (confirmed present alongside `attach-media-dialog.test.tsx`).
+- **ASSUMPTION-004**: Character attach-from-existing is out of end-to-end scope this issue (CON-002); the epic accepts it lighting up when a character host lands.
+
+## 8. Related Specifications / Further Reading
+
+- [Issue #295](https://github.com/shaes-farm/time-traveler/issues/295) — this feature
+- [Epic #297 — Media Library & Picker](https://github.com/shaes-farm/time-traveler/issues/297)
+- [screen 17 — Media library / picker wireframe (annotation #9)](../docs/design/admin/02-wireframes/17-media-library.md#annotations)
+- [screen 15 — Media management / Attach dialog](../docs/design/admin/02-wireframes/15-media-management.md)
+- [fidelity-2-plan § Batch I](../docs/design/admin/fidelity-2-plan.md#batch-i--media-library--picker)
+- [character editor wireframe (05)](../docs/design/admin/02-wireframes/05-character-editor.md) · [event editor wireframe (09)](../docs/design/admin/02-wireframes/09-event-editor.md)
+- Sibling plans: [#294 route](feature-media-library-route-1.md), [#293 detail drawer](feature-media-detail-drawer-1.md), [#291 query layer](feature-media-library-query-layer-1.md)


### PR DESCRIPTION
Closes #295. Wires the "choose from existing" path so one `media` row can be reused across many entities instead of re-uploaded — the consumer half of [fidelity-2-plan § Batch I](docs/design/admin/fidelity-2-plan.md#batch-i--media-library--picker) and the last open issue in epic #297.

## What changed

**Service layer — dedup + revalidation**
- `addMediaToEvent` / `addMediaToTimeline` / `addMediaToCharacter` now `upsert(…, { onConflict, ignoreDuplicates: true }).select().maybeSingle()` → return `Row | null`. Re-attaching an already-linked pair is a silent no-op that preserves the existing `sort_order`/`is_primary` (composite-PK dedup, screen-17 annotation #9).
- New `getExistingMediaIds(client, ids)` for stale-id revalidation.

**Connected pick wrapper**
- Extracted shared browse wiring (debounced search, facets, keyset cursor, filter reset) into `useMediaLibraryBrowser`; `media-library.tsx` now consumes it too.
- New `ExistingMediaPicker` — `MediaPicker mode="pick"` in a bounded scroll container.

**Existing tab**
- `AttachMediaDialog` gains a third **Existing** tab (attach variant only). On confirm it revalidates the selection, drops any ids deleted while the picker was open (with a `toast.warning`), attaches survivors, and closes on success.

**Host wiring**
- `MediaSection` forwards `onAttachExisting`; event + timeline detail clients batch-attach with incrementing `sort_order`.

## Scope note — character host deferred
The character editor/detail is still a `PlaceholderPage` (#56/#57), so no character host mounts `MediaSection` yet. Character attach-from-existing is wired at the **service + `MediaSection`** layer (`ordering="primary"` supported) and will light up when a character host lands — flagged with a `BLOCKED` note in `media-section.tsx`. The issue AC "character/event editor media sections can attach from existing" is therefore demonstrable for events/timelines now, character later.

## Testing
- New/updated tests: idempotent-upsert + dedup-no-op paths and `getExistingMediaIds` (services); Existing-tab visibility, revalidate-then-attach, vanished-id drop + notice, all-vanished no-op, and cancel (dialog); `MediaSection` forwarding; `ExistingMediaPicker` pass-through/busy gating; `useMediaLibraryBrowser` debounce/paging/facet-reset.
- `format`, `check-types`, `lint`, `test:coverage` (≥80%), and `build` all pass. Re-verified after merging latest `main` (picks up the dark-theme border fix #319, destructive-color #320, and right-side filter rail #321).

## Verification still to do (needs a running stack)
- [x] Manual: attach existing media to an event and a timeline; confirm dedup no-op and no duplicate junction rows / correct ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)