### PR TITLE
feat(admin): Character create/edit form with type-specific fields and TemporalInput (#56)

### DIFF
--- a/apps/admin/app/(protected)/_components/media/media-section.tsx
+++ b/apps/admin/app/(protected)/_components/media/media-section.tsx
@@ -213,6 +213,7 @@ export function MediaSection({
       {canEdit && (
         <div className="flex justify-end">
           <Button
+            type="button"
             size="sm"
             variant="secondary"
             onClick={() => setAttachOpen(true)}
@@ -231,6 +232,7 @@ export function MediaSection({
           <p className="text-sm text-destructive">Failed to load media.</p>
           {onRetry && (
             <Button
+              type="button"
               variant="secondary"
               size="sm"
               onClick={() => void onRetry()}
@@ -282,6 +284,7 @@ export function MediaSection({
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button
+                      type="button"
                       variant="ghost"
                       size="sm"
                       className="h-8 w-8 shrink-0 p-0"

--- a/apps/admin/app/(protected)/characters/[slug]/edit/page.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/edit/page.tsx
@@ -1,20 +1,23 @@
-import { PlaceholderPage } from "../../../../../components/placeholder-page";
+import { redirect } from "next/navigation";
+import { getUser } from "../../../../../lib/auth";
+import { getServerSupabaseClient } from "../../../../auth/_lib/server-supabase";
+import { CharacterFormClient } from "../../_components/character-form-client";
 
-interface CharacterDetailPageProps {
+interface EditCharacterPageProps {
   params: Promise<{ slug: string }>;
 }
 
-export default async function CharacterDetailPage({
+export default async function EditCharacterPage({
   params,
-}: CharacterDetailPageProps) {
+}: EditCharacterPageProps) {
   const { slug } = await params;
 
-  return (
-    <PlaceholderPage
-      title={`Edit character: ${slug}`}
-      description="Character editor surface scaffolded for dashboard deep-link flows."
-      trackedIn="a later batch (TBD)"
-      rows={3}
-    />
-  );
+  // Resolve the owner id server-side (session already validated by the
+  // protected layout) so the client hook can build its (userId, slug) query
+  // key on first render without an auth round-trip / loading flash.
+  const client = await getServerSupabaseClient();
+  const user = await getUser(client);
+  if (!user) redirect("/auth/login");
+
+  return <CharacterFormClient mode="edit" userId={user.id} slug={slug} />;
 }

--- a/apps/admin/app/(protected)/characters/_components/character-form-client.tsx
+++ b/apps/admin/app/(protected)/characters/_components/character-form-client.tsx
@@ -764,8 +764,9 @@ export function CharacterFormClient(props: Props) {
             {addAnotherNote && (
               <Alert role="status">
                 <AlertDescription>
-                  Cleared: name, biography, aliases, dates, media. Persisted:
-                  type, significance, cultural context.
+                  Persisted: type, significance, cultural context. Everything
+                  else — name, biography, aliases, physical description, dates,
+                  and media — was cleared.
                 </AlertDescription>
               </Alert>
             )}

--- a/apps/admin/app/(protected)/characters/_components/character-form-client.tsx
+++ b/apps/admin/app/(protected)/characters/_components/character-form-client.tsx
@@ -1,0 +1,1194 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { FileText, Music, UploadCloud, Video } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useForm, useWatch, Controller, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { generateSlug } from "@repo/services/utils/slug";
+
+import {
+  useCharacterBySlug,
+  useCreateCharacter,
+  useUpdateCharacter,
+  useAutosaveCharacter,
+  usePublishCharacter,
+  useUnpublishCharacter,
+  useAddMediaToCharacter,
+  useRemoveMediaFromCharacter,
+  useSetPrimaryCharacterMedia,
+} from "@repo/ui/hooks/use-characters";
+import { useMediaItem } from "@repo/ui/hooks/use-media";
+import { useUiStore } from "@repo/ui/stores";
+
+import { Alert, AlertDescription, AlertTitle } from "@repo/ui/components/alert";
+import { AutosaveIndicator } from "@repo/ui/components/autosave-indicator";
+import { Button } from "@repo/ui/components/button";
+import { ChipInput } from "@repo/ui/components/chip-input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/form";
+import { Label } from "@repo/ui/components/label";
+import { Separator } from "@repo/ui/components/separator";
+import { SaveDropdown } from "@repo/ui/components/save-dropdown";
+import { SlugField } from "@repo/ui/components/slug-field";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { TemporalInput } from "@repo/ui/components/temporal-input";
+import { Textarea } from "@repo/ui/components/textarea";
+
+import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import {
+  MediaSection,
+  type AttachedMedia,
+} from "../../_components/media/media-section";
+import { AttachMediaDialog } from "../../_components/media/attach-media-dialog";
+import { useUnsavedChangesGuard } from "./use-unsaved-changes-guard";
+import {
+  characterFormSchema,
+  BLANK_VALUES,
+  jsonObjectError,
+  mapRowToFormValues,
+  toCreateInput,
+  toUpdateData,
+  seedForAddAnother,
+  type CharacterFormValues,
+  type CharacterType,
+  type Significance,
+} from "./character-form-mappers";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LABEL_CLASS = "mb-1.5 block text-sm font-medium text-foreground";
+const INPUT_CLASS =
+  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+const RADIO_LABEL_CLASS =
+  "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground has-[:checked]:bg-surface has-[:checked]:text-foreground";
+
+const CHARACTER_TYPES: { value: CharacterType; label: string }[] = [
+  { value: "human", label: "Human" },
+  { value: "animal", label: "Animal" },
+  { value: "mythological", label: "Mythological" },
+  { value: "fictional", label: "Fictional" },
+  { value: "organization", label: "Organization" },
+  { value: "divine", label: "Divine" },
+  { value: "artifact", label: "Artifact" },
+];
+
+const SIGNIFICANCE_OPTIONS: { value: Significance; label: string }[] = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "critical", label: "Critical" },
+];
+
+/** Type-specific top-level columns surfaced per character_type. */
+type TypeField = "species" | "breed" | "domain";
+const TYPE_FIELDS: Record<CharacterType, TypeField[]> = {
+  human: [],
+  animal: ["species", "breed"],
+  mythological: ["domain"],
+  fictional: [],
+  organization: [],
+  divine: ["domain"],
+  artifact: [],
+};
+const TYPE_FIELD_LABELS: Record<TypeField, string> = {
+  species: "Species",
+  breed: "Breed",
+  domain: "Domain",
+};
+
+function joinAnd(labels: string[]): string {
+  if (labels.length <= 1) return labels[0] ?? "";
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`;
+}
+
+/** Temporal-scope labels adapt to the character type (wireframe 05). */
+function temporalLabels(type: CharacterType): { birth: string; death: string } {
+  if (type === "organization") return { birth: "Founded", death: "Dissolved" };
+  if (type === "artifact") return { birth: "Created", death: "Destroyed" };
+  return { birth: "Birth date", death: "Death date" };
+}
+
+// ---------------------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------------------
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-4">
+      <h2 className="mb-1.5 font-display text-sm font-normal text-foreground">
+        {children}
+      </h2>
+      <Separator />
+    </div>
+  );
+}
+
+function RequiredMark() {
+  return (
+    <span aria-label="required" className="text-destructive">
+      *
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Create-flow profile media slot
+//
+// The live MediaSection needs a character_id to write junctions, which doesn't
+// exist until the first save. In the create flow we instead let the user pick
+// or upload one media row through the same Attach dialog, hold its id in form
+// state, and write the `character_media` primary junction after the character
+// is created (see onValid).
+// ---------------------------------------------------------------------------
+
+type ServiceClient = ReturnType<typeof getBrowserSupabaseClient>;
+
+function CreateProfileMediaSlot({
+  client,
+  value,
+  onChange,
+}: {
+  client: ServiceClient;
+  value: string | null;
+  onChange: (mediaId: string | null) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const media = useMediaItem(client, value ?? "", { enabled: value != null });
+  const row = media.data;
+
+  const Icon =
+    row?.media_type === "video"
+      ? Video
+      : row?.media_type === "audio"
+        ? Music
+        : FileText;
+
+  return (
+    <div className="space-y-2">
+      {value == null ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex h-28 w-full items-center justify-center rounded-md border border-dashed border-border bg-surface/50 text-sm text-foreground-muted hover:border-ring"
+        >
+          <span className="flex flex-col items-center gap-2">
+            <UploadCloud className="h-5 w-5 opacity-50" aria-hidden />
+            <span>Drop image or click to upload</span>
+          </span>
+        </button>
+      ) : (
+        <>
+          <div className="flex items-center gap-3 rounded-md border border-border bg-background px-3 py-2.5">
+            {row?.media_type === "image" && row.url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={row.url}
+                alt={row.alt_text ?? ""}
+                className="h-12 w-12 shrink-0 rounded-md border border-border object-cover"
+              />
+            ) : (
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground">
+                <Icon className="h-5 w-5" />
+              </div>
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">
+                {row?.caption ?? row?.alt_text ?? "Selected image"}
+              </p>
+              <p className="text-xs text-foreground-muted">
+                Set as the primary image when you save.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => onChange(null)}
+            >
+              Remove
+            </Button>
+          </div>
+        </>
+      )}
+      <AttachMediaDialog
+        open={open}
+        onOpenChange={setOpen}
+        client={client}
+        onAttached={(mediaId) => onChange(mediaId)}
+        onAttachExisting={(mediaIds) => {
+          const first = mediaIds[0];
+          if (first) onChange(first);
+        }}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Edit-flow profile media (live MediaSection, ordering="primary")
+// ---------------------------------------------------------------------------
+
+function EditProfileMedia({
+  client,
+  characterId,
+}: {
+  client: ServiceClient;
+  characterId: string;
+}) {
+  const queryClient = useQueryClient();
+  const addMedia = useAddMediaToCharacter(client);
+  const removeMedia = useRemoveMediaFromCharacter(client);
+  const setPrimary = useSetPrimaryCharacterMedia(client);
+
+  const {
+    data: items = [],
+    isPending,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ["character-media", characterId],
+    queryFn: async (): Promise<AttachedMedia[]> => {
+      const { data: junctions, error: jErr } = await client
+        .from("character_media")
+        .select("media_id, is_primary")
+        .eq("character_id", characterId);
+      if (jErr) throw jErr;
+      if (!junctions?.length) return [];
+      const ids = junctions.map((j) => j.media_id);
+      const { data, error } = await client
+        .from("media")
+        .select("id, alt_text, caption, media_type, url, source")
+        .in("id", ids);
+      if (error) throw error;
+      const byId = new Map((data ?? []).map((m) => [m.id, m]));
+      return junctions
+        .map((j): AttachedMedia | null => {
+          const m = byId.get(j.media_id);
+          if (!m) return null;
+          return {
+            id: m.id,
+            alt_text: m.alt_text ?? null,
+            caption: m.caption ?? null,
+            media_type: m.media_type ?? null,
+            url: m.url ?? null,
+            source: m.source ?? "upload",
+            sort_order: null,
+            is_primary: j.is_primary ?? false,
+          };
+        })
+        .filter((m): m is AttachedMedia => m !== null)
+        .sort((a, b) => Number(b.is_primary) - Number(a.is_primary));
+    },
+    enabled: characterId.length > 0,
+    staleTime: 30_000,
+  });
+
+  const refresh = React.useCallback(async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ["character-media", characterId],
+    });
+  }, [queryClient, characterId]);
+
+  const noPrimaryYet = !items.some((m) => m.is_primary);
+
+  return (
+    <MediaSection
+      client={client}
+      items={items}
+      isLoading={isPending}
+      isError={isError}
+      onRetry={() => void refetch()}
+      canEdit
+      ordering="primary"
+      onAttach={async (mediaId) => {
+        await addMedia.mutateAsync({
+          characterId,
+          mediaId,
+          isPrimary: noPrimaryYet,
+        });
+        await refresh();
+      }}
+      onAttachExisting={async (mediaIds) => {
+        let makePrimary = noPrimaryYet;
+        for (const mediaId of mediaIds) {
+          await addMedia.mutateAsync({
+            characterId,
+            mediaId,
+            isPrimary: makePrimary,
+          });
+          makePrimary = false;
+        }
+        await refresh();
+      }}
+      onDetach={async (mediaId) => {
+        await removeMedia.mutateAsync({ characterId, mediaId });
+        await refresh();
+      }}
+      onSetPrimary={async (mediaId) => {
+        await setPrimary.mutateAsync({ characterId, mediaId });
+        await refresh();
+      }}
+      onChanged={refresh}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+type Props =
+  { mode: "create" } | { mode: "edit"; userId: string; slug: string };
+
+interface PendingTypeChange {
+  next: CharacterType;
+  dropped: TypeField[];
+}
+
+export function CharacterFormClient(props: Props) {
+  const router = useRouter();
+  const addToast = useUiStore((s) => s.addToast);
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+
+  const createCharacter = useCreateCharacter(client);
+  const updateCharacter = useUpdateCharacter(client);
+  const autosave = useAutosaveCharacter(client);
+  const publish = usePublishCharacter(client);
+  const unpublish = useUnpublishCharacter(client);
+  const addMedia = useAddMediaToCharacter(client);
+
+  const isEdit = props.mode === "edit";
+  const editQuery = useCharacterBySlug(
+    client,
+    isEdit ? props.userId : "",
+    isEdit ? props.slug : "",
+    { enabled: isEdit },
+  );
+
+  const cancelHref =
+    props.mode === "edit" ? `/characters/${props.slug}` : "/characters";
+
+  const form = useForm<CharacterFormValues>({
+    resolver: zodResolver(characterFormSchema) as Resolver<CharacterFormValues>,
+    defaultValues: BLANK_VALUES,
+    mode: "onTouched",
+  });
+
+  // Hydrate once from the fetched row; a background refetch must not clobber
+  // in-progress edits.
+  const hydratedRef = React.useRef(false);
+  const editRow = editQuery.data;
+  React.useEffect(() => {
+    if (!isEdit || hydratedRef.current || editRow === undefined) return;
+    form.reset(mapRowToFormValues(editRow));
+    hydratedRef.current = true;
+  }, [isEdit, editRow, form]);
+
+  const isDirty = form.formState.isDirty;
+  const guard = useUnsavedChangesGuard(isDirty);
+
+  const [pendingTypeChange, setPendingTypeChange] =
+    React.useState<PendingTypeChange | null>(null);
+  const [autosaveAt, setAutosaveAt] = React.useState<Date | null>(null);
+  const [addAnotherNote, setAddAnotherNote] = React.useState(false);
+
+  const addAnotherRef = React.useRef(false);
+  // The target published state to reconcile to after the content save; defaults
+  // to the rail toggle, overridden by the Save-as-draft / Save-and-publish
+  // dropdown actions.
+  const publishTargetRef = React.useRef(false);
+
+  // -------------------------------------------------------------------------
+  // Save flow
+  // -------------------------------------------------------------------------
+
+  const characterId = editRow?.id;
+
+  const onValid = React.useCallback(
+    async (values: CharacterFormValues) => {
+      // TODO(#333): this is last-write-wins. Detect a concurrent edit from
+      // another tab (newer stored updated_at than the hydrated baseline) and
+      // prompt to refresh rather than silently overwriting.
+      const addAnother = addAnotherRef.current;
+      addAnotherRef.current = false;
+      const publishTarget = publishTargetRef.current;
+
+      try {
+        let savedId: string;
+        let savedSlug: string;
+        let savedPublished: boolean;
+
+        if (isEdit && editRow) {
+          const row = await updateCharacter.mutateAsync({
+            id: editRow.id,
+            data: toUpdateData(values),
+          });
+          savedId = row.id;
+          savedSlug = row.slug;
+          savedPublished = row.published ?? false;
+        } else {
+          const row = await createCharacter.mutateAsync(toCreateInput(values));
+          savedId = row.id;
+          savedSlug = row.slug;
+          savedPublished = row.published ?? false;
+          // Attach the stashed profile media as primary. Never block the save
+          // on it (wireframe edge case).
+          if (values.pending_primary_media_id) {
+            try {
+              await addMedia.mutateAsync({
+                characterId: savedId,
+                mediaId: values.pending_primary_media_id,
+                isPrimary: true,
+              });
+            } catch {
+              addToast({
+                id: `char-media-fail-${Date.now()}`,
+                message: "Image attach failed — retry from the detail view.",
+                variant: "warning",
+              });
+            }
+          }
+        }
+
+        // Reconcile publication to the target state.
+        if (publishTarget && !savedPublished) {
+          await publish.mutateAsync(savedId);
+          savedPublished = true;
+        } else if (!publishTarget && savedPublished) {
+          await unpublish.mutateAsync(savedId);
+          savedPublished = false;
+        }
+
+        addToast({
+          id: `character-saved-${Date.now()}`,
+          message: isEdit ? "Character updated." : "Character created.",
+          variant: "success",
+        });
+
+        if (addAnother && !isEdit) {
+          form.reset(seedForAddAnother(values));
+          setAutosaveAt(null);
+          setAddAnotherNote(true);
+          return;
+        }
+
+        // Reset to the saved state so isDirty clears before redirect.
+        form.reset({
+          ...values,
+          slug: savedSlug,
+          published: savedPublished,
+          pending_primary_media_id: null,
+        });
+        router.push(`/characters/${savedSlug}`);
+      } catch {
+        // Surfaced via the form-level Alert below.
+      }
+    },
+    [
+      isEdit,
+      editRow,
+      updateCharacter,
+      createCharacter,
+      addMedia,
+      publish,
+      unpublish,
+      form,
+      addToast,
+      router,
+    ],
+  );
+
+  const submit = React.useCallback(
+    (opts?: { addAnother?: boolean; publishTarget?: boolean }) => {
+      // Flush the slug synchronously: SlugField debounces generation, so a fast
+      // name→Save can fire before it lands and trip the schema's slug rule.
+      const { slug, name } = form.getValues();
+      if (slug.trim().length === 0 && name.trim().length > 0) {
+        try {
+          form.setValue("slug", generateSlug(name), { shouldValidate: false });
+        } catch {
+          // Non-sluggable name — let validation surface it.
+        }
+      }
+      if (opts?.publishTarget !== undefined) {
+        form.setValue("published", opts.publishTarget, { shouldDirty: true });
+      }
+      addAnotherRef.current = opts?.addAnother ?? false;
+      publishTargetRef.current =
+        opts?.publishTarget ?? form.getValues("published");
+      setAddAnotherNote(false);
+      void form.handleSubmit(onValid)();
+    },
+    [form, onValid],
+  );
+
+  // -------------------------------------------------------------------------
+  // Auto-save (edit only): every 30s while dirty, never publishes.
+  // -------------------------------------------------------------------------
+
+  React.useEffect(() => {
+    if (!isEdit || editRow === undefined) return;
+    const id = editRow.id;
+    const interval = window.setInterval(() => {
+      if (!form.formState.isDirty) return;
+      // TODO(#333): auto-save is also last-write-wins; same concurrent-edit
+      // guard as the deliberate Save should apply here.
+      const values = form.getValues();
+      // Skip a tick rather than fail on half-typed JSON in the Advanced editors.
+      if (
+        jsonObjectError(values.profile_data_json) !== null ||
+        jsonObjectError(values.metadata_json) !== null
+      ) {
+        return;
+      }
+      autosave.mutate(
+        { id, data: toUpdateData(values) },
+        { onSuccess: () => setAutosaveAt(new Date()) },
+      );
+    }, 30_000);
+    return () => window.clearInterval(interval);
+  }, [isEdit, editRow, form, autosave]);
+
+  // -------------------------------------------------------------------------
+  // character_type change (confirm before clearing type-specific fields)
+  // -------------------------------------------------------------------------
+
+  const handleTypeChange = React.useCallback(
+    (next: CharacterType) => {
+      const current = form.getValues("character_type");
+      if (next === current) return;
+      const nextFields = TYPE_FIELDS[next];
+      const dropped = TYPE_FIELDS[current].filter(
+        (field) =>
+          !nextFields.includes(field) &&
+          form.getValues(field).trim().length > 0,
+      );
+      if (dropped.length > 0) {
+        setPendingTypeChange({ next, dropped });
+        return;
+      }
+      form.setValue("character_type", next, { shouldDirty: true });
+    },
+    [form],
+  );
+
+  const confirmTypeChange = React.useCallback(() => {
+    if (pendingTypeChange === null) return;
+    for (const field of pendingTypeChange.dropped) {
+      form.setValue(field, "", { shouldDirty: true });
+    }
+    form.setValue("character_type", pendingTypeChange.next, {
+      shouldDirty: true,
+    });
+    setPendingTypeChange(null);
+  }, [pendingTypeChange, form]);
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  const watchedName = useWatch({ control: form.control, name: "name" });
+  const watchedType = useWatch({
+    control: form.control,
+    name: "character_type",
+  });
+  const watchedPublished = useWatch({
+    control: form.control,
+    name: "published",
+  });
+
+  const slugMode = isEdit ? "edit" : "create";
+  const isSaving =
+    createCharacter.isPending ||
+    updateCharacter.isPending ||
+    publish.isPending ||
+    unpublish.isPending;
+
+  const mutationError =
+    createCharacter.error ??
+    updateCharacter.error ??
+    publish.error ??
+    unpublish.error ??
+    null;
+  const hasFieldErrors = Object.keys(form.formState.errors).length > 0;
+
+  const labels = temporalLabels(watchedType);
+  const showSpeciesBreed = watchedType === "animal";
+  const showDomain = watchedType === "divine" || watchedType === "mythological";
+  const biographyLabel =
+    watchedType === "divine" ? "Mythological account" : "Biography";
+
+  if (isEdit && editQuery.isPending) {
+    return (
+      <div className="space-y-4 p-6">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (isEdit && editQuery.isError) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive" role="alert">
+          <AlertTitle>Couldn’t load this character</AlertTitle>
+          <AlertDescription>
+            {editQuery.error instanceof Error
+              ? editQuery.error.message
+              : "Unknown error."}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const breadcrumbs = isEdit
+    ? [
+        { label: "Characters", href: "/characters" },
+        { label: watchedName || "Edit character" },
+      ]
+    : [
+        { label: "Characters", href: "/characters" },
+        { label: "New character" },
+      ];
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex h-full flex-col overflow-hidden"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        {/* ── Toolbar ──────────────────────────────────────────────────── */}
+        <div className="flex shrink-0 items-center justify-between border-b border-border px-6 py-3">
+          <nav className="flex items-center gap-1 text-sm text-foreground-muted">
+            {breadcrumbs.map((crumb, i) => (
+              <React.Fragment key={crumb.label}>
+                {i > 0 && (
+                  <span aria-hidden className="mx-1">
+                    ▸
+                  </span>
+                )}
+                {crumb.href ? (
+                  <button
+                    type="button"
+                    className="hover:text-foreground"
+                    onClick={() => guard.requestNavigate(crumb.href!)}
+                  >
+                    {crumb.label}
+                  </button>
+                ) : (
+                  <span className="text-foreground">{crumb.label}</span>
+                )}
+              </React.Fragment>
+            ))}
+          </nav>
+
+          <div className="flex items-center gap-3">
+            {isEdit && (
+              <AutosaveIndicator
+                isSaving={autosave.isPending}
+                savedAt={autosaveAt}
+              />
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => guard.requestNavigate(cancelHref)}
+            >
+              Cancel
+            </Button>
+            <SaveDropdown
+              onSave={() => submit()}
+              disabled={isSaving}
+              onSaveAndAddAnother={
+                isEdit ? undefined : () => submit({ addAnother: true })
+              }
+              onSaveAsDraft={
+                watchedPublished
+                  ? () => submit({ publishTarget: false })
+                  : undefined
+              }
+              onSaveAndPublish={
+                watchedPublished
+                  ? undefined
+                  : () => submit({ publishTarget: true })
+              }
+            />
+          </div>
+        </div>
+
+        {/* ── Body ─────────────────────────────────────────────────────── */}
+        <div className="flex flex-1 overflow-auto">
+          {/* Left column — main form */}
+          <div className="flex-1 space-y-8 overflow-auto px-6 py-6">
+            {(hasFieldErrors || mutationError) && (
+              <Alert variant="destructive" role="alert">
+                <AlertTitle>
+                  {mutationError
+                    ? "Couldn’t save this character"
+                    : "Please fix the highlighted fields"}
+                </AlertTitle>
+                <AlertDescription>
+                  {mutationError instanceof Error
+                    ? mutationError.message
+                    : "Some fields need your attention before saving."}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {addAnotherNote && (
+              <Alert role="status">
+                <AlertDescription>
+                  Cleared: name, biography, aliases, dates, media. Persisted:
+                  type, significance, cultural context.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {/* Identity */}
+            <section>
+              <SectionHeading>Identity</SectionHeading>
+              <div className="space-y-5">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>
+                        Name <RequiredMark />
+                      </FormLabel>
+                      <FormControl>
+                        <input
+                          {...field}
+                          className={INPUT_CLASS}
+                          placeholder="Character name"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <div>
+                  <Label className={LABEL_CLASS}>
+                    Character type <RequiredMark />
+                  </Label>
+                  <div className="grid grid-cols-2 gap-0.5">
+                    {CHARACTER_TYPES.map((t) => (
+                      <label key={t.value} className={RADIO_LABEL_CLASS}>
+                        <input
+                          type="radio"
+                          name="character-type"
+                          value={t.value}
+                          checked={watchedType === t.value}
+                          onChange={() => handleTypeChange(t.value)}
+                          className="h-3.5 w-3.5 shrink-0 accent-primary"
+                        />
+                        <span>{t.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                {showSpeciesBreed && (
+                  <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+                    <FormField
+                      control={form.control}
+                      name="species"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className={LABEL_CLASS}>
+                            Species <RequiredMark />
+                          </FormLabel>
+                          <FormControl>
+                            <input
+                              {...field}
+                              className={INPUT_CLASS}
+                              placeholder="e.g. Tyrannosaurus rex"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="breed"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className={LABEL_CLASS}>Breed</FormLabel>
+                          <FormControl>
+                            <input
+                              {...field}
+                              className={INPUT_CLASS}
+                              placeholder="(n/a for non-domesticated)"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                )}
+
+                {showDomain && (
+                  <FormField
+                    control={form.control}
+                    name="domain"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={LABEL_CLASS}>Domain</FormLabel>
+                        <FormControl>
+                          <input
+                            {...field}
+                            className={INPUT_CLASS}
+                            placeholder="e.g. Sky, thunder, gods"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+
+                <Controller
+                  control={form.control}
+                  name="aliases"
+                  render={({ field }) => (
+                    <ChipInput
+                      label="Aliases"
+                      value={field.value}
+                      onChange={field.onChange}
+                      placeholder="Add alias"
+                      description="Press Enter or comma to add. Backspace removes the last alias."
+                    />
+                  )}
+                />
+
+                <Controller
+                  control={form.control}
+                  name="cultural_context"
+                  render={({ field }) => (
+                    <ChipInput
+                      label="Cultural context"
+                      value={field.value}
+                      onChange={field.onChange}
+                      placeholder="Add context"
+                    />
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="biography"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>
+                        {biographyLabel}
+                      </FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          placeholder="Write a biography…"
+                          className="min-h-30"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="physical_description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className={LABEL_CLASS}>
+                        Physical description
+                      </FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          placeholder="Describe physical appearance…"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </section>
+
+            {/* Temporal scope */}
+            <section>
+              <SectionHeading>Temporal scope</SectionHeading>
+              <div className="space-y-4">
+                <Controller
+                  control={form.control}
+                  name="birth_temporal"
+                  render={({ field, fieldState }) => (
+                    <TemporalInput
+                      label={labels.birth}
+                      value={field.value}
+                      onChange={field.onChange}
+                      error={fieldState.error?.message}
+                    />
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name="death_temporal"
+                  render={({ field, fieldState }) => (
+                    <TemporalInput
+                      label={labels.death}
+                      value={field.value}
+                      onChange={field.onChange}
+                      error={fieldState.error?.message}
+                    />
+                  )}
+                />
+              </div>
+            </section>
+
+            {/* Profile media */}
+            <section>
+              <SectionHeading>Profile media</SectionHeading>
+              {isEdit && characterId ? (
+                <EditProfileMedia client={client} characterId={characterId} />
+              ) : (
+                <Controller
+                  control={form.control}
+                  name="pending_primary_media_id"
+                  render={({ field }) => (
+                    <CreateProfileMediaSlot
+                      client={client}
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  )}
+                />
+              )}
+            </section>
+
+            {/* Advanced */}
+            <section>
+              <details>
+                <summary className="cursor-pointer select-none text-sm text-foreground-muted hover:text-foreground">
+                  Advanced (profile_data, metadata)
+                </summary>
+                <div className="mt-3 space-y-4 rounded-md border border-border bg-surface/30 px-4 py-3">
+                  <p className="text-xs text-foreground-muted">
+                    Raw JSON escape hatch for power users. Each must be a JSON
+                    object. Recurring keys should graduate to real fields.
+                  </p>
+                  <FormField
+                    control={form.control}
+                    name="profile_data_json"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={LABEL_CLASS}>
+                          profile_data
+                        </FormLabel>
+                        <FormControl>
+                          <Textarea
+                            {...field}
+                            spellCheck={false}
+                            className="min-h-30 font-mono text-xs"
+                            placeholder='{ "nationality": "Polish" }'
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="metadata_json"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className={LABEL_CLASS}>metadata</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            {...field}
+                            spellCheck={false}
+                            className="min-h-30 font-mono text-xs"
+                            placeholder="{ }"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </details>
+            </section>
+          </div>
+
+          {/* Right column — metadata rail */}
+          <aside className="w-72 shrink-0 space-y-6 border-l border-border px-5 py-6">
+            <Controller
+              control={form.control}
+              name="slug"
+              render={({ field }) => (
+                <SlugField
+                  label="Slug"
+                  value={field.value}
+                  onChange={field.onChange}
+                  sourceValue={watchedName}
+                  mode={slugMode}
+                  warning={
+                    isEdit
+                      ? "Changing the slug will break existing links to this character."
+                      : undefined
+                  }
+                  description="Auto-generated from name."
+                />
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="significance"
+              render={({ field }) => (
+                <div>
+                  <Label className={LABEL_CLASS}>Significance</Label>
+                  <div className="grid grid-cols-2 gap-0.5">
+                    {SIGNIFICANCE_OPTIONS.map((s) => (
+                      <label key={s.value} className={RADIO_LABEL_CLASS}>
+                        <input
+                          type="radio"
+                          name="significance"
+                          value={s.value}
+                          checked={field.value === s.value}
+                          onChange={() => field.onChange(s.value)}
+                          className="h-3.5 w-3.5 shrink-0 accent-primary"
+                        />
+                        <span>{s.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="published"
+              render={({ field }) => (
+                <div>
+                  <Label className={LABEL_CLASS}>Published</Label>
+                  <label className="flex cursor-pointer items-center gap-2.5 text-sm text-foreground">
+                    <input
+                      type="checkbox"
+                      checked={field.value}
+                      onChange={(e) => field.onChange(e.target.checked)}
+                      className="h-4 w-4 rounded accent-primary"
+                    />
+                    <span>
+                      {field.value ? "Published" : "Draft — publish on save"}
+                    </span>
+                  </label>
+                </div>
+              )}
+            />
+          </aside>
+        </div>
+      </form>
+
+      {/* ── Confirm: switching character type clears type-specific fields ── */}
+      <Dialog
+        open={pendingTypeChange !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingTypeChange(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Clear type-specific fields?</DialogTitle>
+            <DialogDescription>
+              {pendingTypeChange
+                ? `${joinAnd(
+                    pendingTypeChange.dropped.map((f) => TYPE_FIELD_LABELS[f]),
+                  )} will be cleared. Continue?`
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setPendingTypeChange(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={confirmTypeChange}
+            >
+              Switch &amp; clear
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Confirm: discard unsaved changes ──────────────────────────── */}
+      <Dialog
+        open={guard.isConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) guard.cancelNavigation();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Discard unsaved changes?</DialogTitle>
+            <DialogDescription>
+              You have unsaved changes. If you leave now, they’ll be lost.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={guard.cancelNavigation}
+            >
+              Keep editing
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={guard.confirmNavigation}
+            >
+              Discard
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Form>
+  );
+}

--- a/apps/admin/app/(protected)/characters/_components/character-form-mappers.test.ts
+++ b/apps/admin/app/(protected)/characters/_components/character-form-mappers.test.ts
@@ -218,6 +218,19 @@ describe("toUpdateData", () => {
     expect(data.slug).toBe("marie-curie");
     expect("published" in data).toBe(false);
   });
+
+  it("sends null temporal fields so clearing a date persists", () => {
+    const data = toUpdateData(
+      makeValues({ birth_temporal: null, death_temporal: null }),
+    );
+    expect(data.birth_temporal).toBeNull();
+    expect(data.death_temporal).toBeNull();
+  });
+
+  it("passes a set date through unchanged", () => {
+    const data = toUpdateData(makeValues({ birth_temporal: BIRTH }));
+    expect(data.birth_temporal).toEqual(BIRTH);
+  });
 });
 
 describe("seedForAddAnother", () => {

--- a/apps/admin/app/(protected)/characters/_components/character-form-mappers.test.ts
+++ b/apps/admin/app/(protected)/characters/_components/character-form-mappers.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from "vitest";
+
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import type { CharacterWithRelations } from "@repo/services/character-service";
+
+import {
+  characterFormSchema,
+  BLANK_VALUES,
+  jsonObjectError,
+  jsonToText,
+  parseJsonObject,
+  toTemporalOrNull,
+  mapRowToFormValues,
+  toCreateInput,
+  toUpdateData,
+  seedForAddAnother,
+  type CharacterFormValues,
+} from "./character-form-mappers";
+
+const BIRTH: TemporalData = {
+  year: 1867,
+  era: "CE",
+  precision: "exact",
+  month: 11,
+  day: 7,
+};
+
+function makeValues(
+  overrides: Partial<CharacterFormValues> = {},
+): CharacterFormValues {
+  return {
+    ...BLANK_VALUES,
+    name: "Marie Curie",
+    slug: "marie-curie",
+    ...overrides,
+  };
+}
+
+describe("jsonObjectError", () => {
+  it("passes empty text", () => {
+    expect(jsonObjectError("")).toBeNull();
+    expect(jsonObjectError("   ")).toBeNull();
+  });
+
+  it("passes a JSON object", () => {
+    expect(jsonObjectError('{"nationality":"Polish"}')).toBeNull();
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(jsonObjectError("{not json")).toBe("Invalid JSON.");
+  });
+
+  it("rejects non-object JSON (array, scalar)", () => {
+    expect(jsonObjectError("[1,2]")).toBe("Must be a JSON object.");
+    expect(jsonObjectError('"hi"')).toBe("Must be a JSON object.");
+  });
+});
+
+describe("jsonToText / parseJsonObject", () => {
+  it("renders an empty object and null as empty text", () => {
+    expect(jsonToText({})).toBe("");
+    expect(jsonToText(null)).toBe("");
+    expect(jsonToText(undefined)).toBe("");
+  });
+
+  it("pretty-prints a populated object", () => {
+    expect(jsonToText({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+
+  it("round-trips through parseJsonObject", () => {
+    const obj = { nationality: "Polish", occupation: "Physicist" };
+    expect(parseJsonObject(jsonToText(obj))).toEqual(obj);
+  });
+
+  it("parses empty text to undefined", () => {
+    expect(parseJsonObject("")).toBeUndefined();
+    expect(parseJsonObject("   ")).toBeUndefined();
+  });
+});
+
+describe("toTemporalOrNull", () => {
+  it("passes valid TemporalData through", () => {
+    expect(toTemporalOrNull(BIRTH)).toEqual(BIRTH);
+  });
+
+  it("coerces empty/garbage JSON to null", () => {
+    expect(toTemporalOrNull({})).toBeNull();
+    expect(toTemporalOrNull(null)).toBeNull();
+  });
+});
+
+describe("mapRowToFormValues", () => {
+  function makeRow(
+    overrides: Partial<CharacterWithRelations> = {},
+  ): CharacterWithRelations {
+    return {
+      name: "Row name",
+      slug: "row-name",
+      character_type: "human",
+      biography: null,
+      aliases: null,
+      cultural_context: null,
+      physical_description: null,
+      species: null,
+      breed: null,
+      domain: null,
+      significance: null,
+      birth_temporal: null,
+      death_temporal: null,
+      published: null,
+      profile_data: null,
+      metadata: null,
+      ...overrides,
+    } as unknown as CharacterWithRelations;
+  }
+
+  it("falls back to sensible defaults for nullable columns", () => {
+    expect(mapRowToFormValues(makeRow())).toMatchObject({
+      biography: "",
+      aliases: [],
+      cultural_context: [],
+      physical_description: "",
+      species: "",
+      breed: "",
+      domain: "",
+      significance: "medium",
+      birth_temporal: null,
+      death_temporal: null,
+      published: false,
+      profile_data_json: "",
+      metadata_json: "",
+    });
+  });
+
+  it("carries persisted values through", () => {
+    const values = mapRowToFormValues(
+      makeRow({
+        character_type: "animal",
+        species: "Panthera leo",
+        breed: null,
+        significance: "critical",
+        birth_temporal: BIRTH,
+        published: true,
+        profile_data: { conservation_status: "vulnerable" },
+      }),
+    );
+    expect(values).toMatchObject({
+      character_type: "animal",
+      species: "Panthera leo",
+      significance: "critical",
+      birth_temporal: BIRTH,
+      published: true,
+    });
+    expect(values.profile_data_json).toContain("conservation_status");
+  });
+
+  it("treats a legacy empty-object temporal as null", () => {
+    expect(
+      mapRowToFormValues(makeRow({ birth_temporal: {} })).birth_temporal,
+    ).toBeNull();
+  });
+});
+
+describe("toCreateInput", () => {
+  it("drops empty-string optionals and omits an unset slug", () => {
+    const input = toCreateInput(
+      makeValues({ slug: "", biography: "", species: "", breed: "" }),
+    );
+    expect(input.slug).toBeUndefined();
+    expect(input.biography).toBeUndefined();
+    expect(input.species).toBeUndefined();
+    expect(input.breed).toBeUndefined();
+  });
+
+  it("includes a provided slug and species", () => {
+    const input = toCreateInput(
+      makeValues({ character_type: "animal", species: "Panthera leo" }),
+    );
+    expect(input.slug).toBe("marie-curie");
+    expect(input.species).toBe("Panthera leo");
+  });
+
+  it("omits empty arrays and parses the JSON editors", () => {
+    const input = toCreateInput(
+      makeValues({
+        aliases: [],
+        cultural_context: ["Polish"],
+        profile_data_json: '{"nationality":"Polish"}',
+      }),
+    );
+    expect(input.aliases).toBeUndefined();
+    expect(input.cultural_context).toEqual(["Polish"]);
+    expect(input.profile_data).toEqual({ nationality: "Polish" });
+  });
+});
+
+describe("toUpdateData", () => {
+  it("sends cleared text/array fields as-is so the clear persists", () => {
+    const data = toUpdateData(
+      makeValues({ species: "", breed: "", biography: "", aliases: [] }),
+    );
+    expect(data.species).toBe("");
+    expect(data.breed).toBe("");
+    expect(data.biography).toBe("");
+    expect(data.aliases).toEqual([]);
+  });
+
+  it("clears the JSON extras to an empty object when the editor is empty", () => {
+    const data = toUpdateData(
+      makeValues({ profile_data_json: "", metadata_json: "" }),
+    );
+    expect(data.profile_data).toEqual({});
+    expect(data.metadata).toEqual({});
+  });
+
+  it("keeps the slug and never includes published", () => {
+    const data = toUpdateData(makeValues({ published: true }));
+    expect(data.slug).toBe("marie-curie");
+    expect("published" in data).toBe(false);
+  });
+});
+
+describe("seedForAddAnother", () => {
+  it("persists type, significance and cultural context; clears the rest", () => {
+    const seeded = seedForAddAnother(
+      makeValues({
+        name: "Marie Curie",
+        character_type: "divine",
+        significance: "high",
+        cultural_context: ["Greek"],
+        biography: "…",
+        aliases: ["x"],
+        birth_temporal: BIRTH,
+        pending_primary_media_id: "media-1",
+      }),
+    );
+    expect(seeded.character_type).toBe("divine");
+    expect(seeded.significance).toBe("high");
+    expect(seeded.cultural_context).toEqual(["Greek"]);
+    expect(seeded.name).toBe("");
+    expect(seeded.biography).toBe("");
+    expect(seeded.aliases).toEqual([]);
+    expect(seeded.birth_temporal).toBeNull();
+    expect(seeded.pending_primary_media_id).toBeNull();
+  });
+});
+
+describe("characterFormSchema refinements", () => {
+  function base(overrides: Record<string, unknown> = {}) {
+    return {
+      name: "Valid name",
+      character_type: "human",
+      slug: "valid-name",
+      biography: "",
+      aliases: [],
+      cultural_context: [],
+      physical_description: "",
+      species: "",
+      breed: "",
+      domain: "",
+      significance: "medium",
+      birth_temporal: null,
+      death_temporal: null,
+      published: false,
+      profile_data_json: "",
+      metadata_json: "",
+      pending_primary_media_id: null,
+      ...overrides,
+    };
+  }
+
+  it("accepts a valid human", () => {
+    expect(characterFormSchema.safeParse(base()).success).toBe(true);
+  });
+
+  it("requires a name", () => {
+    const result = characterFormSchema.safeParse(base({ name: "" }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === "name")).toBe(true);
+    }
+  });
+
+  it("requires species for an animal", () => {
+    const result = characterFormSchema.safeParse(
+      base({ character_type: "animal", species: "" }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === "species")).toBe(
+        true,
+      );
+    }
+  });
+
+  it("accepts an animal with a species", () => {
+    expect(
+      characterFormSchema.safeParse(
+        base({ character_type: "animal", species: "Panthera leo" }),
+      ).success,
+    ).toBe(true);
+  });
+
+  it("rejects invalid JSON in an Advanced editor", () => {
+    const result = characterFormSchema.safeParse(
+      base({ profile_data_json: "{not json" }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.path[0] === "profile_data_json"),
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/admin/app/(protected)/characters/_components/character-form-mappers.ts
+++ b/apps/admin/app/(protected)/characters/_components/character-form-mappers.ts
@@ -272,12 +272,10 @@ export function toUpdateData(
     breed: values.breed,
     domain: values.domain,
     significance: values.significance,
-    // The service `characterSchema` types these JSONB fields as optional (not
-    // nullable), so a full clear can't be expressed as `null`. A set/change
-    // persists; leaving a populated date untouched round-trips; removing an
-    // existing date is not supported by this form (tracked as a follow-up).
-    birth_temporal: values.birth_temporal ?? undefined,
-    death_temporal: values.death_temporal ?? undefined,
+    // `null` clears an existing date (the schema/column are nullable); a value
+    // sets or updates it. Sent unconditionally so a clear actually persists.
+    birth_temporal: values.birth_temporal,
+    death_temporal: values.death_temporal,
     // Empty JSON text clears the extras to `{}` rather than omitting (which
     // would leave the stored value untouched).
     profile_data: parseJsonObject(values.profile_data_json) ?? {},

--- a/apps/admin/app/(protected)/characters/_components/character-form-mappers.ts
+++ b/apps/admin/app/(protected)/characters/_components/character-form-mappers.ts
@@ -1,0 +1,301 @@
+import { z } from "zod";
+
+import {
+  characterTypeEnum,
+  significanceEnum,
+} from "@repo/services/schemas/character";
+import type { CharacterInput } from "@repo/services/schemas/character";
+import { slugSchema } from "@repo/services/schemas/slug";
+import { temporalDataSchema } from "@repo/services/schemas/temporal";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import type {
+  CreateCharacterInput,
+  CharacterWithRelations,
+} from "@repo/services/character-service";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CharacterType = z.infer<typeof characterTypeEnum>;
+export type Significance = z.infer<typeof significanceEnum>;
+
+/**
+ * The character editor's working value type. Field names mirror the persisted
+ * character row (snake_case) so `zodResolver` validates a shape close to what
+ * is stored.
+ *
+ * Divergences from the service `characterSchema`, all UI-only:
+ *  - temporal fields are `null` in the empty state (the schema has them
+ *    optional-not-nullable);
+ *  - `profile_data` / `metadata` are edited as raw JSON **text** behind the
+ *    Advanced disclosure, parsed back to objects on save;
+ *  - `pending_primary_media_id` holds a media row chosen in the create flow
+ *    before the character (and therefore the `character_media` junction)
+ *    exists; it is written after the create succeeds and never persisted as a
+ *    column.
+ *
+ * `published` is captured here but is **not** part of the create/update
+ * payload — publication transitions run through the dedicated
+ * publish/unpublish service calls (see character-form-client).
+ */
+export interface CharacterFormValues {
+  name: string;
+  character_type: CharacterType;
+  slug: string;
+  biography: string;
+  aliases: string[];
+  cultural_context: string[];
+  physical_description: string;
+  species: string;
+  breed: string;
+  domain: string;
+  significance: Significance;
+  birth_temporal: TemporalData | null;
+  death_temporal: TemporalData | null;
+  published: boolean;
+  profile_data_json: string;
+  metadata_json: string;
+  pending_primary_media_id: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Validation — purpose-built form schema (does not mutate characterSchema)
+// ---------------------------------------------------------------------------
+
+const JSON_FIELDS = ["profile_data_json", "metadata_json"] as const;
+
+/**
+ * Returns a friendly error string when `text` is a non-empty value that is not
+ * a JSON **object**, otherwise `null`. Empty/whitespace text is treated as
+ * "no value" and passes (mapped to `undefined`/`{}` at persist time).
+ */
+export function jsonObjectError(text: string): string | null {
+  const raw = text.trim();
+  if (raw.length === 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return "Invalid JSON.";
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return "Must be a JSON object.";
+  }
+  return null;
+}
+
+/**
+ * Form-only schema. The canonical `characterSchema` still runs server-side in
+ * `createCharacter`/`updateCharacter`; this validates the editor's own value
+ * shape and surfaces the two cross-field rules inline before the round-trip:
+ *  - `animal` requires a non-empty `species` (the service enforces the same
+ *    invariant; this gives an inline message + focus jump);
+ *  - the Advanced JSON editors must hold valid JSON objects.
+ */
+export const characterFormSchema = z
+  .object({
+    name: z.string().min(1, "Name is required.").max(2000),
+    character_type: characterTypeEnum,
+    slug: slugSchema,
+    biography: z.string(),
+    aliases: z.array(z.string()),
+    cultural_context: z.array(z.string()),
+    physical_description: z.string(),
+    species: z.string().max(500),
+    breed: z.string().max(500),
+    domain: z.string().max(500),
+    significance: significanceEnum,
+    birth_temporal: temporalDataSchema.nullable(),
+    death_temporal: temporalDataSchema.nullable(),
+    published: z.boolean(),
+    profile_data_json: z.string(),
+    metadata_json: z.string(),
+    pending_primary_media_id: z.string().nullable(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.character_type === "animal" && data.species.trim().length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["species"],
+        message: "Species is required for animals.",
+      });
+    }
+    for (const field of JSON_FIELDS) {
+      const error = jsonObjectError(data[field]);
+      if (error !== null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [field],
+          message: error,
+        });
+      }
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Pure mappers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+export const BLANK_VALUES: CharacterFormValues = {
+  name: "",
+  character_type: "human",
+  slug: "",
+  biography: "",
+  aliases: [],
+  cultural_context: [],
+  physical_description: "",
+  species: "",
+  breed: "",
+  domain: "",
+  significance: "medium",
+  birth_temporal: null,
+  death_temporal: null,
+  published: false,
+  profile_data_json: "",
+  metadata_json: "",
+  pending_primary_media_id: null,
+};
+
+/** Coerce stored JSON to TemporalData, treating invalid/empty (`{}`) as null. */
+export function toTemporalOrNull(json: unknown): TemporalData | null {
+  const result = temporalDataSchema.safeParse(json);
+  return result.success ? result.data : null;
+}
+
+/**
+ * Render a stored JSONB value as pretty-printed text for an editor textarea.
+ * Empty objects (the migration-00001 `'{}'` default) and null render as an
+ * empty string so the editor doesn't show a meaningless `{}`.
+ */
+export function jsonToText(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value as Record<string, unknown>).length === 0
+  ) {
+    return "";
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Parse an Advanced JSON textarea back to an object. Returns `undefined` for
+ * empty text. Assumes the value already passed `characterFormSchema`
+ * validation (invalid JSON never reaches here on a real submit), so a parse
+ * failure falls back to `undefined` rather than throwing.
+ */
+export function parseJsonObject(
+  text: string,
+): Record<string, unknown> | undefined {
+  const raw = text.trim();
+  if (raw.length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Unreachable on a validated submit; guarded for direct/mapper callers.
+  }
+  return undefined;
+}
+
+export function mapRowToFormValues(
+  row: CharacterWithRelations,
+): CharacterFormValues {
+  return {
+    name: row.name,
+    character_type: (row.character_type as CharacterType | null) ?? "human",
+    slug: row.slug,
+    biography: row.biography ?? "",
+    aliases: row.aliases ?? [],
+    cultural_context: row.cultural_context ?? [],
+    physical_description: row.physical_description ?? "",
+    species: row.species ?? "",
+    breed: row.breed ?? "",
+    domain: row.domain ?? "",
+    significance: (row.significance as Significance | null) ?? "medium",
+    birth_temporal: toTemporalOrNull(row.birth_temporal),
+    death_temporal: toTemporalOrNull(row.death_temporal),
+    published: row.published ?? false,
+    profile_data_json: jsonToText(row.profile_data),
+    metadata_json: jsonToText(row.metadata),
+    pending_primary_media_id: null,
+  };
+}
+
+export function toCreateInput(
+  values: CharacterFormValues,
+): CreateCharacterInput {
+  return {
+    name: values.name,
+    character_type: values.character_type,
+    // The service generates + collision-resolves the slug; only pass a base
+    // when the user has typed one, otherwise omit so it derives from the name.
+    slug: values.slug || undefined,
+    biography: values.biography || undefined,
+    aliases: values.aliases.length > 0 ? values.aliases : undefined,
+    cultural_context:
+      values.cultural_context.length > 0 ? values.cultural_context : undefined,
+    physical_description: values.physical_description || undefined,
+    species: values.species || undefined,
+    breed: values.breed || undefined,
+    domain: values.domain || undefined,
+    significance: values.significance,
+    birth_temporal: values.birth_temporal ?? undefined,
+    death_temporal: values.death_temporal ?? undefined,
+    profile_data: parseJsonObject(values.profile_data_json),
+    metadata: parseJsonObject(values.metadata_json),
+  };
+}
+
+export function toUpdateData(
+  values: CharacterFormValues,
+): Partial<CharacterInput> {
+  return {
+    name: values.name,
+    character_type: values.character_type,
+    slug: values.slug,
+    // Text/array fields are sent as-is (including "") so clearing a field on an
+    // existing record actually persists the clear.
+    biography: values.biography,
+    aliases: values.aliases,
+    cultural_context: values.cultural_context,
+    physical_description: values.physical_description,
+    species: values.species,
+    breed: values.breed,
+    domain: values.domain,
+    significance: values.significance,
+    // The service `characterSchema` types these JSONB fields as optional (not
+    // nullable), so a full clear can't be expressed as `null`. A set/change
+    // persists; leaving a populated date untouched round-trips; removing an
+    // existing date is not supported by this form (tracked as a follow-up).
+    birth_temporal: values.birth_temporal ?? undefined,
+    death_temporal: values.death_temporal ?? undefined,
+    // Empty JSON text clears the extras to `{}` rather than omitting (which
+    // would leave the stored value untouched).
+    profile_data: parseJsonObject(values.profile_data_json) ?? {},
+    metadata: parseJsonObject(values.metadata_json) ?? {},
+  };
+}
+
+/**
+ * The curated subset "Save and add another" carries into the next blank form
+ * (wireframe 05 annotation #9): type, significance, and cultural context.
+ */
+export function seedForAddAnother(
+  values: CharacterFormValues,
+): CharacterFormValues {
+  return {
+    ...BLANK_VALUES,
+    character_type: values.character_type,
+    significance: values.significance,
+    cultural_context: values.cultural_context,
+  };
+}

--- a/apps/admin/app/(protected)/characters/_components/use-unsaved-changes-guard.ts
+++ b/apps/admin/app/(protected)/characters/_components/use-unsaved-changes-guard.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Guards a dirty form against accidental navigation loss.
+ *
+ * Two surfaces are covered:
+ *  - **Hard navigation** (reload / tab close / external link): a `beforeunload`
+ *    listener triggers the browser's native confirmation while `isDirty`.
+ *  - **In-app navigation** the form controls (Cancel button, breadcrumbs):
+ *    call `requestNavigate(href)` instead of `router.push`. When dirty it
+ *    defers the push and exposes `isConfirmOpen` so the caller can render a
+ *    confirm dialog; on confirm it completes the navigation.
+ *
+ * NOTE: the App Router has no stable API to intercept arbitrary in-app
+ * navigation (e.g. clicking a sidebar link), so only the surfaces routed
+ * through `requestNavigate` are guarded in-app; `beforeunload` is the
+ * backstop for everything else.
+ *
+ * (Route-local copy of the timeline editor's guard — kept per-route rather
+ * than promoted to a shared hook to avoid a cross-route import.)
+ */
+export function useUnsavedChangesGuard(isDirty: boolean) {
+  const router = useRouter();
+  const [pendingHref, setPendingHref] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!isDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // Required for Chrome to show the native prompt.
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+
+  const requestNavigate = React.useCallback(
+    (href: string) => {
+      if (isDirty) {
+        setPendingHref(href);
+      } else {
+        router.push(href);
+      }
+    },
+    [isDirty, router],
+  );
+
+  const confirmNavigation = React.useCallback(() => {
+    setPendingHref((href) => {
+      if (href !== null) router.push(href);
+      return null;
+    });
+  }, [router]);
+
+  const cancelNavigation = React.useCallback(() => setPendingHref(null), []);
+
+  return {
+    requestNavigate,
+    isConfirmOpen: pendingHref !== null,
+    confirmNavigation,
+    cancelNavigation,
+  };
+}

--- a/apps/admin/app/(protected)/characters/new/page.tsx
+++ b/apps/admin/app/(protected)/characters/new/page.tsx
@@ -1,0 +1,9 @@
+import { CharacterFormClient } from "../_components/character-form-client";
+
+export const metadata = {
+  title: "New character",
+};
+
+export default function NewCharacterPage() {
+  return <CharacterFormClient mode="create" />;
+}

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         "app/**/_components/media/attach-media-dialog.tsx",
         "app/**/_components/media/media-library.tsx",
         "app/**/_components/media/media-section.tsx",
+        "app/**/character-form-mappers.ts",
         "app/**/event-form-mappers.ts",
         "app/**/timeline-form-mappers.ts",
       ],

--- a/packages/services/src/schemas/character.test.ts
+++ b/packages/services/src/schemas/character.test.ts
@@ -83,6 +83,18 @@ describe("characterSchema — temporal fields", () => {
     expect(result.success).toBe(true);
     expect(result.data?.birth_temporal).toBeUndefined();
   });
+
+  it("accepts null birth/death_temporal (clears the stored date on update)", () => {
+    const result = characterSchema.partial().safeParse({
+      birth_temporal: null,
+      death_temporal: null,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.birth_temporal).toBeNull();
+      expect(result.data.death_temporal).toBeNull();
+    }
+  });
 });
 
 describe("characterSchema — type-specific fields", () => {

--- a/packages/services/src/schemas/character.ts
+++ b/packages/services/src/schemas/character.ts
@@ -50,8 +50,11 @@ export const characterSchema = z.object({
   // Top-level column shared by mythological/divine.
   domain: z.string().max(500).optional(),
   significance: significanceEnum.default("medium"),
-  birth_temporal: temporalDataSchema.optional(),
-  death_temporal: temporalDataSchema.optional(),
+  // Nullable so an editor can clear an existing date on update: a partial patch
+  // sending `null` writes SQL NULL to the column (the DB column is nullable
+  // JSONB). Omitting the field (undefined) leaves the stored value untouched.
+  birth_temporal: temporalDataSchema.nullish(),
+  death_temporal: temporalDataSchema.nullish(),
   // Per-type extras; validated by characterTypeProfileSchema, never top-level.
   profile_data: z.record(z.string(), z.unknown()).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),


### PR DESCRIPTION
Closes #56.

Builds the Character create and edit routes for `apps/admin` — the most type-adaptive form in the app. Both routes share one client (`CharacterFormClient`) with a discriminated `mode` prop, porting the established timeline-editor architecture (react-hook-form + `zodResolver`, once-only edit hydration, two-column layout, unsaved-changes guard, slug flush on submit, split-save button) and dressing it with the `character-editor` story's visual spec. Nearly every dependency (service functions, TanStack Query hooks, primitives) already existed.

## What's included
- **Routes:** `characters/new/page.tsx` (new) and `characters/[slug]/edit/page.tsx` (replaces the placeholder; resolves `userId` server-side for the `(userId, slug)` query key).
- **Type-adaptive fields** via a 7-value `character_type` radio grid: Species/Breed (animal, **species required inline**), Domain (divine/mythological), biography label → "Mythological account" (divine), temporal labels **Founded/Dissolved** (org) and **Created/Destroyed** (artifact). Switching type confirms before clearing populated type-specific fields.
- **Slug** auto-gen (create) / lock-with-warning (edit); **TemporalInput** for birth/death; **ChipInput** for aliases + cultural context.
- **Split SaveDropdown** (draft/publish/add-another). "Save and add another" persists type + significance + cultural context with the inline note.
- **Profile media:** edit mounts the live `MediaSection` (`ordering="primary"`); create stashes a media id and writes the `character_media` primary junction after `createCharacter` succeeds.
- **30s dirty auto-save** (edit only, never publishes) with `AutosaveIndicator`.
- **Advanced disclosure** with validated JSON editors for `profile_data` + `metadata`.
- **Fix:** `MediaSection` action buttons are now `type="button"` so they don't submit the host editor form when embedded (previously "Attach media" saved + navigated instead of opening the Attach dialog).

## Acceptance criteria
All #56 criteria met except cross-tab concurrent-edit detection, **deferred to #333** (needs an optimistic-concurrency service change) with `// TODO(#333)` markers in both save paths.

## Testing
- `format:check`, `check-types`, `lint` (zero-warnings), `build` — all green.
- Admin unit tests: 133 passing; new `character-form-mappers` tests at 97% coverage (mapper added to the ADR-0026 coverage allow-list). UI client is excluded from coverage per the same policy (matches `timeline-form-client`).
- Manual/E2E of the editor flows to be run by Scout QA in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)