### PR TITLE
Build Character list page with type filtering and search

### DIFF
--- a/apps/admin/app/(protected)/characters/_components/character-list-client.tsx
+++ b/apps/admin/app/(protected)/characters/_components/character-list-client.tsx
@@ -545,7 +545,13 @@ export function CharacterListClient() {
   // ---------------------------------------------------------------------------
 
   function updateParams(updates: Record<string, string | null>) {
-    const next = new URLSearchParams(searchParams.toString());
+    // Build from the live URL, not the closed-over `searchParams` snapshot:
+    // the search box's debounced update fires ~300ms after a keystroke, and
+    // if a filter/sort/page change lands in that window, building from the
+    // stale snapshot would drop it. updateParams only runs from event
+    // handlers / the debounce timeout (never during render), so reading
+    // window.location here is safe. See #329.
+    const next = new URLSearchParams(window.location.search);
     for (const [key, val] of Object.entries(updates)) {
       if (val === null || val === "") {
         next.delete(key);

--- a/apps/admin/app/(protected)/characters/_components/character-list-client.tsx
+++ b/apps/admin/app/(protected)/characters/_components/character-list-client.tsx
@@ -1,0 +1,883 @@
+"use client";
+
+import * as React from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@repo/ui/components/sonner";
+import { Plus } from "lucide-react";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import {
+  deleteCharacter,
+  publishCharacter,
+  unpublishCharacter,
+  type CharacterFilters,
+  type CharacterListRow,
+  type CharacterType,
+  type Significance,
+} from "@repo/services/character-service";
+import { BulkActionBar } from "@repo/ui/components/bulk-action-bar";
+import { Button } from "@repo/ui/components/button";
+import {
+  DataTable,
+  createSelectColumn,
+  type DataTableProps,
+  type RowSelectionState,
+} from "@repo/ui/components/data-table";
+import { FilterRail, type FilterGroup } from "@repo/ui/components/filter-rail";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { StatusBadge } from "@repo/ui/components/status-badge";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+import { cn } from "@repo/ui/lib/utils";
+import {
+  characterKeys,
+  useCharactersPage,
+  useCharacterFacetCounts,
+} from "@repo/ui/hooks/use-characters";
+import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import {
+  CharacterTypeBadge,
+  CHARACTER_TYPE_ICON,
+} from "./character-type-badge";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PAGE_SIZE = 20;
+
+// character_type values are the exact schema enum (see characterTypeEnum).
+const CHARACTER_TYPES: { value: CharacterType; label: string }[] = [
+  { value: "human", label: "Human" },
+  { value: "animal", label: "Animal" },
+  { value: "mythological", label: "Mythological" },
+  { value: "fictional", label: "Fictional" },
+  { value: "organization", label: "Organization" },
+  { value: "divine", label: "Divine" },
+  { value: "artifact", label: "Artifact" },
+];
+const VALID_TYPES = new Set<string>(CHARACTER_TYPES.map((t) => t.value));
+
+const SIGNIFICANCES: { value: Significance; label: string }[] = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "critical", label: "Critical" },
+];
+const VALID_SIGNIFICANCES = new Set<string>(SIGNIFICANCES.map((s) => s.value));
+
+// Published and has-media are each rendered as a 2-option checkbox group
+// (not the shared radio component) specifically so both options can carry a
+// count, matching the wireframe — the filter is applied only when exactly one
+// option is checked, same convention the events list uses for its own
+// Status group.
+const VALID_PUBLICATIONS = new Set<string>(["published", "draft"]);
+const VALID_MEDIA = new Set<string>(["yes", "no"]);
+
+const SORT_LABELS: Record<string, string> = {
+  name: "Name",
+  created_at: "Created",
+  updated_at: "Last updated",
+  sort_order_years: "Birth date",
+};
+const VALID_SORT = new Set(Object.keys(SORT_LABELS));
+
+const SIGNIFICANCE_STARS: Record<Significance, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+// Reuses the existing Batch F importance sequential ramp — significance and
+// importance are the same visual language (03-aesthetic-notes.md § Significance
+// scale, finalized). Literal class names (not interpolated) so Tailwind's
+// scanner picks them up.
+const SIGNIFICANCE_CLASS: Record<Significance, string> = {
+  low: "text-importance-low",
+  medium: "text-importance-medium",
+  high: "text-importance-high",
+  critical: "text-importance-critical",
+};
+
+// ---------------------------------------------------------------------------
+// URL state helpers
+// ---------------------------------------------------------------------------
+
+function csvToArray(value: string | null): string[] {
+  if (!value) return [];
+  return value.split(",").filter(Boolean);
+}
+
+function arrayToCsv(values: string[]): string {
+  return values.join(",");
+}
+
+/**
+ * Returns a windowed list of page numbers and "ellipsis" placeholders.
+ * Always shows first, last, current ±2, with "ellipsis" gaps between.
+ */
+function buildPageWindows(
+  current: number,
+  total: number,
+): Array<number | "ellipsis"> {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+  const pages = new Set<number>([1, total]);
+  for (let d = -2; d <= 2; d++) {
+    const p = current + d;
+    if (p >= 1 && p <= total) pages.add(p);
+  }
+  const sorted = [...pages].sort((a, b) => a - b);
+  const result: Array<number | "ellipsis"> = [];
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i]! - sorted[i - 1]! > 1) {
+      result.push("ellipsis");
+    }
+    result.push(sorted[i]!);
+  }
+  return result;
+}
+
+interface ParsedFilters {
+  types: string[];
+  significances: string[];
+  publications: string[];
+  media: string[];
+  search: string;
+  sortBy: string;
+  sortDir: "asc" | "desc";
+  page: number;
+}
+
+function readFiltersFromParams(params: URLSearchParams): ParsedFilters {
+  const rawSort = params.get("sort") ?? "name";
+  const sortBy = VALID_SORT.has(rawSort) ? rawSort : "name";
+
+  const rawPage = parseInt(params.get("page") ?? "1", 10);
+  const page = Number.isFinite(rawPage) ? Math.max(1, rawPage) : 1;
+
+  return {
+    types: csvToArray(params.get("type")).filter((t) => VALID_TYPES.has(t)),
+    significances: csvToArray(params.get("sig")).filter((s) =>
+      VALID_SIGNIFICANCES.has(s),
+    ),
+    publications: csvToArray(params.get("pub")).filter((p) =>
+      VALID_PUBLICATIONS.has(p),
+    ),
+    media: csvToArray(params.get("media")).filter((m) => VALID_MEDIA.has(m)),
+    search: params.get("q") ?? "",
+    sortBy,
+    sortDir: params.get("dir") === "desc" ? "desc" : "asc",
+    page,
+  };
+}
+
+function buildServiceFilters(parsed: ParsedFilters): CharacterFilters {
+  const filters: CharacterFilters = {
+    page: parsed.page,
+    pageSize: PAGE_SIZE,
+    sortBy: parsed.sortBy as CharacterFilters["sortBy"],
+    sortDirection: parsed.sortDir,
+  };
+
+  const safeTypes = parsed.types.filter((t) =>
+    VALID_TYPES.has(t),
+  ) as CharacterType[];
+  if (safeTypes.length > 0) {
+    filters.characterType = safeTypes;
+  }
+
+  const safeSignificances = parsed.significances.filter((s) =>
+    VALID_SIGNIFICANCES.has(s),
+  ) as Significance[];
+  if (safeSignificances.length > 0) {
+    filters.significance = safeSignificances;
+  }
+
+  // published/hasMedia: exactly one value selected → filter; otherwise omit
+  // (both, or neither, checked narrows nothing).
+  if (parsed.publications.length === 1) {
+    filters.published = parsed.publications[0] === "published";
+  }
+  if (parsed.media.length === 1) {
+    filters.hasMedia = parsed.media[0] === "yes";
+  }
+
+  if (parsed.search.length > 0) {
+    filters.search = parsed.search;
+  }
+
+  return filters;
+}
+
+// ---------------------------------------------------------------------------
+// Cells
+// ---------------------------------------------------------------------------
+
+function SignificanceCell({ value }: { value: Significance | null }) {
+  // significance is DEFAULT 'medium' but not NOT NULL (migration 00001), so a
+  // row written outside the app's own create/update path (direct SQL, import)
+  // can carry a null — render the same "—" placeholder as the Temporal cell
+  // rather than indexing the lookup maps with a value they don't cover.
+  if (value === null) {
+    return <span className="text-sm text-foreground-muted">—</span>;
+  }
+  const filled = SIGNIFICANCE_STARS[value];
+  return (
+    <span
+      className={cn("text-sm", SIGNIFICANCE_CLASS[value])}
+      title={`Significance: ${value}`}
+    >
+      <span aria-hidden>{"★".repeat(filled)}</span>
+      <span className="sr-only">{value}</span>
+    </span>
+  );
+}
+
+function NameCell({
+  row,
+  onRowClick,
+}: {
+  row: CharacterListRow;
+  onRowClick: (row: CharacterListRow) => void;
+}) {
+  const primaryMedia =
+    row.character_media.find((m) => m.is_primary === true)?.media ??
+    row.character_media[0]?.media ??
+    null;
+  const aliases = row.aliases ?? [];
+  const firstAlias = aliases[0];
+  const extraAliasCount = aliases.length > 1 ? aliases.length - 1 : 0;
+  const eventCount = row.event_characters[0]?.count ?? 0;
+  const line2 = [
+    firstAlias !== undefined
+      ? `${firstAlias}${extraAliasCount > 0 ? ` +${extraAliasCount}` : ""}`
+      : null,
+    eventCount > 0 ? `${eventCount} event${eventCount !== 1 ? "s" : ""}` : null,
+  ].filter(Boolean);
+  const PlaceholderIcon =
+    CHARACTER_TYPE_ICON[row.character_type as CharacterType];
+
+  return (
+    <div className="group relative">
+      <button
+        type="button"
+        className="flex w-full flex-col gap-0.5 text-left hover:opacity-80 transition-opacity"
+        onClick={(ev) => {
+          ev.stopPropagation();
+          onRowClick(row);
+        }}
+      >
+        <span
+          className="line-clamp-1 font-medium text-foreground leading-tight"
+          title={row.name}
+        >
+          {row.name}
+        </span>
+        {line2.length > 0 && (
+          <span className="text-xs text-foreground-muted">
+            {line2.join(" · ")}
+          </span>
+        )}
+      </button>
+      <div className="pointer-events-none absolute left-0 top-full z-10 mt-1 hidden rounded-md border border-border bg-popover p-1 shadow-md group-hover:block">
+        {primaryMedia ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={primaryMedia.url}
+            alt={primaryMedia.alt_text ?? ""}
+            className="h-24 w-24 rounded object-cover"
+          />
+        ) : (
+          <div className="flex h-24 w-24 items-center justify-center rounded bg-surface-2">
+            <PlaceholderIcon
+              className="h-8 w-8 text-foreground-muted"
+              aria-hidden
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Column definitions
+// ---------------------------------------------------------------------------
+
+function buildColumns(
+  onRowClick: (row: CharacterListRow) => void,
+): DataTableProps<CharacterListRow, unknown>["columns"] {
+  return [
+    createSelectColumn<CharacterListRow>(),
+    {
+      id: "name",
+      header: "Name",
+      enableSorting: false,
+      cell: ({ row }: { row: { original: CharacterListRow } }) => (
+        <NameCell row={row.original} onRowClick={onRowClick} />
+      ),
+    },
+    {
+      accessorKey: "character_type",
+      header: "Type",
+      enableSorting: false,
+      cell: ({ getValue }: { getValue: () => unknown }) => (
+        <CharacterTypeBadge type={getValue() as CharacterType} />
+      ),
+    },
+    {
+      id: "temporal",
+      header: "Temporal",
+      enableSorting: false,
+      cell: ({ row }: { row: { original: CharacterListRow } }) => {
+        const c = row.original;
+        const birth = c.birth_temporal as TemporalData | null;
+        if (!birth || Object.keys(birth).length === 0) {
+          return <span className="text-sm text-foreground-muted">—</span>;
+        }
+        return (
+          <span className="text-sm text-foreground-muted">
+            <TemporalDisplay
+              value={birth}
+              endValue={(c.death_temporal as TemporalData | null) ?? undefined}
+              format="compact"
+            />
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: "significance",
+      // Star glyph for sighted users; sr-only text so the column is announced.
+      header: () => (
+        <>
+          <span aria-hidden>★</span>
+          <span className="sr-only">Significance</span>
+        </>
+      ),
+      enableSorting: false,
+      cell: ({ getValue }: { getValue: () => unknown }) => (
+        <SignificanceCell value={getValue() as Significance | null} />
+      ),
+    },
+    {
+      accessorKey: "published",
+      header: "Published",
+      enableSorting: false,
+      cell: ({ getValue }: { getValue: () => unknown }) => {
+        const v = getValue() as boolean | null;
+        // DECISION NEEDED: wireframe 03 annotation #7 describes a 3rd "shared"
+        // status (reachable via a timeline_collaborators join two hops away).
+        // No query for that reachability exists yet and the events list (the
+        // reference template) doesn't implement it either — deferring to
+        // 2-state per the wireframe's own filter checkboxes and #55's AC.
+        return <StatusBadge status={v === true ? "published" : "draft"} />;
+      },
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton rows
+// ---------------------------------------------------------------------------
+
+function TableSkeleton() {
+  const skeletonRowIds = ["row-1", "row-2", "row-3", "row-4", "row-5", "row-6"];
+  return (
+    <div className="space-y-2">
+      {skeletonRowIds.map((rowId) => (
+        <Skeleton key={rowId} className="h-16 w-full rounded-md" />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function CharacterListClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const parsed = React.useMemo(
+    () => readFiltersFromParams(searchParams),
+    [searchParams],
+  );
+
+  const searchDebounceRef = React.useRef<number | null>(null);
+  const [searchInput, setSearchInput] = React.useState(parsed.search);
+  const [prevUrlSearch, setPrevUrlSearch] = React.useState(parsed.search);
+  if (parsed.search !== prevUrlSearch) {
+    setPrevUrlSearch(parsed.search);
+    setSearchInput(parsed.search);
+  }
+
+  React.useEffect(() => {
+    return () => {
+      if (searchDebounceRef.current !== null) {
+        clearTimeout(searchDebounceRef.current);
+      }
+    };
+  }, []);
+
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+
+  const filters = React.useMemo(() => buildServiceFilters(parsed), [parsed]);
+  // Facet counts key off the filters minus page/sort, so paging or changing
+  // sort doesn't refire all 15 count queries the rail depends on.
+  const facetFilters = React.useMemo<CharacterFilters>(() => {
+    const picked: CharacterFilters = {};
+    if (filters.characterType !== undefined) {
+      picked.characterType = filters.characterType;
+    }
+    if (filters.significance !== undefined) {
+      picked.significance = filters.significance;
+    }
+    if (filters.published !== undefined) {
+      picked.published = filters.published;
+    }
+    if (filters.hasMedia !== undefined) {
+      picked.hasMedia = filters.hasMedia;
+    }
+    if (filters.search !== undefined) {
+      picked.search = filters.search;
+    }
+    return picked;
+  }, [filters]);
+
+  const { data, isPending, isError, refetch } = useCharactersPage(
+    client,
+    filters,
+  );
+  const { data: facetCounts } = useCharacterFacetCounts(client, facetFilters);
+
+  // Current user — used to gate bulk publish/unpublish/delete to owner-owned
+  // rows (RLS re-checks server-side regardless).
+  const { data: userId = "" } = useQuery({
+    queryKey: ["auth", "user-id"],
+    queryFn: async () => {
+      const {
+        data: { user },
+      } = await client.auth.getUser();
+      return user?.id ?? "";
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  const queryClient = useQueryClient();
+
+  // Row selection for the bulk-action bar, keyed by character id (getRowId).
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+  const [bulkBusy, setBulkBusy] = React.useState(false);
+
+  const rows = React.useMemo(
+    () => (data?.rows ?? []) as CharacterListRow[],
+    [data],
+  );
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  // Selection lives on the current page only; reset it whenever the query
+  // (filters/sort/page) changes so stale ids never leak into a bulk action.
+  const filterKey = searchParams.toString();
+  const [prevFilterKey, setPrevFilterKey] = React.useState(filterKey);
+  if (filterKey !== prevFilterKey) {
+    setPrevFilterKey(filterKey);
+    setRowSelection({});
+  }
+
+  const selectedRows = React.useMemo(
+    () => rows.filter((r) => rowSelection[r.id]),
+    [rows, rowSelection],
+  );
+  // Publishing/deleting is owner-only — exclude shared/other-owned rows from
+  // the action and report them as skipped.
+  const ownedSelected = React.useMemo(
+    () => selectedRows.filter((r) => r.user_id === userId),
+    [selectedRows, userId],
+  );
+  const skippedCount = selectedRows.length - ownedSelected.length;
+
+  async function runBulk(action: "publish" | "unpublish" | "delete") {
+    const ids = ownedSelected.map((r) => r.id);
+    if (ids.length === 0) return;
+    setBulkBusy(true);
+    const fn =
+      action === "publish"
+        ? publishCharacter
+        : action === "unpublish"
+          ? unpublishCharacter
+          : deleteCharacter;
+    const results = await Promise.allSettled(ids.map((id) => fn(client, id)));
+    setBulkBusy(false);
+    await queryClient.invalidateQueries({ queryKey: characterKeys.all });
+    setRowSelection({});
+
+    const failed = results.filter((r) => r.status === "rejected").length;
+    const ok = ids.length - failed;
+    const verb =
+      action === "publish"
+        ? "Published"
+        : action === "unpublish"
+          ? "Unpublished"
+          : "Deleted";
+    const noun = (n: number) => `character${n !== 1 ? "s" : ""}`;
+    if (failed === 0) {
+      toast.success(`${verb} ${ok} ${noun(ok)}.`);
+    } else if (ok === 0) {
+      toast.error(`Couldn't ${action} ${failed} ${noun(failed)}. Try again.`);
+    } else {
+      toast.warning(`${verb} ${ok} ${noun(ok)}; ${failed} failed.`);
+    }
+  }
+
+  const hasFilters =
+    parsed.types.length > 0 ||
+    parsed.significances.length > 0 ||
+    parsed.publications.length === 1 ||
+    parsed.media.length === 1 ||
+    parsed.search.length > 0;
+
+  // ---------------------------------------------------------------------------
+  // URL update helpers
+  // ---------------------------------------------------------------------------
+
+  function updateParams(updates: Record<string, string | null>) {
+    const next = new URLSearchParams(searchParams.toString());
+    for (const [key, val] of Object.entries(updates)) {
+      if (val === null || val === "") {
+        next.delete(key);
+      } else {
+        next.set(key, val);
+      }
+    }
+    router.replace(`?${next.toString()}`, { scroll: false });
+  }
+
+  function handleTypeChange(values: string[]) {
+    updateParams({ type: arrayToCsv(values) || null, page: null });
+  }
+  function handleSignificanceChange(values: string[]) {
+    updateParams({ sig: arrayToCsv(values) || null, page: null });
+  }
+  function handlePublicationChange(values: string[]) {
+    updateParams({ pub: arrayToCsv(values) || null, page: null });
+  }
+  function handleMediaChange(values: string[]) {
+    updateParams({ media: arrayToCsv(values) || null, page: null });
+  }
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+    setSearchInput(value);
+    if (searchDebounceRef.current !== null) {
+      clearTimeout(searchDebounceRef.current);
+    }
+    searchDebounceRef.current = window.setTimeout(() => {
+      updateParams({ q: value || null, page: null });
+    }, 300);
+  }
+  function handleSortChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    updateParams({ sort: e.target.value, page: null });
+  }
+  function handleDirToggle() {
+    updateParams({
+      dir: parsed.sortDir === "desc" ? "asc" : "desc",
+      page: null,
+    });
+  }
+  function handlePageChange(newPage: number) {
+    updateParams({ page: newPage === 1 ? null : String(newPage) });
+  }
+  function handleClearAll() {
+    router.replace("?", { scroll: false });
+  }
+
+  function handleNewCharacter() {
+    router.push("/characters/new");
+  }
+
+  const handleRowClick = React.useCallback(
+    (row: CharacterListRow) => {
+      router.push(`/characters/${row.slug}`);
+    },
+    [router],
+  );
+
+  const pageWindowElements: React.ReactNode[] = [];
+  let ellipsisCount = 0;
+  for (const item of buildPageWindows(parsed.page, totalPages)) {
+    if (item === "ellipsis") {
+      ellipsisCount += 1;
+      pageWindowElements.push(
+        <span
+          key={`ellipsis-${ellipsisCount}`}
+          className="px-1 text-sm text-foreground-muted"
+          aria-hidden
+        >
+          …
+        </span>,
+      );
+      continue;
+    }
+    pageWindowElements.push(
+      <button
+        key={item}
+        type="button"
+        onClick={() => handlePageChange(item)}
+        aria-current={item === parsed.page ? "page" : undefined}
+        className={`rounded px-2 py-1 text-sm ${
+          item === parsed.page
+            ? "bg-primary text-primary-foreground"
+            : "text-foreground-muted hover:text-foreground"
+        }`}
+      >
+        {item}
+      </button>,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filter groups. Published and Has-media are checkbox groups (not the
+  // shared radio component) so both options can carry a count.
+  // ---------------------------------------------------------------------------
+
+  const filterGroups: FilterGroup[] = [
+    {
+      type: "checkbox",
+      id: "type",
+      label: "Type",
+      options: CHARACTER_TYPES.map((t) => ({
+        ...t,
+        count: facetCounts?.characterType[t.value],
+      })),
+      value: parsed.types,
+      onChange: handleTypeChange,
+    },
+    {
+      type: "checkbox",
+      id: "significance",
+      label: "Significance",
+      options: SIGNIFICANCES.map((s) => ({
+        ...s,
+        count: facetCounts?.significance[s.value],
+      })),
+      value: parsed.significances,
+      onChange: handleSignificanceChange,
+    },
+    {
+      type: "checkbox",
+      id: "publication",
+      label: "Published",
+      options: [
+        {
+          value: "published",
+          label: "Published",
+          count: facetCounts?.published.published,
+        },
+        { value: "draft", label: "Draft", count: facetCounts?.published.draft },
+      ],
+      value: parsed.publications,
+      onChange: handlePublicationChange,
+    },
+    {
+      type: "checkbox",
+      id: "media",
+      label: "Has media",
+      options: [
+        { value: "yes", label: "Yes", count: facetCounts?.hasMedia.yes },
+        { value: "no", label: "No", count: facetCounts?.hasMedia.no },
+      ],
+      value: parsed.media,
+      onChange: handleMediaChange,
+    },
+  ];
+
+  const columns = React.useMemo(
+    () => buildColumns(handleRowClick),
+    [handleRowClick],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="flex h-full">
+      <main className="flex flex-1 flex-col overflow-auto min-w-0">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-6 py-4 shrink-0">
+          <div>
+            <h1 className="font-display text-xl text-foreground">Characters</h1>
+            <p className="mt-0.5 text-xs text-foreground-muted">
+              {isPending
+                ? "Loading…"
+                : hasFilters
+                  ? `${total} result${total !== 1 ? "s" : ""} · filtered`
+                  : `${total} character${total !== 1 ? "s" : ""}`}
+            </p>
+          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            className="gap-1.5"
+            onClick={handleNewCharacter}
+          >
+            <Plus className="h-3.5 w-3.5" aria-hidden />
+            New character
+          </Button>
+        </div>
+
+        {/* Search */}
+        <div className="flex items-center gap-3 border-b border-border px-6 py-3 shrink-0">
+          <input
+            type="search"
+            placeholder="Search name, biography, aliases…"
+            value={searchInput}
+            onChange={handleSearchChange}
+            className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-foreground-muted focus:outline-none focus:ring-2 focus:ring-ring"
+            aria-label="Search characters"
+          />
+        </div>
+
+        {/* Table area */}
+        <div className="flex-1 overflow-auto p-6">
+          {isError && (
+            <div
+              role="alert"
+              className="flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-8 text-center"
+            >
+              <p className="text-sm text-destructive">
+                Failed to load characters.
+              </p>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => void refetch()}
+              >
+                Retry
+              </Button>
+            </div>
+          )}
+
+          {!isError && isPending && <TableSkeleton />}
+
+          {!isError && !isPending && total === 0 && !hasFilters && (
+            <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+              <p className="max-w-sm text-sm text-foreground-muted">
+                No characters yet. Characters are the people, beings, and
+                organizations that participate in your events.
+              </p>
+              <Button variant="primary" size="sm" onClick={handleNewCharacter}>
+                <Plus className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+                New character
+              </Button>
+            </div>
+          )}
+
+          {!isError && !isPending && total === 0 && hasFilters && (
+            <div className="flex flex-col items-center justify-center gap-2 py-20 text-center">
+              <p className="text-sm text-foreground-muted">
+                No characters match these filters.
+              </p>
+              <button
+                type="button"
+                onClick={handleClearAll}
+                className="text-xs text-primary underline underline-offset-2 hover:opacity-80"
+              >
+                Clear filters
+              </button>
+            </div>
+          )}
+
+          {!isError && !isPending && total > 0 && (
+            <div className="space-y-3">
+              <BulkActionBar
+                count={ownedSelected.length}
+                skippedCount={skippedCount}
+                entityLabel="character"
+                busy={bulkBusy}
+                onPublish={() => void runBulk("publish")}
+                onUnpublish={() => void runBulk("unpublish")}
+                onDelete={() => void runBulk("delete")}
+                onClear={() => setRowSelection({})}
+              />
+              <DataTable
+                columns={columns}
+                data={rows}
+                onRowClick={handleRowClick}
+                getRowId={(row) => row.id}
+                rowSelection={rowSelection}
+                onRowSelectionChange={setRowSelection}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Footer: pagination + sort */}
+        {!isError && !isPending && total > 0 && (
+          <div className="flex items-center justify-between border-t border-border px-6 py-3 shrink-0">
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => handlePageChange(parsed.page - 1)}
+                disabled={parsed.page <= 1}
+                aria-label="Previous page"
+                className="rounded px-2 py-1 text-sm text-foreground-muted hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                ‹
+              </button>
+              {pageWindowElements}
+              <button
+                type="button"
+                onClick={() => handlePageChange(parsed.page + 1)}
+                disabled={parsed.page >= totalPages}
+                aria-label="Next page"
+                className="rounded px-2 py-1 text-sm text-foreground-muted hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                ›
+              </button>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <label
+                htmlFor="character-sort-select"
+                className="text-xs text-foreground-muted"
+              >
+                Sort:
+              </label>
+              <select
+                id="character-sort-select"
+                value={parsed.sortBy}
+                onChange={handleSortChange}
+                className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="name">{SORT_LABELS["name"]}</option>
+                <option value="created_at">{SORT_LABELS["created_at"]}</option>
+                <option value="updated_at">{SORT_LABELS["updated_at"]}</option>
+                <option value="sort_order_years">
+                  {SORT_LABELS["sort_order_years"]}
+                </option>
+              </select>
+              <button
+                type="button"
+                onClick={handleDirToggle}
+                aria-label={
+                  parsed.sortDir === "desc"
+                    ? "Sort descending, click for ascending"
+                    : "Sort ascending, click for descending"
+                }
+                className="rounded border border-border px-2 py-1 text-xs text-foreground-muted hover:text-foreground"
+              >
+                {parsed.sortDir === "desc" ? "▾" : "▴"}
+              </button>
+            </div>
+          </div>
+        )}
+      </main>
+
+      <FilterRail groups={filterGroups} onClearAll={handleClearAll} />
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/characters/_components/character-type-badge.tsx
+++ b/apps/admin/app/(protected)/characters/_components/character-type-badge.tsx
@@ -1,0 +1,100 @@
+// TODO: replace with @repo/ui/components/character-type-badge once #284 ships.
+// Local scaffold per #55's fallback instructions — #284 ("Build
+// CharacterTypeBadge primitive") was still open when this list was built, so
+// the shared `--color-type-*` tokens (Batch J) don't exist yet; this uses
+// inline low-chroma Tailwind classes instead, matching the icon/color mapping
+// from docs/design/admin/03-aesthetic-notes.md § Character-type identity.
+// No `cva` here (unlike the eventual shared primitive) — `class-variance-
+// authority` is a @repo/ui dependency, not an apps/admin one, and pulling it
+// in for a component this scaffold will delete isn't worth the new edge.
+import * as React from "react";
+import {
+  User,
+  PawPrint,
+  Drama,
+  BookOpen,
+  Building2,
+  Sparkles,
+  Gem,
+} from "lucide-react";
+import { cn } from "@repo/ui/lib/utils";
+import { characterTypeEnum } from "@repo/services/schemas/character";
+
+export type CharacterType = (typeof characterTypeEnum.options)[number];
+
+/** Exported for reuse as the type-icon placeholder in the list's name-cell
+ * hover thumbnail (no media → show the type icon instead). */
+export const CHARACTER_TYPE_ICON: Record<
+  CharacterType,
+  React.ComponentType<{ className?: string }>
+> = {
+  human: User,
+  animal: PawPrint,
+  mythological: Drama,
+  fictional: BookOpen,
+  organization: Building2,
+  divine: Sparkles,
+  artifact: Gem,
+};
+
+const TYPE_LABEL: Record<CharacterType, string> = {
+  human: "Human",
+  animal: "Animal",
+  mythological: "Mythological",
+  fictional: "Fictional",
+  organization: "Organization",
+  divine: "Divine",
+  artifact: "Artifact",
+};
+
+const TYPE_CLASS: Record<CharacterType, string> = {
+  human: "bg-slate-500/10 text-slate-400 ring-1 ring-inset ring-slate-500/20",
+  animal:
+    "bg-emerald-500/10 text-emerald-400 ring-1 ring-inset ring-emerald-500/20",
+  mythological:
+    "bg-orange-500/10 text-orange-400 ring-1 ring-inset ring-orange-500/20",
+  fictional:
+    "bg-violet-500/10 text-violet-400 ring-1 ring-inset ring-violet-500/20",
+  organization: "bg-sky-500/10 text-sky-400 ring-1 ring-inset ring-sky-500/20",
+  divine: "bg-amber-500/10 text-amber-400 ring-1 ring-inset ring-amber-500/20",
+  artifact:
+    "bg-yellow-700/10 text-yellow-600 ring-1 ring-inset ring-yellow-700/20",
+};
+
+export interface CharacterTypeBadgeProps extends Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  "children"
+> {
+  /** The character_type value this badge represents (required). */
+  type: CharacterType;
+  /** Optional label override; defaults to the canonical name for the type. */
+  label?: string;
+}
+
+/**
+ * Icon + low-chroma tint + always-visible label for the 7 `character_type`
+ * values. The label always carries the accessible name — the icon is
+ * `aria-hidden` and never stands alone (03-aesthetic-notes.md § Character-type
+ * identity, finalized).
+ */
+export const CharacterTypeBadge = React.forwardRef<
+  HTMLSpanElement,
+  CharacterTypeBadgeProps
+>(({ className, type, label, ...props }, ref) => {
+  const Icon = CHARACTER_TYPE_ICON[type];
+  return (
+    <span
+      ref={ref}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+        TYPE_CLASS[type],
+        className,
+      )}
+      {...props}
+    >
+      <Icon className="h-3 w-3" aria-hidden />
+      {label ?? TYPE_LABEL[type]}
+    </span>
+  );
+});
+CharacterTypeBadge.displayName = "CharacterTypeBadge";

--- a/apps/admin/app/(protected)/characters/page.tsx
+++ b/apps/admin/app/(protected)/characters/page.tsx
@@ -1,11 +1,28 @@
-import { PlaceholderPage } from "../../../components/placeholder-page";
+import { Suspense } from "react";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { CharacterListClient } from "./_components/character-list-client";
+
+export const metadata = {
+  title: "Characters",
+};
+
+const loadingRowIds = ["row-1", "row-2", "row-3", "row-4", "row-5", "row-6"];
 
 export default function CharactersPage() {
   return (
-    <PlaceholderPage
-      title="Characters"
-      description="Human, Animal, Mythological, Fictional, Organization, Divine, Artifact."
-      trackedIn="Batch F (list primitives)"
-    />
+    // Suspense is required because CharacterListClient calls
+    // useSearchParams(), which opts the subtree into client rendering during
+    // the initial render.
+    <Suspense
+      fallback={
+        <div className="p-6 space-y-2">
+          {loadingRowIds.map((rowId) => (
+            <Skeleton key={rowId} className="h-16 w-full rounded-md" />
+          ))}
+        </div>
+      }
+    >
+      <CharacterListClient />
+    </Suspense>
   );
 }

--- a/packages/services/src/modules/character-service.test.ts
+++ b/packages/services/src/modules/character-service.test.ts
@@ -3,14 +3,18 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "../supabase/types";
 import {
   getCharacters,
+  getCharactersPage,
   getCharacterById,
   getCharacterBySlug,
   createCharacter,
   updateCharacter,
   deleteCharacter,
+  publishCharacter,
+  unpublishCharacter,
   getCharacterTimeline,
   getCharacterNetwork,
   getCharacterEvents,
+  getCharacterFacetCounts,
   addMediaToCharacter,
   removeMediaFromCharacter,
   setPrimaryCharacterMedia,
@@ -20,7 +24,11 @@ import {
 // Mock builder helpers (mirrors event-service.test.ts pattern)
 // ---------------------------------------------------------------------------
 
-function makeBuilder(result: { data: unknown; error: unknown }) {
+function makeBuilder(result: {
+  data: unknown;
+  error: unknown;
+  count?: unknown;
+}) {
   const terminal = vi.fn().mockResolvedValue(result);
   const builder = {
     select: vi.fn().mockReturnThis(),
@@ -31,6 +39,7 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
     eq: vi.fn().mockReturnThis(),
     in: vi.fn().mockReturnThis(),
     is: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
     textSearch: vi.fn().mockReturnThis(),
     range: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
@@ -43,7 +52,7 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
 }
 
 function makeClient(overrides: {
-  fromResult?: { data: unknown; error: unknown };
+  fromResult?: { data: unknown; error: unknown; count?: unknown };
   rpcResult?: { data: unknown; error: unknown };
   authUser?: { data: { user: unknown }; error: unknown };
 }) {
@@ -347,6 +356,197 @@ describe("getCharacters", () => {
     });
     await expect(getCharacters(client)).rejects.toThrow(
       "CharacterService.getCharacters: query failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCharactersPage
+// ---------------------------------------------------------------------------
+
+describe("getCharactersPage", () => {
+  function pageClient(count: number, rows: unknown[] = []) {
+    return makeClient({ fromResult: { data: rows, count, error: null } });
+  }
+  function firstBuilder(client: SupabaseClient<Database>) {
+    return (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+  }
+
+  it("returns rows and the total filtered count", async () => {
+    const row = {
+      ...sampleCharacter,
+      character_media: [
+        { is_primary: true, media: { url: "https://x/y.jpg", alt_text: null } },
+      ],
+      event_characters: [{ count: 3 }],
+    };
+    const client = pageClient(42, [row]);
+    const result = await getCharactersPage(client);
+    expect(result.rows).toEqual([row]);
+    expect(result.total).toBe(42);
+  });
+
+  it("returns empty rows and zero total when data is null", async () => {
+    const client = makeClient({
+      fromResult: { data: null, count: null, error: null },
+    });
+    const result = await getCharactersPage(client);
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("requests an exact count", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client);
+    expect(firstBuilder(client).select).toHaveBeenCalledWith(
+      expect.stringContaining("event_characters(count)"),
+      { count: "exact" },
+    );
+  });
+
+  it("filters a single character type with eq", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { characterType: "human" });
+    expect(firstBuilder(client).eq).toHaveBeenCalledWith(
+      "character_type",
+      "human",
+    );
+  });
+
+  it("filters multiple character types with in", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { characterType: ["human", "animal"] });
+    expect(firstBuilder(client).in).toHaveBeenCalledWith("character_type", [
+      "human",
+      "animal",
+    ]);
+  });
+
+  it("filters a single-element character type array as eq", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { characterType: ["human"] });
+    expect(firstBuilder(client).eq).toHaveBeenCalledWith(
+      "character_type",
+      "human",
+    );
+  });
+
+  it("filters significance", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { significance: "critical" });
+    expect(firstBuilder(client).eq).toHaveBeenCalledWith(
+      "significance",
+      "critical",
+    );
+  });
+
+  it("filters a single-element significance array as eq", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { significance: ["critical"] });
+    expect(firstBuilder(client).eq).toHaveBeenCalledWith(
+      "significance",
+      "critical",
+    );
+  });
+
+  it("filters multiple significance values with in", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { significance: ["high", "critical"] });
+    expect(firstBuilder(client).in).toHaveBeenCalledWith("significance", [
+      "high",
+      "critical",
+    ]);
+  });
+
+  it("filters by owner", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { userId: "user-abc" });
+    expect(firstBuilder(client).eq).toHaveBeenCalledWith("user_id", "user-abc");
+  });
+
+  it("filters by published state", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { published: true });
+    expect(firstBuilder(client).eq).toHaveBeenCalledWith("published", true);
+  });
+
+  it("keeps characters with media via an !inner embed carrying the primary media", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { hasMedia: true });
+    expect(firstBuilder(client).select).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "character_media!inner(is_primary, media(url, alt_text))",
+      ),
+      { count: "exact" },
+    );
+  });
+
+  it("keeps characters with no media via a plain embed + is.null", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { hasMedia: false });
+    const builder = firstBuilder(client);
+    expect(builder.is).toHaveBeenCalledWith("character_media", null);
+    expect(builder.select).toHaveBeenCalledWith(
+      expect.stringContaining("character_media(character_id)"),
+      { count: "exact" },
+    );
+  });
+
+  it("embeds the primary media without !inner when hasMedia is omitted", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client);
+    expect(firstBuilder(client).select).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "character_media(is_primary, media(url, alt_text))",
+      ),
+      { count: "exact" },
+    );
+  });
+
+  it("applies search filter via full-text search", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { search: "detective" });
+    expect(firstBuilder(client).textSearch).toHaveBeenCalledWith(
+      "search_vector",
+      "detective",
+      { type: "websearch" },
+    );
+  });
+
+  it("defaults to name ascending", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client);
+    expect(firstBuilder(client).order).toHaveBeenCalledWith("name", {
+      ascending: true,
+      nullsFirst: false,
+    });
+  });
+
+  it("honours an explicit sort column and direction", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, {
+      sortBy: "sort_order_years",
+      sortDirection: "desc",
+    });
+    expect(firstBuilder(client).order).toHaveBeenCalledWith(
+      "sort_order_years",
+      { ascending: false, nullsFirst: false },
+    );
+  });
+
+  it("clamps pageSize>100 to 100", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { page: 1, pageSize: 999 });
+    expect(firstBuilder(client).range).toHaveBeenCalledWith(0, 99);
+  });
+
+  it("throws on Supabase error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, count: null, error: { message: "DB error" } },
+    });
+    await expect(getCharactersPage(client)).rejects.toThrow(
+      "CharacterService.getCharactersPage: DB error",
     );
   });
 });
