### PR TITLE
feat(database,services): add characters.sort_order_years for birth date sorting (#326)

### DIFF
--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -448,6 +448,7 @@ CREATE TABLE characters (
     CHECK (significance IN ('low', 'medium', 'high', 'critical')),
   birth_temporal JSONB,
   death_temporal JSONB,
+  sort_order_years BIGINT GENERATED ALWAYS AS ( /* era conversion */ ) STORED,  -- #326 (migration 00025): keyed off birth_temporal, falling back to death_temporal, else NULL
   profile_data JSONB DEFAULT '{}',
   metadata JSONB DEFAULT '{}',
   search_vector TSVECTOR GENERATED ALWAYS AS (
@@ -1406,6 +1407,7 @@ CREATE INDEX idx_stories_search ON stories USING GIN (search_vector);
 -- Character lookups
 CREATE INDEX idx_characters_type ON characters (character_type);
 CREATE INDEX idx_characters_aliases ON characters USING GIN (aliases);
+CREATE INDEX idx_characters_sort ON characters (sort_order_years);  -- added in migration 00025 (#326)
 
 -- Junction table performance (reverse-FK lookups; the composite PK's leading
 -- column already supports lookups by the first-named column for free)

--- a/packages/services/src/modules/character-service.test.ts
+++ b/packages/services/src/modules/character-service.test.ts
@@ -282,7 +282,10 @@ describe("getCharacters", () => {
     await getCharacters(client);
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
-    expect(builder.order).toHaveBeenCalledWith("name", { ascending: true });
+    expect(builder.order).toHaveBeenCalledWith("name", {
+      ascending: true,
+      nullsFirst: false,
+    });
   });
 
   it("orders by the requested sortBy/sortDirection", async () => {
@@ -295,6 +298,21 @@ describe("getCharacters", () => {
       ?.value as ReturnType<typeof makeBuilder>;
     expect(builder.order).toHaveBeenCalledWith("updated_at", {
       ascending: false,
+      nullsFirst: false,
+    });
+  });
+
+  it("orders by sort_order_years with NULLs last regardless of direction", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCharacters(client, {
+      sortBy: "sort_order_years",
+      sortDirection: "asc",
+    });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.order).toHaveBeenCalledWith("sort_order_years", {
+      ascending: true,
+      nullsFirst: false,
     });
   });
 

--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -50,12 +50,13 @@ export interface CharacterFilters {
   /** When true → only characters with at least one media item; false → none; omit → no filter. */
   hasMedia?: boolean;
   /**
-   * Sort column. Defaults to "name". Excludes birth/death date — the
-   * characters table has no sort_order generated column (unlike
-   * events/timelines, whose sort_order columns derive from the era
-   * conversion formula in docs/system-design.md §4); see #326.
+   * Sort column. Defaults to "name". "sort_order_years" sorts by birth date
+   * (falling back to death date when birth_temporal is absent; NULL — e.g.
+   * mythological/divine characters with neither — sorts last regardless of
+   * sortDirection). See the characters.sort_order_years generated column,
+   * migration 00025 (#326).
    */
-  sortBy?: "name" | "created_at" | "updated_at";
+  sortBy?: "name" | "created_at" | "updated_at" | "sort_order_years";
   /** Sort direction. Defaults to "asc". */
   sortDirection?: "asc" | "desc";
   page?: number;
@@ -113,9 +114,9 @@ function assertAnimalHasSpecies(
 /**
  * Returns a page of characters, optionally filtered by character type,
  * significance, owner, published state, has-media, or full-text search using
- * the `search_vector` GIN index. Supports sorting by name/created_at/updated_at
- * (see `CharacterFilters.sortBy` for why birth/death date sorting isn't
- * supported yet).
+ * the `search_vector` GIN index. Supports sorting by
+ * name/created_at/updated_at/sort_order_years (see `CharacterFilters.sortBy`
+ * for sort_order_years' birth/death-date fallback and NULL handling).
  *
  * `page` is clamped to ≥ 1; `pageSize` is clamped to [1, 100].
  */
@@ -197,8 +198,10 @@ export async function getCharacters(
   // primary sort column has duplicate values (e.g. two characters created in
   // the same request, or sharing a name) — without it, offset pagination can
   // skip or repeat rows across pages when ties are ordered inconsistently.
+  // nullsFirst: false keeps undated characters (sort_order_years IS NULL)
+  // sorted last regardless of direction, matching EventFilters.sortBy.
   query = query
-    .order(sortBy, { ascending })
+    .order(sortBy, { ascending, nullsFirst: false })
     .order("id", { ascending: true })
     .range(from, to);
 

--- a/packages/services/src/supabase/types.ts
+++ b/packages/services/src/supabase/types.ts
@@ -258,6 +258,7 @@ export type Database = {
           search_vector: unknown;
           significance: string | null;
           slug: string;
+          sort_order_years: number | null;
           species: string | null;
           updated_at: string | null;
           user_id: string;
@@ -282,6 +283,7 @@ export type Database = {
           search_vector?: unknown;
           significance?: string | null;
           slug: string;
+          sort_order_years?: number | null;
           species?: string | null;
           updated_at?: string | null;
           user_id: string;
@@ -306,6 +308,7 @@ export type Database = {
           search_vector?: unknown;
           significance?: string | null;
           slug?: string;
+          sort_order_years?: number | null;
           species?: string | null;
           updated_at?: string | null;
           user_id?: string;

--- a/supabase/migrations/00025_characters_sort_order_years.sql
+++ b/supabase/migrations/00025_characters_sort_order_years.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- 00025_characters_sort_order_years.sql
+--
+-- Adds a sort_order_years generated column to characters (issue #326).
+--
+-- The characters-list wireframe (docs/design/admin/02-wireframes/
+-- 03-characters-list.md, "Primary actions") requires sorting by birth date.
+-- Unlike timelines/periods/events, characters had no generated sort_order
+-- column to sort on safely across BCE/CE/KYA/MYA/BYA eras — ad hoc JSONB
+-- comparison doesn't work because the scaled era ranges overlap. This
+-- mirrors the era conversion formula documented in docs/system-design.md
+-- §4.4 and used by events.sort_order_years (00001_initial_schema.sql),
+-- applied here to characters.birth_temporal.
+--
+-- Tie-break: characters are keyed off birth_temporal first. If a character
+-- has no birth_temporal but does have death_temporal (e.g. a historical
+-- figure recorded only by date of death), that is used instead. If neither
+-- is present (mythological/divine characters, which the wireframe says
+-- should render "—"), sort_order_years is NULL. Unlike events.temporal_data
+-- (NOT NULL), characters.birth_temporal/death_temporal are both nullable, so
+-- NULL is an intentional, expected value here — callers must sort with
+-- NULLS LAST regardless of direction so undated characters sort to the end.
+--
+-- No GRANT changes needed: 00023_api_role_table_grants.sql grants
+-- ALL TABLES IN SCHEMA public, which already covers this column (GRANTs are
+-- table-level, not column-level).
+-- ============================================================================
+
+ALTER TABLE characters ADD COLUMN sort_order_years BIGINT GENERATED ALWAYS AS (
+  CASE
+    WHEN (birth_temporal->>'era') = 'CE'  THEN  (birth_temporal->>'year')::BIGINT
+    WHEN (birth_temporal->>'era') = 'BCE' THEN -(birth_temporal->>'year')::BIGINT
+    WHEN (birth_temporal->>'era') = 'KYA' THEN -(birth_temporal->>'year')::BIGINT * 1000
+    WHEN (birth_temporal->>'era') = 'MYA' THEN -(birth_temporal->>'year')::BIGINT * 1000000
+    WHEN (birth_temporal->>'era') = 'BYA' THEN -(birth_temporal->>'year')::BIGINT * 1000000000
+    WHEN (death_temporal->>'era') = 'CE'  THEN  (death_temporal->>'year')::BIGINT
+    WHEN (death_temporal->>'era') = 'BCE' THEN -(death_temporal->>'year')::BIGINT
+    WHEN (death_temporal->>'era') = 'KYA' THEN -(death_temporal->>'year')::BIGINT * 1000
+    WHEN (death_temporal->>'era') = 'MYA' THEN -(death_temporal->>'year')::BIGINT * 1000000
+    WHEN (death_temporal->>'era') = 'BYA' THEN -(death_temporal->>'year')::BIGINT * 1000000000
+    ELSE NULL
+  END
+) STORED;
+
+CREATE INDEX idx_characters_sort ON characters (sort_order_years);

--- a/supabase/tests/database/00025_characters_sort_order_years_test.sql
+++ b/supabase/tests/database/00025_characters_sort_order_years_test.sql
@@ -1,0 +1,89 @@
+-- pgTAP tests for 00025_characters_sort_order_years.sql (issue #326 —
+-- characters.sort_order_years generated column).
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(11);
+
+-- ============================================================================
+-- Column presence + type
+-- ============================================================================
+
+select has_column(
+  'public', 'characters', 'sort_order_years',
+  'characters.sort_order_years column exists'
+);
+
+select col_type_is(
+  'public', 'characters', 'sort_order_years', 'bigint',
+  'characters.sort_order_years is bigint'
+);
+
+select has_index(
+  'public', 'characters', 'idx_characters_sort',
+  'idx_characters_sort index exists'
+);
+
+-- ============================================================================
+-- Test fixtures
+-- ============================================================================
+
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values ('00000000-0000-0000-0000-000000000326'::uuid,
+          '00000000-0000-0000-0000-000000000000'::uuid,
+          'characters-sort-326@local', '', now(), now(), now(),
+          'authenticated', 'authenticated');
+
+insert into characters (user_id, slug, name, character_type, birth_temporal, death_temporal) values
+  ('00000000-0000-0000-0000-000000000326', 'sort-ce',      'CE Character',      'human',
+   '{"year":1969,"era":"CE","precision":"exact"}'::jsonb, null),
+  ('00000000-0000-0000-0000-000000000326', 'sort-bce',     'BCE Character',     'human',
+   '{"year":44,"era":"BCE","precision":"exact"}'::jsonb, null),
+  ('00000000-0000-0000-0000-000000000326', 'sort-kya',     'KYA Character',     'mythological',
+   '{"year":12,"era":"KYA","precision":"approximate"}'::jsonb, null),
+  ('00000000-0000-0000-0000-000000000326', 'sort-mya',     'MYA Character',     'mythological',
+   '{"year":66,"era":"MYA","precision":"approximate"}'::jsonb, null),
+  ('00000000-0000-0000-0000-000000000326', 'sort-bya',     'BYA Character',     'divine',
+   '{"year":14,"era":"BYA","precision":"geological"}'::jsonb, null),
+  ('00000000-0000-0000-0000-000000000326', 'sort-death',   'Death-only Character', 'human',
+   null, '{"year":1616,"era":"CE","precision":"exact"}'::jsonb),
+  ('00000000-0000-0000-0000-000000000326', 'sort-both',    'Both-dates Character', 'human',
+   '{"year":1564,"era":"CE","precision":"exact"}'::jsonb,
+   '{"year":1616,"era":"CE","precision":"exact"}'::jsonb),
+  ('00000000-0000-0000-0000-000000000326', 'sort-neither',  'Undated Character', 'divine',
+   null, null);
+
+-- ============================================================================
+-- Era conversion, keyed off birth_temporal
+-- ============================================================================
+
+select is((select sort_order_years from characters where slug = 'sort-ce'),
+          1969::bigint, 'CE 1969 → sort_order_years = 1969');
+select is((select sort_order_years from characters where slug = 'sort-bce'),
+          -44::bigint, 'BCE 44 → sort_order_years = -44');
+select is((select sort_order_years from characters where slug = 'sort-kya'),
+          -12000::bigint, 'KYA 12 → sort_order_years = -12,000');
+select is((select sort_order_years from characters where slug = 'sort-mya'),
+          -66000000::bigint, 'MYA 66 → sort_order_years = -66,000,000');
+select is((select sort_order_years from characters where slug = 'sort-bya'),
+          -14000000000::bigint, 'BYA 14 → sort_order_years = -14,000,000,000');
+
+-- ============================================================================
+-- Fallback + NULL behaviour
+-- ============================================================================
+
+select is((select sort_order_years from characters where slug = 'sort-death'),
+          1616::bigint,
+          'death_temporal is used when birth_temporal is absent');
+
+select is((select sort_order_years from characters where slug = 'sort-both'),
+          1564::bigint,
+          'birth_temporal wins when both birth_temporal and death_temporal are present');
+
+select is((select sort_order_years from characters where slug = 'sort-neither'),
+          null,
+          'sort_order_years is NULL when neither birth_temporal nor death_temporal is set');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Adds `characters.sort_order_years` GENERATED ALWAYS AS column to enable sorting by birth date across BCE/CE/KYA/MYA/BYA eras. The characters table previously had no sortable date column — ad hoc JSONB comparison fails because scaled era ranges overlap. This implements the pattern established by `events.sort_order_years` (migration 00001, docs/system-design.md §4.4).

## Changes

**Database (Migration 00025):**
- Add `characters.sort_order_years BIGINT GENERATED ALWAYS AS (...)` column
  - Keyed off `birth_temporal` first
  - Falls back to `death_temporal` if birth is absent (e.g. historical figures recorded only by death date)
  - `NULL` for undated characters (mythological/divine), which the wireframe renders as "—"
  - Mirrors the era-conversion CASE formula from `events.sort_order_years` verbatim
- Add `idx_characters_sort` B-tree index on the generated column for query performance
- No GRANT changes needed — `00023_api_role_table_grants.sql` already grants `ALL TABLES IN SCHEMA public`

**pgTAP Tests (00025_characters_sort_order_years_test.sql):**
- Column/index presence assertions
- All five eras (CE, BCE, KYA, MYA, BYA) with correct conversion formulas
- Birth-only, death-only, both (birth wins), neither (NULL) cases
- All 11 assertions passing

**Service Layer (`@repo/services`):**
- `CharacterFilters.sortBy`: extend from `"name" | "created_at" | "updated_at"` to also accept `"sort_order_years"`
- `getCharacters()`: add `nullsFirst: false` to `.order()` call so undated characters sort to the end regardless of direction (matches `EventFilters.sortBy` convention from `event-service.ts`)
- Updated JSDoc comments to reflect the new capability and NULL/fallback behavior

**Tests:**
- Updated two existing sort assertions to account for `nullsFirst: false` parameter
- Added test case for `sortBy: "sort_order_years"` with NULLS-LAST verification
- All 94 character-service tests pass; coverage remains above 80% threshold

**Documentation:**
- `docs/system-design.md`: added `sort_order_years` to the characters CREATE TABLE snapshot with inline migration comment and rationale
- Added `idx_characters_sort` to the index reference list

## Test Plan

- [x] `pnpm run db:reset && pnpm run db:test` — migration applies, all 25 pgTAP suites pass (including new 00025 with 11 assertions)
- [x] `pnpm run db:gen:types` — `sort_order_years` appears in generated `characters.Row/Insert/Update` types
- [x] `pnpm run check-types` — no type errors across monorepo
- [x] `pnpm run lint` — no lint violations
- [x] `pnpm run test:coverage` — 94 character-service tests pass; 831 total @repo/services tests pass; coverage ≥ 80%
- [x] `pnpm run format && pnpm run build` — code is formatted and builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)