### PR TITLE
feat(services,ui): close character hook-layer gaps

### DIFF
--- a/packages/services/src/modules/character-service.test.ts
+++ b/packages/services/src/modules/character-service.test.ts
@@ -29,6 +29,8 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
     update: vi.fn().mockReturnThis(),
     delete: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
     textSearch: vi.fn().mockReturnThis(),
     range: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
@@ -139,12 +141,96 @@ describe("getCharacters", () => {
     expect(builder.eq).toHaveBeenCalledWith("character_type", "fictional");
   });
 
+  it("applies characterType filter as SQL IN for multiple values", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { characterType: ["human", "animal"] });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.in).toHaveBeenCalledWith("character_type", [
+      "human",
+      "animal",
+    ]);
+  });
+
+  it("applies characterType filter as eq for a single-element array", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { characterType: ["human"] });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("character_type", "human");
+  });
+
+  it("applies significance filter", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { significance: "high" });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("significance", "high");
+  });
+
+  it("applies significance filter as SQL IN for multiple values", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { significance: ["high", "critical"] });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.in).toHaveBeenCalledWith("significance", [
+      "high",
+      "critical",
+    ]);
+  });
+
   it("applies userId filter", async () => {
     const client = makeClient({ fromResult: { data: [], error: null } });
     await getCharacters(client, { userId: "user-abc" });
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
     expect(builder.eq).toHaveBeenCalledWith("user_id", "user-abc");
+  });
+
+  it("applies published=true filter", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { published: true });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("published", true);
+  });
+
+  it("applies published=false filter", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { published: false });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("published", false);
+  });
+
+  it("selects an inner has-media embed when hasMedia=true", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { hasMedia: true });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.select).toHaveBeenCalledWith(
+      "*, character_media!inner(count)",
+    );
+    expect(builder.is).not.toHaveBeenCalled();
+  });
+
+  it("selects a plain has-media embed and filters is-null when hasMedia=false", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { hasMedia: false });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.select).toHaveBeenCalledWith(
+      "*, character_media(character_id)",
+    );
+    expect(builder.is).toHaveBeenCalledWith("character_media", null);
+  });
+
+  it("selects a bare * when hasMedia is omitted", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.select).toHaveBeenCalledWith("*");
   });
 
   it("applies search filter via full-text search", async () => {
@@ -191,12 +277,25 @@ describe("getCharacters", () => {
     expect(builder.range).toHaveBeenCalledWith(0, 99);
   });
 
-  it("orders results by name ascending", async () => {
+  it("orders results by name ascending by default", async () => {
     const client = makeClient({ fromResult: { data: [], error: null } });
     await getCharacters(client);
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
     expect(builder.order).toHaveBeenCalledWith("name", { ascending: true });
+  });
+
+  it("orders by the requested sortBy/sortDirection", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, {
+      sortBy: "updated_at",
+      sortDirection: "desc",
+    });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.order).toHaveBeenCalledWith("updated_at", {
+      ascending: false,
+    });
   });
 
   it("throws on Supabase error", async () => {

--- a/packages/services/src/modules/character-service.test.ts
+++ b/packages/services/src/modules/character-service.test.ts
@@ -298,6 +298,31 @@ describe("getCharacters", () => {
     });
   });
 
+  it("adds a secondary order by id for deterministic pagination", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, { sortBy: "name" });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.order).toHaveBeenCalledWith("id", { ascending: true });
+  });
+
+  it("strips the character_media embed from returned rows when hasMedia is set", async () => {
+    const client = makeClient({
+      fromResult: {
+        data: [
+          {
+            ...sampleCharacter,
+            character_media: [{ character_id: "char-1" }],
+          },
+        ],
+        error: null,
+      },
+    });
+    const result = await getCharacters(client, { hasMedia: true });
+    expect(result).toEqual([sampleCharacter]);
+    expect(result[0]).not.toHaveProperty("character_media");
+  });
+
   it("throws on Supabase error", async () => {
     const client = makeClient({
       fromResult: { data: null, error: { message: "query failed" } },

--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -193,11 +193,29 @@ export async function getCharacters(
   }
 
   const ascending = sortDirection === "asc";
-  query = query.order(sortBy, { ascending }).range(from, to);
+  // "id" is a secondary tie-breaker so paging stays deterministic when the
+  // primary sort column has duplicate values (e.g. two characters created in
+  // the same request, or sharing a name) — without it, offset pagination can
+  // skip or repeat rows across pages when ties are ordered inconsistently.
+  query = query
+    .order(sortBy, { ascending })
+    .order("id", { ascending: true })
+    .range(from, to);
 
   const { data, error } = await query;
   assertNoError(error, "getCharacters");
-  return (data ?? []) as unknown as CharacterRow[];
+
+  // The hasMedia embed above exists only to drive the query; strip it back
+  // off so the runtime shape always matches the declared CharacterRow[]
+  // return type instead of leaking the embed to callers.
+  const rows = (data ?? []) as unknown as (CharacterRow & {
+    character_media?: unknown;
+  })[];
+  return rows.map((row) => {
+    const rest = { ...row };
+    delete rest.character_media;
+    return rest;
+  });
 }
 
 /**

--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -4,6 +4,7 @@ import {
   characterSchema,
   characterTypeEnum,
   characterTypeProfileSchema,
+  significanceEnum,
 } from "../schemas/character";
 import type {
   CharacterInput,
@@ -36,9 +37,27 @@ type CharacterNetworkRow =
 
 /** Optional filters accepted by getCharacters */
 export interface CharacterFilters {
-  characterType?: z.infer<typeof characterTypeEnum>;
+  /** Scalar or multi-value character_type filter; multiple values use SQL IN. */
+  characterType?:
+    z.infer<typeof characterTypeEnum> | z.infer<typeof characterTypeEnum>[];
+  /** Scalar or multi-value significance filter; multiple values use SQL IN. */
+  significance?:
+    z.infer<typeof significanceEnum> | z.infer<typeof significanceEnum>[];
   userId?: string;
   search?: string;
+  /** When true → only published rows; false → only draft rows; omit → no filter. */
+  published?: boolean;
+  /** When true → only characters with at least one media item; false → none; omit → no filter. */
+  hasMedia?: boolean;
+  /**
+   * Sort column. Defaults to "name". Excludes birth/death date — the
+   * characters table has no sort_order generated column (unlike
+   * events/timelines, whose sort_order columns derive from the era
+   * conversion formula in docs/system-design.md §4); see #326.
+   */
+  sortBy?: "name" | "created_at" | "updated_at";
+  /** Sort direction. Defaults to "asc". */
+  sortDirection?: "asc" | "desc";
   page?: number;
   pageSize?: number;
 }
@@ -93,7 +112,10 @@ function assertAnimalHasSpecies(
 
 /**
  * Returns a page of characters, optionally filtered by character type,
- * owner, or full-text search using the `search_vector` GIN index.
+ * significance, owner, published state, has-media, or full-text search using
+ * the `search_vector` GIN index. Supports sorting by name/created_at/updated_at
+ * (see `CharacterFilters.sortBy` for why birth/death date sorting isn't
+ * supported yet).
  *
  * `page` is clamped to ≥ 1; `pageSize` is clamped to [1, 100].
  */
@@ -101,7 +123,16 @@ export async function getCharacters(
   client: SupabaseClient<Database>,
   filters: CharacterFilters = {},
 ): Promise<CharacterRow[]> {
-  const { characterType, userId, search } = filters;
+  const {
+    characterType,
+    significance,
+    userId,
+    search,
+    published,
+    hasMedia,
+    sortBy = "name",
+    sortDirection = "asc",
+  } = filters;
   const safePage = Math.max(1, Math.floor(filters.page ?? 1));
   const safePageSize = Math.min(
     100,
@@ -110,24 +141,63 @@ export async function getCharacters(
   const from = (safePage - 1) * safePageSize;
   const to = from + safePageSize - 1;
 
-  let query = client.from("characters").select("*");
+  // Same three-way embed trick as EventService.getEventsPage: "has at least
+  // one" uses an !inner embed; "has none" needs a plain column embed (an
+  // aggregate (count) embed combined with is.null returns the right count but
+  // empty rows). No embed is added when hasMedia is omitted, matching
+  // getCharacters' historical select("*") shape when the filter is unused.
+  const mediaEmbed =
+    hasMedia === true
+      ? "character_media!inner(count)"
+      : hasMedia === false
+        ? "character_media(character_id)"
+        : undefined;
+  const selectClause = mediaEmbed !== undefined ? `*, ${mediaEmbed}` : "*";
+
+  let query = client.from("characters").select(selectClause);
 
   if (characterType !== undefined) {
-    query = query.eq("character_type", characterType);
+    if (Array.isArray(characterType)) {
+      if (characterType.length === 1) {
+        query = query.eq("character_type", characterType[0]!);
+      } else if (characterType.length > 1) {
+        query = query.in("character_type", characterType);
+      }
+    } else {
+      query = query.eq("character_type", characterType);
+    }
+  }
+  if (significance !== undefined) {
+    if (Array.isArray(significance)) {
+      if (significance.length === 1) {
+        query = query.eq("significance", significance[0]!);
+      } else if (significance.length > 1) {
+        query = query.in("significance", significance);
+      }
+    } else {
+      query = query.eq("significance", significance);
+    }
   }
   if (userId !== undefined) {
     query = query.eq("user_id", userId);
+  }
+  if (published !== undefined) {
+    query = query.eq("published", published);
+  }
+  if (hasMedia === false) {
+    query = query.is("character_media", null);
   }
   if (search !== undefined && search.length > 0) {
     // Use PostgREST full-text search to leverage the GIN index on search_vector
     query = query.textSearch("search_vector", search, { type: "websearch" });
   }
 
-  query = query.range(from, to).order("name", { ascending: true });
+  const ascending = sortDirection === "asc";
+  query = query.order(sortBy, { ascending }).range(from, to);
 
   const { data, error } = await query;
   assertNoError(error, "getCharacters");
-  return data ?? [];
+  return (data ?? []) as unknown as CharacterRow[];
 }
 
 /**

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -1453,8 +1453,9 @@ describe("event_characters read consistency", () => {
     expect(eventBuilder.select).toHaveBeenCalledWith("*");
     expect(eventBuilder.eq).toHaveBeenCalledWith("event_id", "event-1");
 
-    const characterBuilder = (characterSideClient.from as ReturnType<typeof vi.fn>)
-      .mock.results[0]?.value as ReturnType<typeof makeBuilder>;
+    const characterBuilder = (
+      characterSideClient.from as ReturnType<typeof vi.fn>
+    ).mock.results[0]?.value as ReturnType<typeof makeBuilder>;
     expect(characterBuilder.select).toHaveBeenCalledWith("*");
     expect(characterBuilder.eq).toHaveBeenCalledWith("character_id", "char-1");
   });

--- a/packages/ui/src/hooks/use-characters.test.tsx
+++ b/packages/ui/src/hooks/use-characters.test.tsx
@@ -7,6 +7,7 @@ import {
   useCharacter,
   useCreateCharacter,
   useUpdateCharacter,
+  useAutosaveCharacter,
   useDeleteCharacter,
   useCharacterTimeline,
   useCharacterNetwork,
@@ -14,6 +15,7 @@ import {
   useRemoveMediaFromCharacter,
   useSetPrimaryCharacterMedia,
   characterKeys,
+  characterMutationKeys,
 } from "./use-characters";
 
 // ---------------------------------------------------------------------------
@@ -77,6 +79,14 @@ const mockCharacter = {
 };
 
 const mockCharacters = [mockCharacter];
+
+const mockCharacterWithMedia = {
+  ...mockCharacter,
+  character_media: [
+    { character_id: "char-1", media_id: "media-1", is_primary: true },
+    { character_id: "char-1", media_id: "media-2", is_primary: false },
+  ],
+};
 
 // ---------------------------------------------------------------------------
 // useCharacters
@@ -421,6 +431,119 @@ describe("useSetPrimaryCharacterMedia", () => {
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: characterKeys.detail("char-1") }),
+    );
+  });
+
+  it("optimistically flips is_primary across character_media before the server responds", async () => {
+    vi.mocked(setPrimaryCharacterMedia).mockResolvedValue({} as never);
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(
+      characterKeys.detail("char-1"),
+      mockCharacterWithMedia,
+    );
+
+    const { result } = renderHook(
+      () => useSetPrimaryCharacterMedia(mockClient),
+      { wrapper },
+    );
+
+    result.current.mutate({ characterId: "char-1", mediaId: "media-2" });
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<typeof mockCharacterWithMedia>(
+        characterKeys.detail("char-1"),
+      );
+      expect(cached?.character_media).toEqual([
+        { character_id: "char-1", media_id: "media-1", is_primary: false },
+        { character_id: "char-1", media_id: "media-2", is_primary: true },
+      ]);
+    });
+  });
+
+  it("rolls back the optimistic primary swap on error", async () => {
+    vi.mocked(setPrimaryCharacterMedia).mockRejectedValue(
+      new Error("DB error"),
+    );
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(
+      characterKeys.detail("char-1"),
+      mockCharacterWithMedia,
+    );
+
+    const { result } = renderHook(
+      () => useSetPrimaryCharacterMedia(mockClient),
+      { wrapper },
+    );
+
+    result.current.mutate({ characterId: "char-1", mediaId: "media-2" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(characterKeys.detail("char-1"))).toEqual(
+      mockCharacterWithMedia,
+    );
+  });
+
+  it("does not throw when there is no prior cache data on error", async () => {
+    vi.mocked(setPrimaryCharacterMedia).mockRejectedValue(
+      new Error("DB error"),
+    );
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useSetPrimaryCharacterMedia(mockClient),
+      { wrapper },
+    );
+
+    result.current.mutate({ characterId: "char-1", mediaId: "media-2" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("characterMutationKeys", () => {
+  it("produces distinct keys for update and autosave", () => {
+    expect(characterMutationKeys.update).toEqual(["characters", "update"]);
+    expect(characterMutationKeys.autosave).toEqual(["characters", "autosave"]);
+  });
+});
+
+describe("useAutosaveCharacter", () => {
+  it("calls updateCharacter and invalidates only the detail query", async () => {
+    vi.mocked(updateCharacter).mockResolvedValue(mockCharacter as never);
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useAutosaveCharacter(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate({ id: "char-1", data: { biography: "Draft..." } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(updateCharacter).toHaveBeenCalledWith(mockClient, "char-1", {
+      biography: "Draft...",
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: characterKeys.detail("char-1") }),
+    );
+    expect(invalidateSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: characterKeys.lists() }),
+    );
+  });
+
+  it("rolls back the optimistic snapshot on error", async () => {
+    vi.mocked(updateCharacter).mockRejectedValue(new Error("DB error"));
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(characterKeys.detail("char-1"), mockCharacter);
+
+    const { result } = renderHook(() => useAutosaveCharacter(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate({ id: "char-1", data: { biography: "bad" } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(characterKeys.detail("char-1"))).toEqual(
+      mockCharacter,
     );
   });
 });

--- a/packages/ui/src/hooks/use-characters.test.tsx
+++ b/packages/ui/src/hooks/use-characters.test.tsx
@@ -497,6 +497,33 @@ describe("useSetPrimaryCharacterMedia", () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
+
+  it("skips the optimistic flip when the target media is not in the cached list", async () => {
+    vi.mocked(setPrimaryCharacterMedia).mockResolvedValue({} as never);
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(
+      characterKeys.detail("char-1"),
+      mockCharacterWithMedia,
+    );
+
+    const { result } = renderHook(
+      () => useSetPrimaryCharacterMedia(mockClient),
+      { wrapper },
+    );
+
+    result.current.mutate({
+      characterId: "char-1",
+      mediaId: "media-not-cached",
+    });
+
+    // Cache is left untouched (rather than every row being flipped to false)
+    // until the real invalidation/refetch lands.
+    expect(queryClient.getQueryData(characterKeys.detail("char-1"))).toEqual(
+      mockCharacterWithMedia,
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
 });
 
 describe("characterMutationKeys", () => {
@@ -507,7 +534,7 @@ describe("characterMutationKeys", () => {
 });
 
 describe("useAutosaveCharacter", () => {
-  it("calls updateCharacter and invalidates only the detail query", async () => {
+  it("calls updateCharacter, invalidates detail immediately, and marks lists stale without refetching", async () => {
     vi.mocked(updateCharacter).mockResolvedValue(mockCharacter as never);
     const { wrapper, queryClient } = createWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -525,8 +552,11 @@ describe("useAutosaveCharacter", () => {
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: characterKeys.detail("char-1") }),
     );
-    expect(invalidateSpy).not.toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: characterKeys.lists() }),
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: characterKeys.lists(),
+        refetchType: "none",
+      }),
     );
   });
 

--- a/packages/ui/src/hooks/use-characters.tsx
+++ b/packages/ui/src/hooks/use-characters.tsx
@@ -60,6 +60,30 @@ export const characterKeys = {
 };
 
 // ---------------------------------------------------------------------------
+// Mutation keys
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutation keys distinguishing the deliberate "Save" action from the
+ * character editor's (#56) 30s dirty-interval auto-save. Distinct keys let
+ * the editor track each mutation's pending state independently via
+ * `useIsMutating({ mutationKey: characterMutationKeys.autosave })` — without
+ * this split, an in-flight auto-save and a user-initiated Save would share
+ * one pending flag, so an auto-save completing in the background would reset
+ * the Save button's own pending/success state.
+ *
+ * DECISION: deferred per #54 — a Zustand slice for editor dirty/autosave-timer
+ * state was considered here but is out of scope this milestone; `ui-store`
+ * continues to own only global panel/drawer state. The editor should track
+ * its own dirty flag and timer locally and read mutation status via these
+ * keys with `useIsMutating`/`useMutationState`.
+ */
+export const characterMutationKeys = {
+  update: [...characterKeys.all, "update"] as const,
+  autosave: [...characterKeys.all, "autosave"] as const,
+};
+
+// ---------------------------------------------------------------------------
 // Query hooks
 // ---------------------------------------------------------------------------
 
@@ -169,6 +193,7 @@ export function useCreateCharacter(client: ServiceClient) {
 export function useUpdateCharacter(client: ServiceClient) {
   const queryClient = useQueryClient();
   return useMutation({
+    mutationKey: characterMutationKeys.update,
     mutationFn: ({ id, data }: { id: string; data: CharacterUpdateData }) =>
       updateCharacter(client, id, data),
     onMutate: async ({ id }) => {
@@ -186,6 +211,39 @@ export function useUpdateCharacter(client: ServiceClient) {
         queryKey: characterKeys.detail(id),
       });
       void queryClient.invalidateQueries({ queryKey: characterKeys.lists() });
+    },
+  });
+}
+
+/**
+ * Auto-save variant of `useUpdateCharacter` for the editor's periodic
+ * dirty-save (#56). Same request and snapshot/rollback shape, but keyed
+ * separately (`characterMutationKeys.autosave`) so it never shares pending
+ * state with the deliberate Save mutation, and invalidates only the detail
+ * query — not the lists — since auto-save never toggles `published` (the
+ * editor's Save button is still required to transition Draft → Published)
+ * and re-fetching the whole list on every 30s tick would be wasteful.
+ */
+export function useAutosaveCharacter(client: ServiceClient) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: characterMutationKeys.autosave,
+    mutationFn: ({ id, data }: { id: string; data: CharacterUpdateData }) =>
+      updateCharacter(client, id, data),
+    onMutate: async ({ id }) => {
+      await queryClient.cancelQueries({ queryKey: characterKeys.detail(id) });
+      const previous = queryClient.getQueryData(characterKeys.detail(id));
+      return { previous, id };
+    },
+    onError: (_err, { id }, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(characterKeys.detail(id), context.previous);
+      }
+    },
+    onSuccess: (_data, { id }) => {
+      void queryClient.invalidateQueries({
+        queryKey: characterKeys.detail(id),
+      });
     },
   });
 }
@@ -242,7 +300,13 @@ export function useRemoveMediaFromCharacter(client: ServiceClient) {
   });
 }
 