@@ -1084,6 +1284,80 @@ describe("deleteCharacter", () => {
 });
 
 // ---------------------------------------------------------------------------
+// publishCharacter / unpublishCharacter
+// ---------------------------------------------------------------------------
+
+describe("publishCharacter", () => {
+  it("sets published=true and published_at timestamp", async () => {
+    const publishedRow = {
+      ...sampleCharacter,
+      published: true,
+      published_at: "2026-01-02T12:34:56Z",
+    };
+    const client = makeClient({
+      fromResult: { data: publishedRow, error: null },
+    });
+
+    const result = await publishCharacter(client, "char-1");
+
+    expect(result).toEqual(publishedRow);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        published: true,
+        published_at: expect.any(String),
+      }),
+    );
+    expect(builder.eq).toHaveBeenCalledWith("id", "char-1");
+  });
+
+  it("throws on publish error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "publish failed" } },
+    });
+
+    await expect(publishCharacter(client, "char-1")).rejects.toThrow(
+      "CharacterService.publishCharacter: publish failed",
+    );
+  });
+});
+
+describe("unpublishCharacter", () => {
+  it("sets published=false and clears published_at", async () => {
+    const unpublishedRow = {
+      ...sampleCharacter,
+      published: false,
+      published_at: null,
+    };
+    const client = makeClient({
+      fromResult: { data: unpublishedRow, error: null },
+    });
+
+    const result = await unpublishCharacter(client, "char-1");
+
+    expect(result).toEqual(unpublishedRow);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.update).toHaveBeenCalledWith({
+      published: false,
+      published_at: null,
+    });
+    expect(builder.eq).toHaveBeenCalledWith("id", "char-1");
+  });
+
+  it("throws on unpublish error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "unpublish failed" } },
+    });
+
+    await expect(unpublishCharacter(client, "char-1")).rejects.toThrow(
+      "CharacterService.unpublishCharacter: unpublish failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // getCharacterTimeline
 // ---------------------------------------------------------------------------
 
@@ -1395,6 +1669,267 @@ describe("setPrimaryCharacterMedia", () => {
       setPrimaryCharacterMedia(client, "char-1", "media-1"),
     ).rejects.toThrow(
       "CharacterService.setPrimaryCharacterMedia: clear failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCharacterFacetCounts
+// ---------------------------------------------------------------------------
+
+interface RecordedCalls {
+  select: unknown[][];
+  eq: unknown[][];
+  in: unknown[][];
+  is: unknown[][];
+  not: unknown[][];
+  textSearch: unknown[][];
+}
+
+interface RecordingBuilder {
+  calls: RecordedCalls;
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  is: ReturnType<typeof vi.fn>;
+  not: ReturnType<typeof vi.fn>;
+  textSearch: ReturnType<typeof vi.fn>;
+  then: (resolve: (v: unknown) => unknown) => Promise<unknown>;
+}
+
+/** A chainable PostgREST builder mock that records every filter call so tests
+ * can assert the exact query construction, and resolves to a fixed result
+ * (mirrors MediaService.test.ts's makeRecordingBuilder). */
+function makeRecordingBuilder(result: {
+  data?: unknown;
+  count?: number | null;
+  error?: unknown;
+}): RecordingBuilder {
+  const calls: RecordedCalls = {
+    select: [],
+    eq: [],
+    in: [],
+    is: [],
+    not: [],
+    textSearch: [],
+  };
+  const resolved = {
+    data: result.data ?? null,
+    count: result.count ?? null,
+    error: result.error ?? null,
+  };
+  const builder: RecordingBuilder = {
+    calls,
+    select: vi.fn((...a: unknown[]) => {
+      calls.select.push(a);
+      return builder;
+    }),
+    eq: vi.fn((...a: unknown[]) => {
+      calls.eq.push(a);
+      return builder;
+    }),
+    in: vi.fn((...a: unknown[]) => {
+      calls.in.push(a);
+      return builder;
+    }),
+    is: vi.fn((...a: unknown[]) => {
+      calls.is.push(a);
+      return builder;
+    }),
+    not: vi.fn((...a: unknown[]) => {
+      calls.not.push(a);
+      return builder;
+    }),
+    textSearch: vi.fn((...a: unknown[]) => {
+      calls.textSearch.push(a);
+      return builder;
+    }),
+    then: (resolve: (v: unknown) => unknown) =>
+      Promise.resolve(resolved).then(resolve),
+  };
+  return builder;
+}
+
+/** Client whose `from()` returns the next queued result, in call order —
+ * needed because getCharacterFacetCounts fires 15 sequential head-count
+ * queries and each assertion needs to target a specific one by index. */
+function makeQueueClient(
+  queue: { data?: unknown; count?: number | null; error?: unknown }[],
+) {
+  const builders: RecordingBuilder[] = [];
+  const from = vi.fn(() => {
+    const result = queue.shift() ?? { data: [], count: 0, error: null };
+    const b = makeRecordingBuilder(result);
+    builders.push(b);
+    return b;
+  });
+  const client = { from } as unknown as SupabaseClient<Database>;
+  return { client, builders };
+}
+
+describe("getCharacterFacetCounts", () => {
+  // 15 head-count round-trips, in construction order: 7 character_type
+  // (human, animal, mythological, fictional, organization, divine, artifact),
+  // 4 significance (low, medium, high, critical), published, draft,
+  // hasMedia yes, hasMedia no.
+  const fifteenCounts = (counts: number[]) =>
+    counts.map((count) => ({ count }));
+
+  it("maps per-option counts into the facet structure", async () => {
+    const { client } = makeQueueClient(
+      fifteenCounts([10, 4, 7, 3, 5, 2, 3, 1, 2, 3, 4, 20, 4, 31, 16]),
+    );
+    const result = await getCharacterFacetCounts(client, {});
+    expect(result.characterType).toEqual({
+      human: 10,
+      animal: 4,
+      mythological: 7,
+      fictional: 3,
+      organization: 5,
+      divine: 2,
+      artifact: 3,
+    });
+    expect(result.significance).toEqual({
+      low: 1,
+      medium: 2,
+      high: 3,
+      critical: 4,
+    });
+    expect(result.published).toEqual({ published: 20, draft: 4 });
+    expect(result.hasMedia).toEqual({ yes: 31, no: 16 });
+  });
+
+  it("excludes a group's own selection from its own counts but keeps it for others", async () => {
+    const { client, builders } = makeQueueClient(
+      fifteenCounts(new Array(15).fill(1)),
+    );
+    await getCharacterFacetCounts(client, { characterType: "human" });
+    // The "human" type-count builder's own per-option predicate happens to
+    // match the current selection value — skipCharacterType must prevent
+    // applyCharacterListFilters from applying it a second time on top.
+    const humanBuilder = builders[0]!; // characterTypeEnum.options[0] === "human"
+    const matchingCalls = humanBuilder.calls.eq.filter(
+      (call) => call[0] === "character_type" && call[1] === "human",
+    );
+    expect(matchingCalls).toHaveLength(1);
+    // the significance-count builders (indexes 7-10) DO inherit the type filter
+    expect(builders[7]!.calls.eq).toContainEqual(["character_type", "human"]);
+  });
+
+  it("counts hasMedia yes/no via not/is on the character_media embed", async () => {
+    const { client, builders } = makeQueueClient(
+      fifteenCounts(new Array(15).fill(1)),
+    );
+    await getCharacterFacetCounts(client, {});
+    const yesBuilder = builders[13]!;
+    const noBuilder = builders[14]!;
+    expect(yesBuilder.calls.not).toContainEqual([
+      "character_media",
+      "is",
+      null,
+    ]);
+    expect(noBuilder.calls.is).toContainEqual(["character_media", null]);
+  });
+
+  it("applies userId, published, hasMedia, and search to a non-owning group's counts", async () => {
+    const { client, builders } = makeQueueClient(
+      fifteenCounts(new Array(15).fill(1)),
+    );
+    await getCharacterFacetCounts(client, {
+      userId: "user-9",
+      published: true,
+      hasMedia: true,
+      search: "curie",
+    });
+    // The type-count builders own neither published nor hasMedia, so both
+    // apply on top of userId + search.
+    const typeBuilder = builders[0]!;
+    expect(typeBuilder.calls.eq).toContainEqual(["user_id", "user-9"]);
+    expect(typeBuilder.calls.eq).toContainEqual(["published", true]);
+    expect(typeBuilder.calls.not).toContainEqual([
+      "character_media",
+      "is",
+      null,
+    ]);
+    expect(typeBuilder.calls.textSearch).toContainEqual([
+      "search_vector",
+      "curie",
+      { type: "websearch" },
+    ]);
+  });
+
+  it("excludes published from its own two counts but keeps hasMedia", async () => {
+    const { client, builders } = makeQueueClient(
+      fifteenCounts(new Array(15).fill(1)),
+    );
+    await getCharacterFacetCounts(client, { published: true, hasMedia: true });
+    const publishedBuilder = builders[11]!;
+    const draftBuilder = builders[12]!;
+    // Neither published-count builder should double-apply the current
+    // published selection — only its own per-option eq("published", …) call.
+    expect(
+      publishedBuilder.calls.eq.filter((c) => c[0] === "published"),
+    ).toEqual([["published", true]]);
+    expect(draftBuilder.calls.eq.filter((c) => c[0] === "published")).toEqual([
+      ["published", false],
+    ]);
+    // Both still inherit the unrelated hasMedia selection.
+    expect(publishedBuilder.calls.not).toContainEqual([
+      "character_media",
+      "is",
+      null,
+    ]);
+    expect(draftBuilder.calls.not).toContainEqual([
+      "character_media",
+      "is",
+      null,
+    ]);
+  });
+
+  it("applies characterType/significance filters as eq for single-element arrays", async () => {
+    const { client, builders } = makeQueueClient(
+      fifteenCounts(new Array(15).fill(1)),
+    );
+    await getCharacterFacetCounts(client, {
+      characterType: ["animal"],
+      significance: ["high"],
+    });
+    // significance-count builders (7-10) inherit the characterType selection.
+    expect(builders[7]!.calls.eq).toContainEqual(["character_type", "animal"]);
+    // type-count builders (0-6) inherit the significance selection.
+    expect(builders[0]!.calls.eq).toContainEqual(["significance", "high"]);
+  });
+
+  it("applies significance filter as eq for a scalar value", async () => {
+    const { client, builders } = makeQueueClient(
+      fifteenCounts(new Array(15).fill(1)),
+    );
+    await getCharacterFacetCounts(client, { significance: "high" });
+    expect(builders[0]!.calls.eq).toContainEqual(["significance", "high"]);
+  });
+
+  it("applies characterType/significance filters as in for multi-element arrays", async () => {
+    const { client, builders } = makeQueueClient(
+      fifteenCounts(new Array(15).fill(1)),
+    );
+    await getCharacterFacetCounts(client, {
+      characterType: ["animal", "human"],
+      significance: ["high", "critical"],
+    });
+    expect(builders[7]!.calls.in).toContainEqual([
+      "character_type",
+      ["animal", "human"],
+    ]);
+    expect(builders[0]!.calls.in).toContainEqual([
+      "significance",
+      ["high", "critical"],
+    ]);
+  });
+
+  it("throws a contextual error on failure", async () => {
+    const { client } = makeQueueClient([{ error: { message: "nope" } }]);
+    await expect(getCharacterFacetCounts(client, {})).rejects.toThrow(
+      /CharacterService\.getCharacterFacetCounts/,
     );
   });
 });

--- a/packages/services/src/modules/character-service.test.ts
+++ b/packages/services/src/modules/character-service.test.ts
@@ -471,6 +471,15 @@ describe("getCharactersPage", () => {
     expect(firstBuilder(client).eq).toHaveBeenCalledWith("published", true);
   });
 
+  it("filters drafts as published IS NOT TRUE so NULL rows are included (#331)", async () => {
+    const client = pageClient(0);
+    await getCharactersPage(client, { published: false });
+    const builder = firstBuilder(client);
+    expect(builder.not).toHaveBeenCalledWith("published", "is", true);
+    // Must NOT use eq(published,false), which would exclude NULL rows.
+    expect(builder.eq).not.toHaveBeenCalledWith("published", false);
+  });
+
   it("keeps characters with media via an !inner embed carrying the primary media", async () => {
     const client = pageClient(0);
     await getCharactersPage(client, { hasMedia: true });
@@ -1858,6 +1867,18 @@ describe("getCharacterFacetCounts", () => {
     ]);
   });
 
+  it("inherits a published=false selection as published IS NOT TRUE on non-owning groups (#331)", async () => {
+    const { client, builders } = makeQueueClient(
+      fifteenCounts(new Array(15).fill(1)),
+    );
+    await getCharacterFacetCounts(client, { published: false });
+    // A type-count builder (doesn't own the published group) inherits the
+    // draft selection via the not-is-true predicate, not eq(published,false).
+    const typeBuilder = builders[0]!;
+    expect(typeBuilder.calls.not).toContainEqual(["published", "is", true]);
+    expect(typeBuilder.calls.eq).not.toContainEqual(["published", false]);
+  });
+
   it("excludes published from its own two counts but keeps hasMedia", async () => {
     const { client, builders } = makeQueueClient(
       fifteenCounts(new Array(15).fill(1)),
@@ -1866,13 +1887,16 @@ describe("getCharacterFacetCounts", () => {
     const publishedBuilder = builders[11]!;
     const draftBuilder = builders[12]!;
     // Neither published-count builder should double-apply the current
-    // published selection — only its own per-option eq("published", …) call.
+    // published selection — only its own per-option predicate.
     expect(
       publishedBuilder.calls.eq.filter((c) => c[0] === "published"),
     ).toEqual([["published", true]]);
-    expect(draftBuilder.calls.eq.filter((c) => c[0] === "published")).toEqual([
-      ["published", false],
-    ]);
+    // Draft counts NULL rows too: its predicate is `published IS NOT TRUE`
+    // (not `eq(published, false)`, which would exclude NULL). See #331.
+    expect(draftBuilder.calls.eq.filter((c) => c[0] === "published")).toEqual(
+      [],
+    );
+    expect(draftBuilder.calls.not).toContainEqual(["published", "is", true]);
     // Both still inherit the unrelated hasMedia selection.
     expect(publishedBuilder.calls.not).toContainEqual([
       "character_media",

--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -326,8 +326,14 @@ export async function getCharactersPage(
   if (userId !== undefined) {
     query = query.eq("user_id", userId);
   }
-  if (published !== undefined) {
-    query = query.eq("published", published);
+  if (published === true) {
+    query = query.eq("published", true);
+  } else if (published === false) {
+    // "draft" must also match NULL rows: `published` is nullable (no NOT NULL
+    // on the column), and the list badge renders NULL as "Draft", so the
+    // filter has to too — otherwise a NULL row shows "Draft" yet vanishes
+    // under the Draft filter. `not.is.true` = published IS NOT TRUE. See #331.
+    query = query.not("published", "is", true);
   }
   if (hasMedia === false) {
     query = query.is("character_media", null);
@@ -698,7 +704,7 @@ interface CharacterFilterBuilder<T> {
   eq(column: string, value: string | boolean): T;
   in(column: string, values: readonly string[]): T;
   is(column: string, value: null): T;
-  not(column: string, op: string, value: null): T;
+  not(column: string, op: string, value: boolean | null): T;
   textSearch(column: string, query: string, opts: { type: "websearch" }): T;
 }
 
@@ -755,7 +761,9 @@ function applyCharacterListFilters<T extends CharacterFilterBuilder<T>>(
     q = q.eq("user_id", userId);
   }
   if (!opts.skipPublished && published !== undefined) {
-    q = q.eq("published", published);
+    // "draft" (published === false) must also match NULL rows — see the
+    // matching comment in getCharactersPage and #331.
+    q = published ? q.eq("published", true) : q.not("published", "is", true);
   }
   if (!opts.skipHasMedia && hasMedia !== undefined) {
     q = hasMedia
@@ -772,7 +780,11 @@ function applyCharacterListFilters<T extends CharacterFilterBuilder<T>>(
 interface CharacterCountPredicateBuilder {
   eq(column: string, value: string | boolean): CharacterCountPredicateBuilder;
   is(column: string, value: null): CharacterCountPredicateBuilder;
-  not(column: string, op: string, value: null): CharacterCountPredicateBuilder;
+  not(
+    column: string,
+    op: string,
+    value: boolean | null,
+  ): CharacterCountPredicateBuilder;
 }
 
 /** One head-count round-trip: count characters matching the base filters plus `apply`. */
@@ -861,7 +873,9 @@ export async function getCharacterFacetCounts(
       client,
       filters,
       { skipPublished: true },
-      (q) => q.eq("published", false),
+      // Draft = published IS NOT TRUE (false OR null), matching the list badge
+      // and the getCharactersPage draft filter. See #331.
+      (q) => q.not("published", "is", true),
       "getCharacterFacetCounts.published.draft",
     ),
     countCharactersWith(

--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -31,6 +31,9 @@ type CharacterTimelineViewRow =
 type CharacterNetworkRow =
   Database["public"]["Functions"]["character_network"]["Returns"][number];
 
+export type CharacterType = z.infer<typeof characterTypeEnum>;
+export type Significance = z.infer<typeof significanceEnum>;
+
 // ---------------------------------------------------------------------------
 // Exported interfaces
 // ---------------------------------------------------------------------------
@@ -67,6 +70,33 @@ export interface CharacterFilters {
 export interface CharacterWithRelations extends CharacterRow {
   character_media: CharacterMediaRow[];
   character_relationships: CharacterRelationshipRow[];
+}
+
+/**
+ * A character row as returned by getCharactersPage — carries the primary
+ * media (for the list's name-cell hover thumbnail) and the count of events
+ * the character participated in (for the list's two-line row).
+ */
+export interface CharacterListRow extends CharacterRow {
+  character_media: {
+    is_primary: boolean | null;
+    media: { url: string; alt_text: string | null } | null;
+  }[];
+  event_characters: { count: number }[];
+}
+
+/** Paginated result from getCharactersPage — includes the total filtered count. */
+export interface CharactersPage {
+  rows: CharacterListRow[];
+  total: number;
+}
+
+/** Per-option counts for the characters list filter rail (see getCharacterFacetCounts). */
+export interface CharacterFacetCounts {
+  characterType: Record<CharacterType, number>;
+  significance: Record<Significance, number>;
+  published: { published: number; draft: number };
+  hasMedia: { yes: number; no: number };
 }
 
 export type { CreateCharacterInput };
@@ -219,6 +249,106 @@ export async function getCharacters(
     delete rest.character_media;
     return rest;
   });
+}
+
+/**
+ * Returns a page of characters together with the total filtered count, the
+ * primary media (for the name-cell hover thumbnail), and the event-
+ * participation count the characters list renders on each row.
+ *
+ * Supports the same filter set as getCharacters (type, significance, owner,
+ * published, has-media, search) plus sorting by
+ * name/created_at/updated_at/sort_order_years.
+ *
+ * `page` is clamped to ≥ 1; `pageSize` is clamped to [1, 100].
+ */
+export async function getCharactersPage(
+  client: SupabaseClient<Database>,
+  filters: CharacterFilters = {},
+): Promise<CharactersPage> {
+  const {
+    characterType,
+    significance,
+    userId,
+    search,
+    published,
+    hasMedia,
+    sortBy = "name",
+    sortDirection = "asc",
+  } = filters;
+  const safePage = Math.max(1, Math.floor(filters.page ?? 1));
+  const safePageSize = Math.min(
+    100,
+    Math.max(1, Math.floor(filters.pageSize ?? 20)),
+  );
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+
+  // Same three-way embed trick as getCharacters (see its comment for why
+  // "has none" needs a plain-column embed rather than an aggregate one), but
+  // carrying the primary media's URL instead of just a count — a thumbnail is
+  // only ever relevant on rows that already have media, so this single embed
+  // shape serves both the hasMedia filter and the list's display need.
+  const mediaEmbed =
+    hasMedia === true
+      ? "character_media!inner(is_primary, media(url, alt_text))"
+      : hasMedia === false
+        ? "character_media(character_id)"
+        : "character_media(is_primary, media(url, alt_text))";
+  const selectClause = `*, ${mediaEmbed}, event_characters(count)`;
+
+  let query = client
+    .from("characters")
+    .select(selectClause, { count: "exact" });
+
+  if (characterType !== undefined) {
+    if (Array.isArray(characterType)) {
+      if (characterType.length === 1) {
+        query = query.eq("character_type", characterType[0]!);
+      } else if (characterType.length > 1) {
+        query = query.in("character_type", characterType);
+      }
+    } else {
+      query = query.eq("character_type", characterType);
+    }
+  }
+  if (significance !== undefined) {
+    if (Array.isArray(significance)) {
+      if (significance.length === 1) {
+        query = query.eq("significance", significance[0]!);
+      } else if (significance.length > 1) {
+        query = query.in("significance", significance);
+      }
+    } else {
+      query = query.eq("significance", significance);
+    }
+  }
+  if (userId !== undefined) {
+    query = query.eq("user_id", userId);
+  }
+  if (published !== undefined) {
+    query = query.eq("published", published);
+  }
+  if (hasMedia === false) {
+    query = query.is("character_media", null);
+  }
+  if (search !== undefined && search.length > 0) {
+    query = query.textSearch("search_vector", search, { type: "websearch" });
+  }
+
+  const ascending = sortDirection === "asc";
+  query = query
+    .order(sortBy, { ascending, nullsFirst: false })
+    .order("id", { ascending: true })
+    .range(from, to);
+
+  const { data, count, error } = await query;
+  assertNoError(error, "getCharactersPage");
+
+  return {
+    rows: (data ?? []) as unknown as CharacterListRow[],
+    total: count ?? 0,
+  };
 }
 
 /**
@@ -449,6 +579,42 @@ export async function deleteCharacter(
   assertNoError(error, "deleteCharacter");
 }
 
+/**
+ * Marks a character as published and records `published_at`.
+ */
+export async function publishCharacter(
+  client: SupabaseClient<Database>,
+  id: string,
+): Promise<CharacterRow> {
+  const { data, error } = await client
+    .from("characters")
+    .update({ published: true, published_at: new Date().toISOString() })
+    .eq("id", id)
+    .select()
+    .single();
+
+  assertNoError(error, "publishCharacter");
+  return data as CharacterRow;
+}
+
+/**
+ * Reverts a character to unpublished state and clears `published_at`.
+ */
+export async function unpublishCharacter(
+  client: SupabaseClient<Database>,
+  id: string,
+): Promise<CharacterRow> {
+  const { data, error } = await client
+    .from("characters")
+    .update({ published: false, published_at: null })
+    .eq("id", id)
+    .select()
+    .single();
+
+  assertNoError(error, "unpublishCharacter");
+  return data as CharacterRow;
+}
+
 // ---------------------------------------------------------------------------
 // View queries
 // ---------------------------------------------------------------------------
@@ -521,6 +687,219 @@ export async function getCharacterEvents(
 
   assertNoError(error, "getCharacterEvents");
   return data ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Facet counts
+// ---------------------------------------------------------------------------
+
+/** Builder surface needed by applyCharacterListFilters. */
+interface CharacterFilterBuilder<T> {
+  eq(column: string, value: string | boolean): T;
+  in(column: string, values: readonly string[]): T;
+  is(column: string, value: null): T;
+  not(column: string, op: string, value: null): T;
+  textSearch(column: string, query: string, opts: { type: "websearch" }): T;
+}
+
+/**
+ * Applies the character_type, significance, owner, published, has-media, and
+ * search filters shared by every getCharacterFacetCounts per-option count
+ * query. Skip flags omit a group's own predicate so counting that group's
+ * options isn't constrained by the group's own current selection — the
+ * standard faceted-filter convention (mirrors MediaService.applySharedFilters).
+ *
+ * has-media is expressed here via `.not/.is` against the plain-column
+ * `character_media` embed rather than the `!inner` trick getCharactersPage
+ * uses — these are head:true count-only queries with no data rows to protect,
+ * so the simpler predicate (also used by MediaService's attachedTo counts) is
+ * sufficient.
+ */
+function applyCharacterListFilters<T extends CharacterFilterBuilder<T>>(
+  builder: T,
+  filters: CharacterFilters,
+  opts: {
+    skipCharacterType?: boolean;
+    skipSignificance?: boolean;
+    skipPublished?: boolean;
+    skipHasMedia?: boolean;
+  } = {},
+): T {
+  let q = builder;
+  const { characterType, significance, userId, search, published, hasMedia } =
+    filters;
+
+  if (!opts.skipCharacterType && characterType !== undefined) {
+    if (Array.isArray(characterType)) {
+      if (characterType.length === 1) {
+        q = q.eq("character_type", characterType[0]!);
+      } else if (characterType.length > 1) {
+        q = q.in("character_type", characterType);
+      }
+    } else {
+      q = q.eq("character_type", characterType);
+    }
+  }
+  if (!opts.skipSignificance && significance !== undefined) {
+    if (Array.isArray(significance)) {
+      if (significance.length === 1) {
+        q = q.eq("significance", significance[0]!);
+      } else if (significance.length > 1) {
+        q = q.in("significance", significance);
+      }
+    } else {
+      q = q.eq("significance", significance);
+    }
+  }
+  if (userId !== undefined) {
+    q = q.eq("user_id", userId);
+  }
+  if (!opts.skipPublished && published !== undefined) {
+    q = q.eq("published", published);
+  }
+  if (!opts.skipHasMedia && hasMedia !== undefined) {
+    q = hasMedia
+      ? q.not("character_media", "is", null)
+      : q.is("character_media", null);
+  }
+  if (search !== undefined && search.length > 0) {
+    q = q.textSearch("search_vector", search, { type: "websearch" });
+  }
+  return q;
+}
+
+/** Builder surface for the per-option count predicates (`.eq`, `.is`, `.not`). */
+interface CharacterCountPredicateBuilder {
+  eq(column: string, value: string | boolean): CharacterCountPredicateBuilder;
+  is(column: string, value: null): CharacterCountPredicateBuilder;
+  not(column: string, op: string, value: null): CharacterCountPredicateBuilder;
+}
+
+/** One head-count round-trip: count characters matching the base filters plus `apply`. */
+async function countCharactersWith(
+  client: SupabaseClient<Database>,
+  filters: CharacterFilters,
+  skip: {
+    skipCharacterType?: boolean;
+    skipSignificance?: boolean;
+    skipPublished?: boolean;
+    skipHasMedia?: boolean;
+  },
+  apply: (q: CharacterCountPredicateBuilder) => CharacterCountPredicateBuilder,
+  context: string,
+): Promise<number> {
+  const base = client
+    .from("characters")
+    .select("*, character_media(character_id)", {
+      count: "exact",
+      head: true,
+    });
+  const filtered = applyCharacterListFilters(
+    base as unknown as CharacterFilterBuilder<typeof base>,
+    filters,
+    skip,
+  ) as unknown as typeof base;
+  apply(filtered as unknown as CharacterCountPredicateBuilder);
+  const { count, error } = await filtered;
+  assertNoError(error, context);
+  return count ?? 0;
+}
+
+/**
+ * Returns per-option counts for the characters list filter rail. Each of the
+ * four groups (type, significance, published, has-media) is counted with its
+ * OWN selection removed (so toggling an option within a group does not zero
+ * out its siblings) but with the other groups + search + owner applied — OR
+ * within a group, AND across groups, matching the wireframe. Mirrors
+ * MediaService.getMediaFacetCounts.
+ */
+export async function getCharacterFacetCounts(
+  client: SupabaseClient<Database>,
+  filters: CharacterFilters = {},
+): Promise<CharacterFacetCounts> {
+  const typeOptions = characterTypeEnum.options;
+  const significanceOptions = significanceEnum.options;
+
+  const [
+    typeCounts,
+    significanceCounts,
+    publishedCount,
+    draftCount,
+    hasMediaYes,
+    hasMediaNo,
+  ] = await Promise.all([
+    Promise.all(
+      typeOptions.map((t) =>
+        countCharactersWith(
+          client,
+          filters,
+          { skipCharacterType: true },
+          (q) => q.eq("character_type", t),
+          "getCharacterFacetCounts.characterType",
+        ),
+      ),
+    ),
+    Promise.all(
+      significanceOptions.map((s) =>
+        countCharactersWith(
+          client,
+          filters,
+          { skipSignificance: true },
+          (q) => q.eq("significance", s),
+          "getCharacterFacetCounts.significance",
+        ),
+      ),
+    ),
+    countCharactersWith(
+      client,
+      filters,
+      { skipPublished: true },
+      (q) => q.eq("published", true),
+      "getCharacterFacetCounts.published.published",
+    ),
+    countCharactersWith(
+      client,
+      filters,
+      { skipPublished: true },
+      (q) => q.eq("published", false),
+      "getCharacterFacetCounts.published.draft",
+    ),
+    countCharactersWith(
+      client,
+      filters,
+      { skipHasMedia: true },
+      (q) => q.not("character_media", "is", null),
+      "getCharacterFacetCounts.hasMedia.yes",
+    ),
+    countCharactersWith(
+      client,
+      filters,
+      { skipHasMedia: true },
+      (q) => q.is("character_media", null),
+      "getCharacterFacetCounts.hasMedia.no",
+    ),
+  ]);
+
+  return {
+    characterType: {
+      human: typeCounts[typeOptions.indexOf("human")] ?? 0,
+      animal: typeCounts[typeOptions.indexOf("animal")] ?? 0,
+      mythological: typeCounts[typeOptions.indexOf("mythological")] ?? 0,
+      fictional: typeCounts[typeOptions.indexOf("fictional")] ?? 0,
+      organization: typeCounts[typeOptions.indexOf("organization")] ?? 0,
+      divine: typeCounts[typeOptions.indexOf("divine")] ?? 0,
+      artifact: typeCounts[typeOptions.indexOf("artifact")] ?? 0,
+    },
+    significance: {
+      low: significanceCounts[significanceOptions.indexOf("low")] ?? 0,
+      medium: significanceCounts[significanceOptions.indexOf("medium")] ?? 0,
+      high: significanceCounts[significanceOptions.indexOf("high")] ?? 0,
+      critical:
+        significanceCounts[significanceOptions.indexOf("critical")] ?? 0,
+    },
+    published: { published: publishedCount, draft: draftCount },
+    hasMedia: { yes: hasMediaYes, no: hasMediaNo },
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/components/bulk-action-bar.test.tsx
+++ b/packages/ui/src/components/bulk-action-bar.test.tsx
@@ -142,4 +142,75 @@ describe("BulkActionBar", () => {
     await user.click(confirmButton);
     expect(onPublish).not.toHaveBeenCalled();
   });
+
+  it("does not render a Delete button when onDelete is not passed (no regression for publish/unpublish-only consumers)", () => {
+    render(
+      <BulkActionBar
+        count={2}
+        onPublish={vi.fn()}
+        onUnpublish={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an enabled Delete button when onDelete is passed", () => {
+    render(<BulkActionBar count={2} onDelete={vi.fn()} onClear={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Delete" })).toBeEnabled();
+  });
+
+  it("shows destructive confirm copy and fires onDelete from the delete confirm", async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BulkActionBar
+        count={3}
+        entityLabel="character"
+        onDelete={onDelete}
+        onClear={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByText("Delete 3 characters?"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByText("This cannot be undone."),
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("disables the Delete button while busy", () => {
+    render(
+      <BulkActionBar count={2} busy onDelete={vi.fn()} onClear={vi.fn()} />,
+    );
+    expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+  });
+
+  it("does not re-fire onDelete when confirming while busy", async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <BulkActionBar count={3} onDelete={onDelete} onClear={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    rerender(
+      <BulkActionBar count={3} busy onDelete={onDelete} onClear={vi.fn()} />,
+    );
+    const confirmButton = within(screen.getByRole("dialog")).getByRole(
+      "button",
+      { name: "Delete" },
+    );
+    expect(confirmButton).toBeDisabled();
+    await user.click(confirmButton);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ui/src/components/bulk-action-bar.tsx
+++ b/packages/ui/src/components/bulk-action-bar.tsx
@@ -17,16 +17,16 @@ import {
  * BulkActionBar — the multi-select action bar for list pages (wireframe
  * docs/design/admin/02-wireframes/16-publish-workflow.md §3).
  *
- * Shows "N selected · [Publish] [Unpublish] [Cancel]" for the currently
- * selected rows and routes each transition through a single **batched** confirm
- * dialog ("Publish 4 events?") rather than one dialog per row. `count` is the
- * number of *actionable* (owner-owned) rows — the consumer filters out
- * non-owned/shared rows before passing it, and passes the excluded total as
- * `skippedCount` so the bar can note them. Renders nothing when there is
- * nothing to act on.
+ * Shows "N selected · [Publish] [Unpublish] [Delete] [Cancel]" for the
+ * currently selected rows and routes each transition through a single
+ * **batched** confirm dialog ("Publish 4 events?") rather than one dialog per
+ * row. `count` is the number of *actionable* (owner-owned) rows — the
+ * consumer filters out non-owned/shared rows before passing it, and passes
+ * the excluded total as `skippedCount` so the bar can note them. Renders
+ * nothing when there is nothing to act on.
  */
 export interface BulkActionBarProps {
-  /** Number of selected rows the current user may publish/unpublish. */
+  /** Number of selected rows the current user may publish/unpublish/delete. */
   count: number;
   /** Singular noun for the entity, e.g. "event" or "timeline". */
   entityLabel?: string;
@@ -34,6 +34,7 @@ export interface BulkActionBarProps {
   entityLabelPlural?: string;
   onPublish?: () => void;
   onUnpublish?: () => void;
+  onDelete?: () => void;
   /** Clear the selection (Cancel). */
   onClear: () => void;
   /** Selected rows excluded because the user does not own them. */
@@ -43,7 +44,7 @@ export interface BulkActionBarProps {
   className?: string;
 }
 
-type PendingAction = "publish" | "unpublish" | null;
+type PendingAction = "publish" | "unpublish" | "delete" | null;
 
 export function BulkActionBar({
   count,
@@ -51,6 +52,7 @@ export function BulkActionBar({
   entityLabelPlural,
   onPublish,
   onUnpublish,
+  onDelete,
   onClear,
   skippedCount = 0,
   busy = false,
@@ -69,6 +71,7 @@ export function BulkActionBar({
     if (busy) return;
     if (pending === "publish") onPublish?.();
     else if (pending === "unpublish") onUnpublish?.();
+    else if (pending === "delete") onDelete?.();
     setPending(null);
   };
 
@@ -108,6 +111,17 @@ export function BulkActionBar({
         >
           Unpublish
         </Button>
+        {onDelete && (
+          <Button
+            type="button"
+            size="sm"
+            variant="destructive"
+            disabled={busy}
+            onClick={() => setPending("delete")}
+          >
+            Delete
+          </Button>
+        )}
         <Button type="button" size="sm" variant="ghost" onClick={onClear}>
           Cancel
         </Button>
@@ -124,12 +138,16 @@ export function BulkActionBar({
             <DialogTitle>
               {pending === "unpublish"
                 ? `Unpublish ${count} ${noun}?`
-                : `Publish ${count} ${noun}?`}
+                : pending === "delete"
+                  ? `Delete ${count} ${noun}?`
+                  : `Publish ${count} ${noun}?`}
             </DialogTitle>
             <DialogDescription>
               {pending === "unpublish"
                 ? `They will revert to drafts and stop appearing in reader-facing views. Visibility is unchanged.`
-                : `They will appear to readers according to their visibility settings. You can unpublish at any time.`}
+                : pending === "delete"
+                  ? `This cannot be undone.`
+                  : `They will appear to readers according to their visibility settings. You can unpublish at any time.`}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -144,11 +162,19 @@ export function BulkActionBar({
             <Button
               type="button"
               size="sm"
-              variant={pending === "unpublish" ? "destructive" : "primary"}
+              variant={
+                pending === "unpublish" || pending === "delete"
+                  ? "destructive"
+                  : "primary"
+              }
               disabled={busy}
               onClick={confirm}
             >
-              {pending === "unpublish" ? "Unpublish" : "Publish"}
+              {pending === "unpublish"
+                ? "Unpublish"
+                : pending === "delete"
+                  ? "Delete"
+                  : "Publish"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/packages/ui/src/hooks/use-characters.test.tsx
+++ b/packages/ui/src/hooks/use-characters.test.tsx
@@ -4,13 +4,17 @@ import { type ReactNode, createElement } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   useCharacters,
+  useCharactersPage,
   useCharacter,
   useCreateCharacter,
   useUpdateCharacter,
   useAutosaveCharacter,
   useDeleteCharacter,
+  usePublishCharacter,
+  useUnpublishCharacter,
   useCharacterTimeline,
   useCharacterNetwork,
+  useCharacterFacetCounts,
   useAddMediaToCharacter,
   useRemoveMediaFromCharacter,
   useSetPrimaryCharacterMedia,
@@ -24,13 +28,17 @@ import {
 
 vi.mock("@repo/services/character-service", () => ({
   getCharacters: vi.fn(),
+  getCharactersPage: vi.fn(),
   getCharacterById: vi.fn(),
   getCharacterBySlug: vi.fn(),
   createCharacter: vi.fn(),
   updateCharacter: vi.fn(),
   deleteCharacter: vi.fn(),
+  publishCharacter: vi.fn(),
+  unpublishCharacter: vi.fn(),
   getCharacterTimeline: vi.fn(),
   getCharacterNetwork: vi.fn(),
+  getCharacterFacetCounts: vi.fn(),
   addMediaToCharacter: vi.fn(),
   removeMediaFromCharacter: vi.fn(),
   setPrimaryCharacterMedia: vi.fn(),
@@ -38,12 +46,16 @@ vi.mock("@repo/services/character-service", () => ({
 
 import {
   getCharacters,
+  getCharactersPage,
   getCharacterById,
   createCharacter,
   updateCharacter,
   deleteCharacter,
+  publishCharacter,
+  unpublishCharacter,
   getCharacterTimeline,
   getCharacterNetwork,
+  getCharacterFacetCounts,
   addMediaToCharacter,
   removeMediaFromCharacter,
   setPrimaryCharacterMedia,
@@ -123,6 +135,34 @@ describe("useCharacters", () => {
 
     expect(queryClient.getQueryData(characterKeys.list(filters))).toEqual(
       mockCharacters,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useCharactersPage
+// ---------------------------------------------------------------------------
+
+describe("useCharactersPage", () => {
+  it("calls getCharactersPage with client and filters and returns the page", async () => {
+    const page = { rows: mockCharacters, total: 1 };
+    vi.mocked(getCharactersPage).mockResolvedValue(page as never);
+    const filters = { characterType: "human" as const, page: 2 };
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useCharactersPage(mockClient, filters),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getCharactersPage).toHaveBeenCalledWith(mockClient, filters);
+    expect(result.current.data).toEqual(page);
+  });
+
+  it("uses a distinct query key from useCharacters", () => {
+    const filters = { characterType: "human" as const };
+    expect(characterKeys.page(filters)).not.toEqual(
+      characterKeys.list(filters),
     );
   });
 });
@@ -328,6 +368,91 @@ describe("useDeleteCharacter", () => {
 });
 
 // ---------------------------------------------------------------------------
+// usePublishCharacter / useUnpublishCharacter
+// ---------------------------------------------------------------------------
+
+describe("usePublishCharacter", () => {
+  it("calls publishCharacter and invalidates all character caches", async () => {
+    vi.mocked(publishCharacter).mockResolvedValue(mockCharacter as never);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => usePublishCharacter(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate("char-1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(publishCharacter).toHaveBeenCalledWith(mockClient, "char-1");
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: characterKeys.all }),
+    );
+  });
+});
+
+describe("useUnpublishCharacter", () => {
+  it("calls unpublishCharacter and invalidates all character caches", async () => {
+    vi.mocked(unpublishCharacter).mockResolvedValue(mockCharacter as never);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnpublishCharacter(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate("char-1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(unpublishCharacter).toHaveBeenCalledWith(mockClient, "char-1");
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: characterKeys.all }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useCharacterFacetCounts
+// ---------------------------------------------------------------------------
+
+describe("useCharacterFacetCounts", () => {
+  it("calls getCharacterFacetCounts with client and filters", async () => {
+    const counts = {
+      characterType: {
+        human: 1,
+        animal: 0,
+        mythological: 0,
+        fictional: 0,
+        organization: 0,
+        divine: 0,
+        artifact: 0,
+      },
+      significance: { low: 0, medium: 1, high: 0, critical: 0 },
+      published: { published: 1, draft: 0 },
+      hasMedia: { yes: 1, no: 0 },
+    };
+    vi.mocked(getCharacterFacetCounts).mockResolvedValue(counts as never);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useCharacterFacetCounts(mockClient, {}),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getCharacterFacetCounts).toHaveBeenCalledWith(mockClient, {});
+    expect(result.current.data).toEqual(counts);
+  });
+
+  it("uses a distinct query key from useCharactersPage", () => {
+    const filters = { characterType: "human" as const };
+    expect(characterKeys.facetCounts(filters)).not.toEqual(
+      characterKeys.page(filters),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // characterKeys factory
 // ---------------------------------------------------------------------------
 
@@ -338,6 +463,16 @@ describe("characterKeys", () => {
     expect(characterKeys.list({ page: 1 })).toEqual([
       "characters",
       "list",
+      { page: 1 },
+    ]);
+    expect(characterKeys.page({ page: 1 })).toEqual([
+      "characters",
+      "page",
+      { page: 1 },
+    ]);
+    expect(characterKeys.facetCounts({ page: 1 })).toEqual([
+      "characters",
+      "facetCounts",
       { page: 1 },
     ]);
     expect(characterKeys.detail("abc")).toEqual([

--- a/packages/ui/src/hooks/use-characters.tsx
+++ b/packages/ui/src/hooks/use-characters.tsx
@@ -15,13 +15,17 @@ import {
 } from "@tanstack/react-query";
 import {
   getCharacters,
+  getCharactersPage,
   getCharacterById,
   getCharacterBySlug,
   createCharacter,
   updateCharacter,
   deleteCharacter,
+  publishCharacter,
+  unpublishCharacter,
   getCharacterTimeline,
   getCharacterNetwork,
+  getCharacterFacetCounts,
   addMediaToCharacter,
   removeMediaFromCharacter,
   setPrimaryCharacterMedia,
@@ -50,6 +54,10 @@ export const characterKeys = {
   lists: () => [...characterKeys.all, "list"] as const,
   list: (filters: CharacterFilters) =>
     [...characterKeys.lists(), filters] as const,
+  page: (filters: CharacterFilters) =>
+    [...characterKeys.all, "page", filters] as const,
+  facetCounts: (filters: CharacterFilters) =>
+    [...characterKeys.all, "facetCounts", filters] as const,
   details: () => [...characterKeys.all, "detail"] as const,
   detail: (id: string) => [...characterKeys.details(), id] as const,
   bySlug: (userId: string, slug: string) =>
@@ -99,6 +107,44 @@ export function useCharacters(
   return useQuery({
     queryKey: characterKeys.list(filters),
     queryFn: () => getCharacters(client, filters),
+    staleTime: 30_000,
+    ...options,
+  });
+}
+
+/**
+ * Fetch a page of characters together with the total filtered count, the
+ * primary media, and the event-participation count the characters list
+ * renders on each row.
+ */
+export function useCharactersPage(
+  client: ServiceClient,
+  filters: CharacterFilters = {},
+  options?: Omit<
+    UseQueryOptions<Awaited<ReturnType<typeof getCharactersPage>>>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery({
+    queryKey: characterKeys.page(filters),
+    queryFn: () => getCharactersPage(client, filters),
+    staleTime: 30_000,
+    ...options,
+  });
+}
+
+/** Fetch per-option facet counts for the characters list filter rail. */
+export function useCharacterFacetCounts(
+  client: ServiceClient,
+  filters: CharacterFilters = {},
+  options?: Omit<
+    UseQueryOptions<Awaited<ReturnType<typeof getCharacterFacetCounts>>>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery({
+    queryKey: characterKeys.facetCounts(filters),
+    queryFn: () => getCharacterFacetCounts(client, filters),
     staleTime: 30_000,
     ...options,
   });
@@ -262,6 +308,32 @@ export function useDeleteCharacter(client: ServiceClient) {
     onSuccess: (_data, id) => {
       queryClient.removeQueries({ queryKey: characterKeys.detail(id) });
       void queryClient.invalidateQueries({ queryKey: characterKeys.lists() });
+    },
+  });
+}
+
+/** Publish a character (set published=true and record published_at). */
+export function usePublishCharacter(client: ServiceClient) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => publishCharacter(client, id),
+    onSuccess: () => {
+      // Invalidate by prefix so bySlug and other derived queries stay
+      // consistent with RLS visibility changes — mirrors usePublishEvent.
+      void queryClient.invalidateQueries({ queryKey: characterKeys.all });
+    },
+  });
+}
+
+/** Unpublish a character (set published=false and clear published_at). */
+export function useUnpublishCharacter(client: ServiceClient) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => unpublishCharacter(client, id),
+    onSuccess: () => {
+      // Invalidate by prefix so bySlug and other derived queries stay
+      // consistent with RLS visibility changes — mirrors useUnpublishEvent.
+      void queryClient.invalidateQueries({ queryKey: characterKeys.all });
     },
   });
 }


### PR DESCRIPTION
## Summary

- Wires the real `/characters` route (`apps/admin/app/(protected)/characters/page.tsx`), replacing the `PlaceholderPage` stub: URL-driven filter rail (type/significance/published/has-media, all with per-option counts), debounced search, 4 sort options (name/created/updated/birth date), windowed pagination, two-line rows with a name-cell hover thumbnail (primary media image or type-icon placeholder), significance stars, and a bulk publish/unpublish/delete action bar — mirroring the events list template (`event-list-client.tsx`).
- Adds the data-layer pieces the page needed but `@repo/services`/`@repo/ui` didn't have yet: `getCharactersPage` (paginated + total count), `publishCharacter`/`unpublishCharacter`, `getCharacterFacetCounts` (per-option counts, mirroring `MediaService.getMediaFacetCounts`'s pattern), and the matching `useCharactersPage`/`usePublishCharacter`/`useUnpublishCharacter`/`useCharacterFacetCounts` hooks.
- Extends the shared `BulkActionBar` with an optional `onDelete` action (backward compatible — no behavior change for its existing `events`/`timelines` callers, verified by a dedicated regression test).
- Scaffolds a route-local `CharacterTypeBadge` (7-type icon + tint + label) since #284 (the shared primitive) hasn't shipped yet — has a `// TODO` pointing at the real one.
- Implements **2-state** Published/Draft per the wireframe's own filter checkboxes and #55's acceptance criteria, deferring the wireframe's 3rd "shared" status — no reachability query exists for it yet, and the events reference template doesn't implement it either. Flagged with a `// DECISION NEEDED` comment.

Closes #55.

## Follow-ups filed during review

Found during `/code-review`; same class of bug in each case, but larger blast radius than this PR (shared list-page pattern across events/timelines, or a service-layer query fix + new tests) so filed rather than fixed inline:

- #329 — debounced search can clobber a concurrent filter/sort change (stale `searchParams` closure)
- #330 — list pages don't clamp the page number after a bulk action shrinks the result set below it
- #331 — `characters.published` is nullable; the Draft filter/facet-count excludes null rows that the badge still labels "Draft"

One review finding *was* fixed inline (small, isolated to this PR): a null `significance` now renders "—" like the Temporal cell, instead of indexing the star/color lookup maps with a value they don't cover.

## Test plan

- [x] `pnpm run format`
- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [x] `pnpm run test:coverage` — 126 new/updated service tests, 27 hook tests, 15 `BulkActionBar` tests, all passing; full-repo coverage well above the 80% threshold (services 96.9%, ui 95.3%)
- [x] `pnpm run build`
- [x] Manual: seeded 10 diverse characters (all 7 types, all 4 significance levels, published/draft, with/without media, event participations) against local Supabase and drove the route end-to-end in a real browser — filter counts, search debounce + URL params, sort, pagination, hover thumbnail (both real image and icon-placeholder cases), and the full bulk-action bar including the destructive delete-confirm dialog all verified correct with zero console errors
- [x] Manual: confirmed the `events` and `timelines` list pages' bulk-action bars still render/behave exactly as before (no Delete button, no third dialog branch) after the `BulkActionBar` extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)