### PR TITLE
feat(services): close event-character participation service gaps

### DIFF
--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -414,6 +414,10 @@ export async function getCharacterNetwork(
  * Returns all `event_characters` junction rows for a character. This surfaces
  * which events the character participated in along with the role and
  * significance assigned to each participation.
+ *
+ * Shape mirrors EventService.getEventParticipants (both select("*") from the
+ * same junction table, filtered on the opposite FK) — see
+ * event-service.test.ts for a cross-check that the two stay in sync.
  */
 export async function getCharacterEvents(
   client: SupabaseClient<Database>,

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -23,6 +23,7 @@ import {
   removeCharacterFromEvent,
   getEventParticipants,
 } from "./event-service";
+import { getCharacterEvents } from "./character-service";
 
 // ---------------------------------------------------------------------------
 // Mock builder helpers
@@ -1306,6 +1307,53 @@ describe("addCharacterToEvent", () => {
       addCharacterToEvent(client, "event-1", "char-1"),
     ).rejects.toThrow("EventService.addCharacterToEvent: insert failed");
   });
+
+  it("throws a clean error for an invalid role without querying the DB", async () => {
+    const client = makeClient({
+      fromResult: { data: sampleCharacter, error: null },
+    });
+    await expect(
+      addCharacterToEvent(
+        client,
+        "event-1",
+        "char-1",
+        // @ts-expect-error intentionally invalid role
+        "hero",
+      ),
+    ).rejects.toThrow(/not a valid character role/);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("throws a clean error for an invalid significance without querying the DB", async () => {
+    const client = makeClient({
+      fromResult: { data: sampleCharacter, error: null },
+    });
+    await expect(
+      addCharacterToEvent(
+        client,
+        "event-1",
+        "char-1",
+        "protagonist",
+        // @ts-expect-error intentionally invalid significance
+        "legendary",
+      ),
+    ).rejects.toThrow(/not a valid significance level/);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("throws a descriptive error on duplicate participation (23505)", async () => {
+    const client = makeClient({
+      fromResult: {
+        data: null,
+        error: { code: "23505", message: "duplicate key" },
+      },
+    });
+    await expect(
+      addCharacterToEvent(client, "event-1", "char-1"),
+    ).rejects.toThrow(
+      "EventService.addCharacterToEvent: character is already a participant in this event",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1361,6 +1409,43 @@ describe("getEventParticipants", () => {
     });
     await expect(getEventParticipants(client, "event-1")).rejects.toThrow(
       "EventService.getEventParticipants: DB error",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// event_characters read consistency (#53)
+// ---------------------------------------------------------------------------
+
+describe("event_characters read consistency", () => {
+  it("getEventParticipants and getCharacterEvents surface identical row shape for the same junction row", async () => {
+    const row = {
+      event_id: "event-1",
+      character_id: "char-1",
+      role: "protagonist",
+      significance: "primary",
+      description: "led the expedition",
+    };
+
+    const eventSideClient = makeClient({
+      fromResult: { data: [row], error: null },
+    });
+    const characterSideClient = makeClient({
+      fromResult: { data: [row], error: null },
+    });
+
+    const fromEventSide = await getEventParticipants(
+      eventSideClient,
+      "event-1",
+    );
+    const fromCharacterSide = await getCharacterEvents(
+      characterSideClient,
+      "char-1",
+    );
+
+    expect(fromEventSide[0]).toEqual(fromCharacterSide[0]);
+    expect(Object.keys(fromEventSide[0] ?? {}).sort()).toEqual(
+      Object.keys(fromCharacterSide[0] ?? {}).sort(),
     );
   });
 });

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -1447,5 +1447,15 @@ describe("event_characters read consistency", () => {
     expect(Object.keys(fromEventSide[0] ?? {}).sort()).toEqual(
       Object.keys(fromCharacterSide[0] ?? {}).sort(),
     );
+
+    const eventBuilder = (eventSideClient.from as ReturnType<typeof vi.fn>).mock
+      .results[0]?.value as ReturnType<typeof makeBuilder>;
+    expect(eventBuilder.select).toHaveBeenCalledWith("*");
+    expect(eventBuilder.eq).toHaveBeenCalledWith("event_id", "event-1");
+
+    const characterBuilder = (characterSideClient.from as ReturnType<typeof vi.fn>)
+      .mock.results[0]?.value as ReturnType<typeof makeBuilder>;
+    expect(characterBuilder.select).toHaveBeenCalledWith("*");
+    expect(characterBuilder.eq).toHaveBeenCalledWith("character_id", "char-1");
   });
 });

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -2,6 +2,10 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { z } from "zod";
 import { eventSchema, eventTypeEnum } from "../schemas/event";
 import type { EventInput } from "../schemas/event";
+import {
+  characterRoleEnum,
+  eventCharacterSignificanceEnum,
+} from "../schemas/event-character";
 import { eraEnum } from "../schemas/temporal";
 import type { Era } from "../schemas/temporal";
 import { generateSlug, resolveCollision } from "../utils/slug";
@@ -22,22 +26,12 @@ type EventCharacterRow =
   Database["public"]["Tables"]["event_characters"]["Row"];
 
 /** A role in an event as defined by the DB CHECK constraint on event_characters.role */
-export type CharacterRole =
-  | "protagonist"
-  | "antagonist"
-  | "witness"
-  | "participant"
-  | "victim"
-  | "beneficiary"
-  | "performer"
-  | "competitor"
-  | "owner"
-  | "creator"
-  | "observer";
+export type CharacterRole = z.infer<typeof characterRoleEnum>;
 
 /** Significance level as defined by the DB CHECK constraint on event_characters.significance */
-export type CharacterSignificance =
-  "primary" | "secondary" | "minor" | "mentioned";
+export type CharacterSignificance = z.infer<
+  typeof eventCharacterSignificanceEnum
+>;
 
 /** Canonical event type enum value. */
 export type EventType = z.infer<typeof eventTypeEnum>;
@@ -954,6 +948,14 @@ export async function reorderEventMedia(
  * Records a character's participation in an event via the `event_characters`
  * junction table. `role` defaults to `'participant'` and `significance`
  * defaults to `'secondary'` per the DB CHECK constraints.
+ *
+ * RLS: SELECT on event_characters is open to any user as long as the parent
+ * event exists. INSERT/UPDATE/DELETE require
+ * `events.user_id = auth.uid() OR is_admin()` — ownership is derived
+ * transitively through the EVENT side only; the character's own owner is not
+ * separately checked, so a caller who owns the event may attach any
+ * character as a participant. This is the intended model
+ * (00007_rls_policies.sql / 00011_rls_performance_hardening.sql).
  */
 export async function addCharacterToEvent(
   client: SupabaseClient<Database>,
@@ -962,6 +964,20 @@ export async function addCharacterToEvent(
   role: CharacterRole = "participant",
   significance: CharacterSignificance = "secondary",
 ): Promise<EventCharacterRow> {
+  const roleResult = characterRoleEnum.safeParse(role);
+  if (!roleResult.success) {
+    throw new Error(
+      `EventService.addCharacterToEvent: "${role}" is not a valid character role`,
+    );
+  }
+  const significanceResult =
+    eventCharacterSignificanceEnum.safeParse(significance);
+  if (!significanceResult.success) {
+    throw new Error(
+      `EventService.addCharacterToEvent: "${significance}" is not a valid significance level`,
+    );
+  }
+
   const { data, error } = await client
     .from("event_characters")
     .insert({
@@ -973,12 +989,19 @@ export async function addCharacterToEvent(
     .select()
     .single();
 
+  if (error !== null && error.code === "23505") {
+    throw new Error(
+      "EventService.addCharacterToEvent: character is already a participant in this event",
+    );
+  }
   assertNoError(error, "addCharacterToEvent");
   return data;
 }
 
 /**
  * Removes the participation record for a character in an event.
+ *
+ * RLS: same event-derived ownership model as addCharacterToEvent above.
  */
 export async function removeCharacterFromEvent(
   client: SupabaseClient<Database>,
@@ -1002,6 +1025,10 @@ export async function removeCharacterFromEvent(
  * type, etc.) is NOT joined. Callers that need full character details must
  * fetch characters separately by `character_id`, or query the
  * `event_participants_view` database view directly.
+ *
+ * Shape mirrors CharacterService.getCharacterEvents (both select("*") from
+ * the same junction table, filtered on the opposite FK) — see
+ * event-service.test.ts for a cross-check that the two stay in sync.
  */
 export async function getEventParticipants(
   client: SupabaseClient<Database>,

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -949,9 +949,9 @@ export async function reorderEventMedia(
  * junction table. `role` defaults to `'participant'` and `significance`
  * defaults to `'secondary'` per the DB CHECK constraints.
  *
- * RLS: SELECT on event_characters is open to any user as long as the parent
- * event exists. INSERT/UPDATE/DELETE require
- * `events.user_id = auth.uid() OR is_admin()` — ownership is derived
+ * RLS: SELECT on event_characters is allowed when the parent event is visible
+ * under events RLS (published, owner, admin, or timeline collaborator).
+ * INSERT/UPDATE/DELETE require `events.user_id = auth.uid() OR is_admin()` — ownership is derived
  * transitively through the EVENT side only; the character's own owner is not
  * separately checked, so a caller who owns the event may attach any
  * character as a participant. This is the intended model

--- a/packages/services/src/schemas/event-character.test.ts
+++ b/packages/services/src/schemas/event-character.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  characterRoleEnum,
+  eventCharacterSignificanceEnum,
+} from "./event-character";
+
+describe("characterRoleEnum", () => {
+  it.each(characterRoleEnum.options)("accepts role '%s'", (role) => {
+    expect(characterRoleEnum.safeParse(role).success).toBe(true);
+  });
+
+  it("rejects an invalid role", () => {
+    expect(characterRoleEnum.safeParse("hero").success).toBe(false);
+  });
+});
+
+describe("eventCharacterSignificanceEnum", () => {
+  it.each(eventCharacterSignificanceEnum.options)(
+    "accepts significance '%s'",
+    (sig) => {
+      expect(eventCharacterSignificanceEnum.safeParse(sig).success).toBe(true);
+    },
+  );
+
+  it("rejects an invalid significance", () => {
+    expect(eventCharacterSignificanceEnum.safeParse("legendary").success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/services/src/schemas/event-character.ts
+++ b/packages/services/src/schemas/event-character.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+/**
+ * Role of a character's participation in an event, per the DB CHECK
+ * constraint on `event_characters.role`
+ * (supabase/migrations/00002_relationships_junctions.sql).
+ */
+export const characterRoleEnum = z.enum([
+  "protagonist",
+  "antagonist",
+  "witness",
+  "participant",
+  "victim",
+  "beneficiary",
+  "performer",
+  "competitor",
+  "owner",
+  "creator",
+  "observer",
+]);
+
+/**
+ * Significance of a character's participation in an event, per the DB CHECK
+ * constraint on `event_characters.significance`. Distinct from
+ * `significanceEnum` in ./character.ts, which governs the unrelated
+ * `characters.significance` field with a different value set.
+ */
+export const eventCharacterSignificanceEnum = z.enum([
+  "primary",
+  "secondary",
+  "minor",
+  "mentioned",
+]);

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
         "src/schemas/media.ts",
         "src/schemas/story.ts",
         "src/schemas/character-relationship.ts",
+        "src/schemas/event-character.ts",
         "src/schemas/slug.ts",
         "src/modules/temporal-service.ts",
         "src/modules/timeline-service.ts",


### PR DESCRIPTION
## Summary
- Adds `characterRoleEnum`/`eventCharacterSignificanceEnum` Zod schemas (`packages/services/src/schemas/event-character.ts`) matching the DB CHECK constraints on `event_characters`, and re-derives `EventService`'s `CharacterRole`/`CharacterSignificance` types from them (same exported names, non-breaking for `@repo/ui`'s `use-events.tsx`).
- `addCharacterToEvent` now validates `role`/`significance` before insert (clean error instead of a raw CHECK violation) and throws a clean error on duplicate-participation (Postgres 23505), mirroring the pattern #52 established for `character-relationship-service.ts` (commit 8116630).
- Documents the event-derived RLS/ownership model in service-layer comments on `addCharacterToEvent`/`removeCharacterFromEvent`.
- Adds a bidirectional shape-consistency test proving `getEventParticipants` (event-service.ts) and `getCharacterEvents` (character-service.ts) return identical junction-row shape.
- No migration/RLS changes — the CHECK constraints and event-derived RLS already existed and are correct; this is a service-layer-only hardening pass.

Closes #53

## Test plan
- [x] `pnpm run format` / `format:check`
- [x] `pnpm run check-types`
- [x] `pnpm run lint` (zero-warnings)
- [x] `pnpm run test:coverage` (818 services tests passing, coverage threshold maintained; new `event-character.ts` schema added to the coverage include list)
- [x] `pnpm run build` (admin, docs, reader all compile against the re-derived types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)