-/** Set a media item as the character's primary image (sequential two-step swap; not transactional). */
+/**
+ * Set a media item as the character's primary image. Optimistically flips
+ * `is_primary` across the cached character's `character_media` array before
+ * the server responds (the server call itself remains a sequential two-step
+ * swap, not transactional — see `setPrimaryCharacterMedia` in
+ * character-service.ts), rolling back to the snapshot on error.
+ */
 export function useSetPrimaryCharacterMedia(client: ServiceClient) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -253,6 +317,35 @@ export function useSetPrimaryCharacterMedia(client: ServiceClient) {
       characterId: string;
       mediaId: string;
     }) => setPrimaryCharacterMedia(client, characterId, mediaId),
+    onMutate: async ({ characterId, mediaId }) => {
+      await queryClient.cancelQueries({
+        queryKey: characterKeys.detail(characterId),
+      });
+      const previous = queryClient.getQueryData<CharacterWithRelations>(
+        characterKeys.detail(characterId),
+      );
+      if (previous !== undefined) {
+        queryClient.setQueryData<CharacterWithRelations>(
+          characterKeys.detail(characterId),
+          {
+            ...previous,
+            character_media: previous.character_media.map((media) => ({
+              ...media,
+              is_primary: media.media_id === mediaId,
+            })),
+          },
+        );
+      }
+      return { previous, characterId };
+    },
+    onError: (_err, { characterId }, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(
+          characterKeys.detail(characterId),
+          context.previous,
+        );
+      }
+    },
     onSuccess: (_data, { characterId }) => {
       void queryClient.invalidateQueries({
         queryKey: characterKeys.detail(characterId),

--- a/packages/ui/src/hooks/use-characters.tsx
+++ b/packages/ui/src/hooks/use-characters.tsx
@@ -219,10 +219,12 @@ export function useUpdateCharacter(client: ServiceClient) {
  * Auto-save variant of `useUpdateCharacter` for the editor's periodic
  * dirty-save (#56). Same request and snapshot/rollback shape, but keyed
  * separately (`characterMutationKeys.autosave`) so it never shares pending
- * state with the deliberate Save mutation, and invalidates only the detail
- * query — not the lists — since auto-save never toggles `published` (the
- * editor's Save button is still required to transition Draft → Published)
- * and re-fetching the whole list on every 30s tick would be wasteful.
+ * state with the deliberate Save mutation. Invalidates the detail query
+ * immediately; the lists query is invalidated with `refetchType: "none"` —
+ * marked stale for the next mount rather than refetched right away, so a
+ * background 30s tick doesn't cause a list refetch, but a user returning to
+ * the list shortly after an auto-save doesn't see stale `useCharacters` data
+ * either (it has its own 30s `staleTime`).
  */
 export function useAutosaveCharacter(client: ServiceClient) {
   const queryClient = useQueryClient();
@@ -243,6 +245,10 @@ export function useAutosaveCharacter(client: ServiceClient) {
     onSuccess: (_data, { id }) => {
       void queryClient.invalidateQueries({
         queryKey: characterKeys.detail(id),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: characterKeys.lists(),
+        refetchType: "none",
       });
     },
   });
@@ -324,7 +330,15 @@ export function useSetPrimaryCharacterMedia(client: ServiceClient) {
       const previous = queryClient.getQueryData<CharacterWithRelations>(
         characterKeys.detail(characterId),
       );
-      if (previous !== undefined) {
+      // Only flip locally when the target media is actually present in the
+      // cached list — otherwise (stale cache, or a media item added moments
+      // earlier that hasn't been refetched yet) mapping every row to false
+      // would optimistically clear the primary image entirely rather than
+      // leaving the existing primary alone until the server responds.
+      const targetIsCached = previous?.character_media.some(
+        (media) => media.media_id === mediaId,
+      );
+      if (previous !== undefined && targetIsCached === true) {
         queryClient.setQueryData<CharacterWithRelations>(
           characterKeys.detail(characterId),
           {


### PR DESCRIPTION
## Summary
- Extend `CharacterFilters`/`getCharacters` with `significance`, `published`, `hasMedia`, `sortBy`/`sortDirection`, and scalar-or-array `characterType`/`significance` — mirroring the `EventFilters`/`getEventsPage` pattern (including the has-media three-way embed trick) so the characters list (#55) has the filter contract it needs.
- Make `useSetPrimaryCharacterMedia` optimistic: flips `is_primary` locally across `character_media` in `onMutate`, with rollback on error.
- Add a `characterMutationKeys` factory (`update`/`autosave`) and a new `useAutosaveCharacter` hook so the editor's future 30s auto-save (#56) never resets the deliberate Save button's pending state.
- Document the Zustand deferral decision inline (`// DECISION: deferred per #54`) — no new store/slice added.
- Birth-date sorting is intentionally omitted from `sortBy` — `characters` has no `sort_order` generated column (unlike `events`/`timelines`), tracked separately in #326.

Closes #54.

## Test plan
- [x] `pnpm run format` / `format:check`
- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [x] `pnpm run test:coverage` (new filter tests in `character-service.test.ts`; new optimistic-swap/rollback/mutation-key/autosave tests in `use-characters.test.tsx`)
- [x] `pnpm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)