### PR TITLE
feat(admin): character detail page with relationships, events, and media (#57)

### DIFF
--- a/apps/admin/app/(protected)/_components/media/media-section.tsx
+++ b/apps/admin/app/(protected)/_components/media/media-section.tsx
@@ -263,7 +263,9 @@ export function MediaSection({
                 <p className="truncate text-sm font-medium">
                   {item.caption ?? item.alt_text ?? "Untitled media"}
                 </p>
-                <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                {/* A <div>, not <p>: the primary <Badge> renders a <div>, which
+                    is invalid (and a hydration error) nested in a <p>. */}
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                   <span>
                     {item.source === "external" ? "external" : "uploaded"}
                   </span>
@@ -277,7 +279,7 @@ export function MediaSection({
                       Primary
                     </Badge>
                   )}
-                </p>
+                </div>
               </div>
 
               {canEdit && (

--- a/apps/admin/app/(protected)/characters/[slug]/_components/add-relationship-sheet.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/_components/add-relationship-sheet.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import { getCharacters } from "@repo/services/character-service";
+import {
+  RelationshipTypeSelector,
+  type RelationshipType,
+} from "@repo/ui/components/relationship-type-selector";
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import { Label } from "@repo/ui/components/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@repo/ui/components/sheet";
+import { TemporalInput } from "@repo/ui/components/temporal-input";
+import { Textarea } from "@repo/ui/components/textarea";
+import { toast } from "@repo/ui/components/sonner";
+import { cn } from "@repo/ui/lib/utils";
+import {
+  useCreateRelationship,
+  useUpdateRelationship,
+} from "@repo/ui/hooks/use-character-relationships";
+
+type ServiceClient = Parameters<typeof getCharacters>[0];
+
+/** An existing relationship (focal → other), for excluding duplicates by type. */
+export interface ExistingLink {
+  otherId: string;
+  type: string;
+}
+
+/** When set, the sheet edits an existing relationship instead of creating one. */
+export interface RelationshipEditTarget {
+  id: string;
+  otherId: string;
+  otherName: string;
+  type: RelationshipType;
+  role: string | null;
+  description: string | null;
+  startTemporal: TemporalData | null;
+  endTemporal: TemporalData | null;
+}
+
+interface AddRelationshipSheetProps {
+  open: boolean;
+  onClose: () => void;
+  client: ServiceClient;
+  focalCharacterId: string;
+  focalCharacterName: string;
+  /** Relationships that already exist, to exclude duplicates by chosen type. */
+  existingLinks: ExistingLink[];
+  editing?: RelationshipEditTarget | null;
+  /** Pre-select the other character in create mode (e.g. "Duplicate as type"). */
+  initialOther?: OtherCharacter | null;
+  onSaved: () => void;
+}
+
+interface OtherCharacter {
+  id: string;
+  name: string;
+  characterType: string;
+}
+
+export function AddRelationshipSheet({
+  open,
+  onClose,
+  client,
+  focalCharacterId,
+  focalCharacterName,
+  existingLinks,
+  editing,
+  initialOther,
+  onSaved,
+}: AddRelationshipSheetProps) {
+  const isEdit = !!editing;
+  const createRel = useCreateRelationship(client);
+  const updateRel = useUpdateRelationship(client);
+
+  const [other, setOther] = React.useState<OtherCharacter | null>(null);
+  const [type, setType] = React.useState<RelationshipType>("family");
+  const [role, setRole] = React.useState<string | null>(null);
+  const [description, setDescription] = React.useState("");
+  const [start, setStart] = React.useState<TemporalData | null>(null);
+  const [end, setEnd] = React.useState<TemporalData | null>(null);
+
+  // Seed / reset form state when the sheet opens (derived-state pattern).
+  const [prevOpen, setPrevOpen] = React.useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      if (editing) {
+        setOther({
+          id: editing.otherId,
+          name: editing.otherName,
+          characterType: "",
+        });
+        setType(editing.type);
+        setRole(editing.role);
+        setDescription(editing.description ?? "");
+        setStart(editing.startTemporal);
+        setEnd(editing.endTemporal);
+      } else {
+        setOther(initialOther ?? null);
+        setType("family");
+        setRole(null);
+        setDescription("");
+        setStart(null);
+        setEnd(null);
+      }
+    }
+  }
+
+  // Other-character ids already linked by the *currently chosen* type — exclude
+  // them from the picker so we never trip the (chars, type) unique index.
+  const excludedIds = React.useMemo(() => {
+    const ids = new Set<string>([focalCharacterId]);
+    for (const link of existingLinks) {
+      if (link.type === type) ids.add(link.otherId);
+    }
+    return ids;
+  }, [existingLinks, type, focalCharacterId]);
+
+  const isPending = createRel.isPending || updateRel.isPending;
+
+  function handleSave() {
+    if (!isEdit && !other) {
+      toast.error("Choose a character first.");
+      return;
+    }
+    if (isEdit && editing) {
+      updateRel.mutate(
+        {
+          id: editing.id,
+          data: {
+            relationship_type: type,
+            relationship_role: role,
+            description: description.trim() || undefined,
+            start_temporal: start ?? undefined,
+            end_temporal: end ?? undefined,
+          },
+        },
+        {
+          onSuccess: () => {
+            toast.success("Relationship updated.");
+            onSaved();
+            onClose();
+          },
+          onError: (err) => toast.error(errMsg(err)),
+        },
+      );
+      return;
+    }
+
+    createRel.mutate(
+      {
+        character_id: focalCharacterId,
+        related_character_id: other!.id,
+        relationship_type: type,
+        relationship_role: role,
+        description: description.trim() || undefined,
+        start_temporal: start ?? undefined,
+        end_temporal: end ?? undefined,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Relationship added.");
+          onSaved();
+          onClose();
+        },
+        onError: (err) => toast.error(errMsg(err)),
+      },
+    );
+  }
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+    >
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>
+            {isEdit ? "Edit relationship" : "Add relationship"}
+          </SheetTitle>
+          <SheetDescription>
+            From {focalCharacterName}&apos;s perspective. A reverse entry is
+            created automatically where the relationship type calls for one.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="space-y-6 py-4">
+          {/* Other character */}
+          <div className="space-y-1.5">
+            <Label>Other character</Label>
+            {isEdit ? (
+              <p className="rounded-md border border-border px-3 py-2 text-sm">
+                {other?.name}
+              </p>
+            ) : (
+              <OtherCharacterCombobox
+                client={client}
+                excludedIds={excludedIds}
+                value={other}
+                onChange={setOther}
+              />
+            )}
+          </div>
+
+          {/* Type + sub-role */}
+          {/* DECISION NEEDED (#335): wireframe 06 specifies a paired
+              directional sub-role control ("Marie is the [parent ▾] of X" +
+              inverse-pair hint). Per #57 we reuse the shipped flat-radio
+              RelationshipTypeSelector; the service still stores the correct
+              inverse. The directional-control fidelity is deferred to #335. */}
+          <div className="space-y-1.5">
+            <Label>Type</Label>
+            <RelationshipTypeSelector
+              type={type}
+              role={role}
+              onChange={(next) => {
+                setType(next.type);
+                setRole(next.role);
+              }}
+            />
+          </div>
+
+          {/* Temporal range */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <TemporalInput label="Start" value={start} onChange={setStart} />
+            <TemporalInput label="End" value={end} onChange={setEnd} />
+          </div>
+          <p className="-mt-3 text-xs text-muted-foreground">
+            Leave end empty for ongoing or unknown.
+          </p>
+
+          {/* Description */}
+          <div className="space-y-1.5">
+            <Label htmlFor="rel-description">Description</Label>
+            <Textarea
+              id="rel-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={`From ${focalCharacterName}'s perspective (optional)`}
+            />
+            <p className="text-xs text-muted-foreground">
+              The reverse entry is created with its description blank —
+              descriptions don&apos;t sync.
+            </p>
+          </div>
+        </div>
+
+        <SheetFooter>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={isPending}>
+            {isPending ? "Saving…" : "Save"}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : "Failed to save relationship";
+}
+
+// ---------------------------------------------------------------------------
+// Other-character combobox (Command inside a Popover).
+// ---------------------------------------------------------------------------
+
+function OtherCharacterCombobox({
+  client,
+  excludedIds,
+  value,
+  onChange,
+}: {
+  client: ServiceClient;
+  excludedIds: Set<string>;
+  value: OtherCharacter | null;
+  onChange: (next: OtherCharacter) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState("");
+  const [debounced, setDebounced] = React.useState("");
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(
+    () => () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    },
+    [],
+  );
+
+  function handleSearchChange(v: string) {
+    setSearch(v);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setDebounced(v), 300);
+  }
+
+  const { data: results = [], isFetching } = useQuery({
+    queryKey: ["character-search-relationship", debounced],
+    queryFn: () =>
+      getCharacters(client, {
+        search: debounced.length > 1 ? debounced : undefined,
+        pageSize: 20,
+      }),
+    enabled: open,
+    staleTime: 10_000,
+  });
+
+  const available = results.filter((c) => !excludedIds.has(c.id));
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="secondary"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          {value ? value.name : "Select a character…"}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[--radix-popover-trigger-width] p-0"
+        align="start"
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Search characters…"
+            value={search}
+            onValueChange={handleSearchChange}
+          />
+          <CommandList>
+            {isFetching && (
+              <div className="px-3 py-2 text-sm text-muted-foreground">
+                Searching…
+              </div>
+            )}
+            {!isFetching && (
+              <CommandEmpty>
+                {debounced.length > 1
+                  ? "No characters found."
+                  : "Type to search."}
+              </CommandEmpty>
+            )}
+            <CommandGroup>
+              {available.map((c) => (
+                <CommandItem
+                  key={c.id}
+                  value={c.id}
+                  onSelect={() => {
+                    onChange({
+                      id: c.id,
+                      name: c.name,
+                      characterType: c.character_type,
+                    });
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value?.id === c.id ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="flex-1 truncate">{c.name}</span>
+                  <span className="ml-2 text-xs capitalize text-muted-foreground">
+                    {c.character_type}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/admin/app/(protected)/characters/[slug]/_components/character-detail-client.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/_components/character-detail-client.tsx
@@ -80,10 +80,11 @@ export function CharacterDetailClient({
       url: string | null;
       alt: string | null;
     } | null> => {
+      if (!characterId) return null;
       const { data: junction, error: jError } = await client
         .from("character_media")
         .select("media_id")
-        .eq("character_id", characterId!)
+        .eq("character_id", characterId)
         .eq("is_primary", true)
         .maybeSingle();
       if (jError) throw jError;
@@ -326,6 +327,7 @@ export function CharacterDetailClient({
         <div className="rounded-md border border-destructive/30">
           <button
             type="button"
+            aria-expanded={showDangerZone}
             className="flex w-full items-center gap-2 px-4 py-3 text-sm text-destructive transition-colors hover:bg-destructive/5"
             onClick={() => setShowDangerZone((v) => !v)}
           >

--- a/apps/admin/app/(protected)/characters/[slug]/_components/character-detail-client.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/_components/character-detail-client.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ChevronDown, ChevronUp, MoreHorizontal } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "@repo/ui/components/sonner";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import { Button, buttonVariants } from "@repo/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@repo/ui/components/dropdown-menu";
+import { PublishControl } from "@repo/ui/components/publish-control";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@repo/ui/components/tabs";
+import {
+  useCharacterBySlug,
+  usePublishCharacter,
+  useUnpublishCharacter,
+  useDeleteCharacter,
+} from "@repo/ui/hooks/use-characters";
+import { getBrowserSupabaseClient } from "../../../../../lib/auth/browser-client";
+import {
+  CharacterTypeBadge,
+  CHARACTER_TYPE_ICON,
+  type CharacterType,
+} from "../../_components/character-type-badge";
+import { CharacterOverviewTab } from "./character-overview-tab";
+import { CharacterEventsTab } from "./character-events-tab";
+import { CharacterRelationshipsTab } from "./character-relationships-tab";
+import { CharacterMediaTab } from "./character-media-tab";
+
+const SIGNIFICANCE_LABEL: Record<string, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  critical: "Critical",
+};
+
+export function CharacterDetailClient({
+  userId,
+  slug,
+}: {
+  userId: string;
+  slug: string;
+}) {
+  const router = useRouter();
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+
+  const {
+    data: character,
+    isPending,
+    isError,
+  } = useCharacterBySlug(client, userId, slug);
+
+  // Primary media thumbnail for the header — the embedded character_media rows
+  // carry only ids, so resolve the primary item's URL separately.
+  const characterId = character?.id;
+  const { data: primaryMedia } = useQuery({
+    queryKey: ["character-primary-media", characterId],
+    queryFn: async (): Promise<{
+      url: string | null;
+      alt: string | null;
+    } | null> => {
+      const { data: junction, error: jError } = await client
+        .from("character_media")
+        .select("media_id")
+        .eq("character_id", characterId!)
+        .eq("is_primary", true)
+        .maybeSingle();
+      if (jError) throw jError;
+      if (!junction) return null;
+      const { data, error } = await client
+        .from("media")
+        .select("url, alt_text")
+        .eq("id", junction.media_id)
+        .maybeSingle();
+      if (error) throw error;
+      return data ? { url: data.url, alt: data.alt_text } : null;
+    },
+    enabled: !!characterId,
+    staleTime: 30_000,
+  });
+
+  const [tab, setTab] = React.useState("overview");
+  const [showDelete, setShowDelete] = React.useState(false);
+  const [showDangerZone, setShowDangerZone] = React.useState(false);
+
+  const publish = usePublishCharacter(client);
+  const unpublish = useUnpublishCharacter(client);
+  const deleteCharacter = useDeleteCharacter(client);
+
+  if (isPending) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-8 w-64 rounded-md" />
+        <Skeleton className="h-4 w-96 rounded-md" />
+        <Skeleton className="h-4 w-48 rounded-md" />
+        <div className="mt-6 space-y-2">
+          {[1, 2, 3, 4].map((step) => (
+            <Skeleton key={step} className="h-14 w-full rounded-md" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !character) {
+    return (
+      <div className="p-6 text-center space-y-4">
+        <p className="text-muted-foreground">Character not found.</p>
+        <Link
+          href="/characters"
+          className={buttonVariants({ variant: "secondary", size: "sm" })}
+        >
+          Back to characters
+        </Link>
+      </div>
+    );
+  }
+
+  const isOwner = character.user_id === userId;
+  const canEdit = isOwner;
+  const editHref = `/characters/${slug}/edit`;
+  const type = character.character_type as CharacterType;
+  const TypeIcon = CHARACTER_TYPE_ICON[type];
+  const birth = (character.birth_temporal as TemporalData | null) ?? null;
+  const death = (character.death_temporal as TemporalData | null) ?? null;
+
+  const relationshipCount = character.character_relationships.length;
+  const mediaCount = character.character_media.length;
+
+  return (
+    <div className="p-6 space-y-6 max-w-4xl">
+      {/* Header */}
+      <div className="flex items-start gap-4">
+        {/* Primary media thumbnail */}
+        <div className="shrink-0">
+          <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-md border border-border bg-muted text-muted-foreground">
+            {primaryMedia?.url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={primaryMedia.url}
+                alt={primaryMedia.alt ?? character.name}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <TypeIcon className="h-8 w-8" />
+            )}
+          </div>
+          {canEdit && (
+            <button
+              type="button"
+              onClick={() => setTab("media")}
+              className="mt-1 w-full text-center text-xs text-primary hover:underline"
+            >
+              Replace
+            </button>
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 space-y-1">
+              <h1 className="truncate text-2xl font-bold tracking-tight">
+                {character.name}
+              </h1>
+              <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                <CharacterTypeBadge type={type} />
+                {character.significance && (
+                  <span className="text-xs">
+                    {SIGNIFICANCE_LABEL[character.significance] ??
+                      character.significance}{" "}
+                    significance
+                  </span>
+                )}
+              </div>
+              <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                <span className="font-mono">{character.slug}</span>
+                {(birth || death) && <span>·</span>}
+                {(birth || death) && (
+                  <TemporalDisplay
+                    value={birth ?? (death as TemporalData)}
+                    endValue={birth && death ? death : undefined}
+                    format="inline"
+                  />
+                )}
+              </div>
+              {character.aliases && character.aliases.length > 0 && (
+                <p className="truncate text-xs text-muted-foreground">
+                  Also known as: {character.aliases.join(", ")}
+                </p>
+              )}
+              {character.cultural_context &&
+                character.cultural_context.length > 0 && (
+                  <p className="truncate text-xs text-muted-foreground">
+                    {character.cultural_context.join(" · ")}
+                  </p>
+                )}
+            </div>
+
+            <div className="flex shrink-0 items-center gap-2">
+              <PublishControl
+                published={character.published ?? false}
+                entityLabel="character"
+                canPublish={isOwner}
+                onPublish={() =>
+                  publish.mutate(character.id, {
+                    onSuccess: () => toast.success("Character published."),
+                    onError: (err) =>
+                      toast.error(
+                        err instanceof Error ? err.message : "Publish failed",
+                      ),
+                  })
+                }
+                onUnpublish={() =>
+                  unpublish.mutate(character.id, {
+                    onSuccess: () => toast.success("Character unpublished."),
+                    onError: (err) =>
+                      toast.error(
+                        err instanceof Error ? err.message : "Unpublish failed",
+                      ),
+                  })
+                }
+              />
+              {canEdit && (
+                <Link
+                  href={editHref}
+                  className={buttonVariants({
+                    variant: "secondary",
+                    size: "sm",
+                  })}
+                >
+                  Edit
+                </Link>
+              )}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0"
+                    aria-label="More actions"
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    onClick={() =>
+                      void navigator.clipboard.writeText(character.id)
+                    }
+                  >
+                    Copy ID
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="events">Events</TabsTrigger>
+          <TabsTrigger value="relationships">
+            Relationships ({relationshipCount})
+          </TabsTrigger>
+          <TabsTrigger value="media">Media ({mediaCount})</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="pt-4">
+          <CharacterOverviewTab character={character} editHref={editHref} />
+        </TabsContent>
+
+        <TabsContent value="events" className="pt-4">
+          <CharacterEventsTab
+            client={client}
+            characterId={character.id}
+            canEdit={canEdit}
+            birthTemporal={birth}
+            deathTemporal={death}
+          />
+        </TabsContent>
+
+        <TabsContent value="relationships" className="pt-4">
+          <CharacterRelationshipsTab
+            client={client}
+            characterId={character.id}
+            characterName={character.name}
+            canEdit={canEdit}
+          />
+        </TabsContent>
+
+        <TabsContent value="media" className="pt-4">
+          <CharacterMediaTab
+            client={client}
+            characterId={character.id}
+            canEdit={canEdit}
+          />
+        </TabsContent>
+      </Tabs>
+
+      {/* Danger zone */}
+      {isOwner && (
+        <div className="rounded-md border border-destructive/30">
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 px-4 py-3 text-sm text-destructive transition-colors hover:bg-destructive/5"
+            onClick={() => setShowDangerZone((v) => !v)}
+          >
+            {showDangerZone ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+            Danger zone
+          </button>
+          {showDangerZone && (
+            <div className="border-t border-destructive/20 px-4 pb-4 pt-1">
+              <p className="mb-3 text-xs text-muted-foreground">
+                Deleting a character is permanent and cannot be undone. All
+                relationships, event participation, and media associations will
+                be removed.
+              </p>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setShowDelete(true)}
+              >
+                Delete character
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Delete confirmation */}
+      <Dialog
+        open={showDelete}
+        onOpenChange={(o) => {
+          if (!o) setShowDelete(false);
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete character?</DialogTitle>
+            <DialogDescription>
+              <strong>{character.name}</strong> and all its junction data
+              (relationships, event participation, media links) will be
+              permanently deleted. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowDelete(false)}
+              disabled={deleteCharacter.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={deleteCharacter.isPending}
+              onClick={() =>
+                deleteCharacter.mutate(character.id, {
+                  onSuccess: () => {
+                    toast.success("Character deleted.");
+                    router.push("/characters");
+                  },
+                  onError: (err) =>
+                    toast.error(
+                      err instanceof Error ? err.message : "Delete failed",
+                    ),
+                })
+              }
+            >
+              {deleteCharacter.isPending ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/characters/[slug]/_components/character-events-tab.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/_components/character-events-tab.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import * as React from "react";
+import { ArrowDownUp, CornerRightDown, Plus } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import { getEvents } from "@repo/services/event-service";
+import { Badge } from "@repo/ui/components/badge";
+import { Button } from "@repo/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import { Input } from "@repo/ui/components/input";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { toast } from "@repo/ui/components/sonner";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+import {
+  useCharacterTimeline,
+  characterKeys,
+} from "@repo/ui/hooks/use-characters";
+import { useAddCharacterToEvent } from "@repo/ui/hooks/use-events";
+
+type ServiceClient = Parameters<typeof useCharacterTimeline>[0];
+
+interface CharacterEventsTabProps {
+  client: ServiceClient;
+  characterId: string;
+  canEdit: boolean;
+  /** Birth/death temporal markers that bookend the participation list. */
+  birthTemporal: TemporalData | null;
+  deathTemporal: TemporalData | null;
+}
+
+function humanize(value: string | null): string {
+  return value ? value.replace(/_/g, " ") : "";
+}
+
+// A non-clickable birth/death context marker framing the lifespan.
+function GhostMarker({ label, value }: { label: string; value: TemporalData }) {
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 text-xs text-muted-foreground italic">
+      <CornerRightDown className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span className="w-32 shrink-0">
+        <TemporalDisplay value={value} format="compact" />
+      </span>
+      <span>{label} (referenced)</span>
+    </div>
+  );
+}
+
+export function CharacterEventsTab({
+  client,
+  characterId,
+  canEdit,
+  birthTemporal,
+  deathTemporal,
+}: CharacterEventsTabProps) {
+  const {
+    data: rows = [],
+    isPending,
+    isError,
+    refetch,
+  } = useCharacterTimeline(client, characterId, {
+    enabled: !!characterId,
+  });
+
+  const [reverse, setReverse] = React.useState(false);
+  const [showAdd, setShowAdd] = React.useState(false);
+
+  // The view is already sorted chronologically (sort_order_years asc); reverse
+  // just flips it. Copy before reversing to avoid mutating the query cache.
+  const ordered = reverse ? [...rows].reverse() : rows;
+  const existingEventIds = React.useMemo(
+    () =>
+      new Set(rows.map((r) => r.event_id).filter((id): id is string => !!id)),
+    [rows],
+  );
+
+  if (isPending) {
+    return (
+      <div className="space-y-2 p-1">
+        {[1, 2, 3].map((step) => (
+          <Skeleton key={step} className="h-12 w-full rounded-md" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div
+        role="alert"
+        className="flex flex-col items-center gap-3 rounded-md border border-destructive/30 bg-destructive/10 p-8 text-center"
+      >
+        <p className="text-sm text-destructive">
+          Failed to load event participation.
+        </p>
+        <Button variant="secondary" size="sm" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm text-muted-foreground">
+          Participating events ({rows.length})
+        </p>
+        <div className="flex items-center gap-2">
+          {rows.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setReverse((v) => !v)}
+            >
+              <ArrowDownUp className="mr-1.5 h-4 w-4" />
+              {reverse ? "Reverse" : "Chronological"}
+            </Button>
+          )}
+          {canEdit && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => setShowAdd(true)}
+            >
+              <Plus className="mr-1.5 h-4 w-4" />
+              Add to event
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-12 text-center text-muted-foreground">
+          <p className="text-sm">
+            This character doesn&apos;t participate in any events yet.
+          </p>
+          {canEdit && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => setShowAdd(true)}
+            >
+              <Plus className="mr-1.5 h-4 w-4" />
+              Add to event
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-1">
+          {/* Birth marker bookends the top when chronological. */}
+          {!reverse && birthTemporal && (
+            <GhostMarker label="Birth" value={birthTemporal} />
+          )}
+          {reverse && deathTemporal && (
+            <GhostMarker label="Death" value={deathTemporal} />
+          )}
+
+          {ordered.map((row) => (
+            <div
+              key={row.event_id ?? `${row.event_title}`}
+              className="flex items-center gap-3 rounded-md border border-border bg-background px-4 py-3"
+            >
+              <div className="w-32 shrink-0 text-xs text-muted-foreground">
+                {row.temporal_data ? (
+                  <TemporalDisplay
+                    value={row.temporal_data as TemporalData}
+                    format="compact"
+                  />
+                ) : (
+                  "—"
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium">
+                  {row.event_title ?? "Untitled event"}
+                </span>
+              </div>
+              <div className="flex shrink-0 items-center gap-1.5">
+                {row.role && (
+                  <Badge variant="secondary" className="text-xs capitalize">
+                    {humanize(row.role)}
+                  </Badge>
+                )}
+                {row.significance && (
+                  <Badge variant="outline" className="text-xs capitalize">
+                    {humanize(row.significance)}
+                  </Badge>
+                )}
+              </div>
+            </div>
+          ))}
+
+          {!reverse && deathTemporal && (
+            <GhostMarker label="Death" value={deathTemporal} />
+          )}
+          {reverse && birthTemporal && (
+            <GhostMarker label="Birth" value={birthTemporal} />
+          )}
+        </div>
+      )}
+
+      <AddToEventDialog
+        open={showAdd}
+        onClose={() => setShowAdd(false)}
+        client={client}
+        characterId={characterId}
+        existingEventIds={existingEventIds}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add-to-event dialog — search an event and link this character to it.
+// Role/significance are set from the event editor; this just creates the
+// participation. Mirrors the timeline detail's LinkEventDialog.
+// ---------------------------------------------------------------------------
+
+interface AddToEventDialogProps {
+  open: boolean;
+  onClose: () => void;
+  client: ServiceClient;
+  characterId: string;
+  existingEventIds: Set<string>;
+}
+
+function AddToEventDialog({
+  open,
+  onClose,
+  client,
+  characterId,
+  existingEventIds,
+}: AddToEventDialogProps) {
+  const [search, setSearch] = React.useState("");
+  const [debounced, setDebounced] = React.useState("");
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queryClient = useQueryClient();
+  const addCharacter = useAddCharacterToEvent(client);
+
+  const [prevOpen, setPrevOpen] = React.useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (!open) {
+      setSearch("");
+      setDebounced("");
+    }
+  }
+
+  React.useEffect(
+    () => () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    },
+    [],
+  );
+
+  function handleSearchChange(v: string) {
+    setSearch(v);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setDebounced(v), 300);
+  }
+
+  const { data: results = [], isFetching } = useQuery({
+    queryKey: ["event-search-character-add", debounced],
+    queryFn: () =>
+      getEvents(client, {
+        search: debounced.length > 1 ? debounced : undefined,
+        pageSize: 20,
+      }),
+    enabled: open,
+    staleTime: 10_000,
+  });
+
+  const available = results.filter((e) => !existingEventIds.has(e.id));
+
+  function handleAdd(eventId: string) {
+    addCharacter.mutate(
+      { eventId, characterId },
+      {
+        onSuccess: () => {
+          void queryClient.invalidateQueries({
+            queryKey: characterKeys.timeline(characterId),
+          });
+          toast.success("Added to event.");
+          onClose();
+        },
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Failed to add to event",
+          ),
+      },
+    );
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add to an event</DialogTitle>
+          <DialogDescription>
+            Search for an event to add this character to as a participant. Set
+            the role and significance from the event editor.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Input
+          placeholder="Search events…"
+          value={search}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          autoFocus
+        />
+
+        <div className="mt-2 max-h-72 space-y-1 overflow-y-auto">
+          {isFetching && (
+            <div className="space-y-1">
+              {[1, 2, 3].map((step) => (
+                <Skeleton key={step} className="h-10 w-full rounded" />
+              ))}
+            </div>
+          )}
+          {!isFetching && available.length === 0 && (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              {debounced.length > 1
+                ? "No matching events found."
+                : "Type to search events."}
+            </p>
+          )}
+          {available.map((event) => (
+            <button
+              key={event.id}
+              type="button"
+              disabled={addCharacter.isPending}
+              onClick={() => handleAdd(event.id)}
+              className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-left hover:bg-muted disabled:opacity-50"
+            >
+              <span className="flex-1 truncate text-sm">{event.title}</span>
+              {event.event_type && (
+                <Badge
+                  variant="outline"
+                  className="shrink-0 text-xs capitalize"
+                >
+                  {event.event_type}
+                </Badge>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/app/(protected)/characters/[slug]/_components/character-media-tab.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/_components/character-media-tab.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import * as React from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@repo/ui/components/sonner";
+import {
+  MediaSection,
+  type AttachedMedia,
+} from "../../../_components/media/media-section";
+import {
+  useAddMediaToCharacter,
+  useRemoveMediaFromCharacter,
+  useSetPrimaryCharacterMedia,
+} from "@repo/ui/hooks/use-characters";
+import { getBrowserSupabaseClient } from "../../../../../lib/auth/browser-client";
+
+type ServiceClient = ReturnType<typeof getBrowserSupabaseClient>;
+
+const EMPTY: AttachedMedia[] = [];
+
+interface CharacterMediaTabProps {
+  client: ServiceClient;
+  characterId: string;
+  canEdit: boolean;
+}
+
+export function CharacterMediaTab({
+  client,
+  characterId,
+  canEdit,
+}: CharacterMediaTabProps) {
+  const queryClient = useQueryClient();
+  const mediaQueryKey = ["character-media-details", characterId] as const;
+
+  const {
+    data: items = EMPTY,
+    isPending,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: mediaQueryKey,
+    queryFn: async (): Promise<AttachedMedia[]> => {
+      const { data: junctions, error: jError } = await client
+        .from("character_media")
+        .select("media_id, is_primary")
+        .eq("character_id", characterId);
+      if (jError) throw jError;
+      if (!junctions?.length) return [];
+      const ids = junctions.map((j) => j.media_id);
+      const { data, error } = await client
+        .from("media")
+        .select("id, alt_text, caption, media_type, url, source")
+        .in("id", ids);
+      if (error) throw error;
+      const byId = new Map((data ?? []).map((m) => [m.id, m]));
+      return (
+        junctions
+          .map((j): AttachedMedia | null => {
+            const m = byId.get(j.media_id);
+            if (!m) return null;
+            return {
+              id: m.id,
+              alt_text: m.alt_text,
+              caption: m.caption,
+              media_type: m.media_type,
+              url: m.url,
+              source: m.source,
+              // Character media has no sort_order — ordering is primary-only.
+              sort_order: null,
+              is_primary: j.is_primary ?? false,
+            };
+          })
+          .filter((m): m is AttachedMedia => m !== null)
+          // Primary first, then stable.
+          .sort((a, b) => Number(b.is_primary) - Number(a.is_primary))
+      );
+    },
+    enabled: !!characterId,
+    staleTime: 30_000,
+  });
+
+  const addMedia = useAddMediaToCharacter(client);
+  const removeMedia = useRemoveMediaFromCharacter(client);
+  const setPrimary = useSetPrimaryCharacterMedia(client);
+
+  async function refreshMedia() {
+    await queryClient.invalidateQueries({ queryKey: mediaQueryKey });
+  }
+
+  // First attached item becomes primary when the character has none yet.
+  async function handleAttach(mediaId: string) {
+    const isFirst = items.length === 0;
+    await addMedia.mutateAsync({ characterId, mediaId, isPrimary: isFirst });
+    await refreshMedia();
+  }
+
+  async function handleAttachExisting(mediaIds: string[]) {
+    const hadNone = items.length === 0;
+    await Promise.all(
+      mediaIds.map((mediaId, i) =>
+        addMedia.mutateAsync({
+          characterId,
+          mediaId,
+          isPrimary: hadNone && i === 0,
+        }),
+      ),
+    );
+    await refreshMedia();
+  }
+
+  async function handleDetach(mediaId: string) {
+    await removeMedia.mutateAsync({ characterId, mediaId });
+    await refreshMedia();
+  }
+
+  async function handleSetPrimary(mediaId: string) {
+    try {
+      await setPrimary.mutateAsync({ characterId, mediaId });
+      await refreshMedia();
+      toast.success("Primary image updated.");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to set primary image",
+      );
+      await refreshMedia();
+    }
+  }
+
+  return (
+    <MediaSection
+      client={client}
+      items={items}
+      isLoading={isPending}
+      isError={isError}
+      onRetry={() => void refetch()}
+      canEdit={canEdit}
+      ordering="primary"
+      onAttach={handleAttach}
+      onAttachExisting={handleAttachExisting}
+      onDetach={handleDetach}
+      onSetPrimary={handleSetPrimary}
+      onChanged={refreshMedia}
+    />
+  );
+}

--- a/apps/admin/app/(protected)/characters/[slug]/_components/character-overview-tab.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/_components/character-overview-tab.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import type { CharacterWithRelations } from "@repo/services/character-service";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+import { livedYears } from "../../_components/character-detail-helpers";
+
+/** Birth/Death labels adapt to the character type (mirrors the editor form). */
+function temporalLabels(type: string): { birth: string; death: string } {
+  if (type === "organization") return { birth: "Founded", death: "Dissolved" };
+  if (type === "artifact") return { birth: "Created", death: "Destroyed" };
+  return { birth: "Birth", death: "Death" };
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold text-foreground border-b border-border pb-1">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+/** A label/value row; renders a muted "Add …" edit link when the value is empty. */
+function Field({
+  label,
+  value,
+  addHref,
+  addLabel,
+}: {
+  label: string;
+  value?: React.ReactNode;
+  addHref?: string;
+  addLabel?: string;
+}) {
+  return (
+    <div className="flex gap-3 text-sm">
+      <span className="w-32 shrink-0 text-muted-foreground">{label}</span>
+      {value != null && value !== "" ? (
+        <span className="min-w-0 flex-1">{value}</span>
+      ) : addHref ? (
+        <Link href={addHref} className="text-primary hover:underline text-sm">
+          {addLabel ?? `Add ${label.toLowerCase()}`}
+        </Link>
+      ) : (
+        <span className="min-w-0 flex-1 text-muted-foreground">—</span>
+      )}
+    </div>
+  );
+}
+
+function profileString(
+  profile: Record<string, unknown> | null,
+  key: string,
+): string | undefined {
+  const v = profile?.[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/** Type-specific detail rows, driven by the character_type. */
+function TypeDetails({ character }: { character: CharacterWithRelations }) {
+  const profile = (character.profile_data as Record<string, unknown>) ?? null;
+  const rows: Array<{ label: string; value?: string }> = [];
+
+  switch (character.character_type) {
+    case "animal":
+      rows.push(
+        { label: "Species", value: character.species ?? undefined },
+        { label: "Breed", value: character.breed ?? undefined },
+        {
+          label: "Conservation",
+          value: profileString(profile, "conservation_status")?.replace(
+            /_/g,
+            " ",
+          ),
+        },
+      );
+      break;
+    case "divine":
+      rows.push(
+        { label: "Domain", value: character.domain ?? undefined },
+        { label: "Pantheon", value: profileString(profile, "pantheon") },
+        {
+          label: "Worship period",
+          value: profileString(profile, "worship_period"),
+        },
+      );
+      break;
+    case "mythological":
+      rows.push(
+        { label: "Domain", value: character.domain ?? undefined },
+        { label: "Mythology", value: profileString(profile, "mythology") },
+      );
+      break;
+    case "human":
+      rows.push(
+        { label: "Nationality", value: profileString(profile, "nationality") },
+        { label: "Occupation", value: profileString(profile, "occupation") },
+      );
+      break;
+    case "fictional":
+      rows.push(
+        { label: "Source work", value: profileString(profile, "source_work") },
+        { label: "Author", value: profileString(profile, "author") },
+        { label: "Genre", value: profileString(profile, "genre") },
+      );
+      break;
+    case "organization":
+      rows.push(
+        { label: "Type", value: profileString(profile, "org_type") },
+        {
+          label: "Headquarters",
+          value: profileString(profile, "headquarters"),
+        },
+      );
+      break;
+    case "artifact":
+      rows.push(
+        { label: "Type", value: profileString(profile, "artifact_type") },
+        { label: "Material", value: profileString(profile, "material") },
+        {
+          label: "Location",
+          value: profileString(profile, "current_location"),
+        },
+      );
+      break;
+  }
+
+  if (rows.every((r) => !r.value)) return null;
+
+  return (
+    <Section title="Details">
+      <div className="space-y-1.5">
+        {rows
+          .filter((r) => r.value)
+          .map((r) => (
+            <Field key={r.label} label={r.label} value={r.value} />
+          ))}
+      </div>
+    </Section>
+  );
+}
+
+export function CharacterOverviewTab({
+  character,
+  editHref,
+}: {
+  character: CharacterWithRelations;
+  editHref: string;
+}) {
+  const birth = (character.birth_temporal as TemporalData | null) ?? null;
+  const death = (character.death_temporal as TemporalData | null) ?? null;
+  const labels = temporalLabels(character.character_type);
+  const lived = livedYears(birth, death);
+
+  function formatDate(value: string | null): string {
+    if (!value) return "—";
+    return new Date(value).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <Section title="Biography">
+        {character.biography ? (
+          <p className="text-sm whitespace-pre-wrap text-foreground">
+            {character.biography}
+          </p>
+        ) : (
+          <Link
+            href={editHref}
+            className="text-sm text-primary hover:underline"
+          >
+            Add biography
+          </Link>
+        )}
+      </Section>
+
+      <Section title="Physical description">
+        {character.physical_description ? (
+          <p className="text-sm whitespace-pre-wrap text-foreground">
+            {character.physical_description}
+          </p>
+        ) : (
+          <Link
+            href={editHref}
+            className="text-sm text-primary hover:underline"
+          >
+            Add physical description
+          </Link>
+        )}
+      </Section>
+
+      <Section title="Temporal scope">
+        <div className="space-y-1.5">
+          <Field
+            label={labels.birth}
+            value={
+              birth ? (
+                <TemporalDisplay value={birth} format="inline" />
+              ) : undefined
+            }
+            addHref={editHref}
+            addLabel={`Add ${labels.birth.toLowerCase()} date`}
+          />
+          <Field
+            label={labels.death}
+            value={
+              death ? (
+                <TemporalDisplay value={death} format="inline" />
+              ) : (
+                "ongoing"
+              )
+            }
+          />
+          {lived != null && (
+            <p className="text-sm text-muted-foreground pt-1">
+              Lived {lived} year{lived === 1 ? "" : "s"}.
+            </p>
+          )}
+        </div>
+      </Section>
+
+      <TypeDetails character={character} />
+
+      <Section title="Metadata">
+        <div className="space-y-1.5">
+          <Field label="Created" value={formatDate(character.created_at)} />
+          <Field label="Updated" value={formatDate(character.updated_at)} />
+          <Field label="Slug" value={character.slug} />
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/characters/[slug]/_components/character-relationships-tab.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/_components/character-relationships-tab.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDown, ChevronRight, Plus } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import { Button } from "@repo/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import { RelationshipCard } from "@repo/ui/components/relationship-card";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { toast } from "@repo/ui/components/sonner";
+import { getBrowserSupabaseClient } from "../../../../../lib/auth/browser-client";
+import {
+  useCharacterRelationships,
+  useDeleteRelationship,
+} from "@repo/ui/hooks/use-character-relationships";
+import type { RelationshipType } from "@repo/ui/components/relationship-type-selector";
+import {
+  directionLabel,
+  groupRelationshipsByFamily,
+  initials,
+  otherCharacterId,
+  type RelationshipLike,
+} from "../../_components/character-detail-helpers";
+import {
+  AddRelationshipSheet,
+  type RelationshipEditTarget,
+} from "./add-relationship-sheet";
+
+type ServiceClient = ReturnType<typeof getBrowserSupabaseClient>;
+
+interface OtherCharacterInfo {
+  id: string;
+  name: string;
+  slug: string;
+  character_type: string;
+}
+
+interface CharacterRelationshipsTabProps {
+  client: ServiceClient;
+  characterId: string;
+  characterName: string;
+  canEdit: boolean;
+}
+
+export function CharacterRelationshipsTab({
+  client,
+  characterId,
+  characterName,
+  canEdit,
+}: CharacterRelationshipsTabProps) {
+  const {
+    data: relationships = [],
+    isPending,
+    isError,
+    refetch,
+  } = useCharacterRelationships(
+    client,
+    characterId,
+    {},
+    { enabled: !!characterId },
+  );
+
+  const deleteRel = useDeleteRelationship(client);
+
+  // Resolve the names/types of the characters on the other end of each edge.
+  const otherIds = React.useMemo(() => {
+    const ids = new Set<string>();
+    for (const rel of relationships) {
+      ids.add(otherCharacterId(rel, characterId));
+    }
+    return [...ids];
+  }, [relationships, characterId]);
+
+  const { data: otherChars = [] } = useQuery({
+    queryKey: ["relationship-other-characters", characterId, otherIds],
+    queryFn: async (): Promise<OtherCharacterInfo[]> => {
+      if (otherIds.length === 0) return [];
+      const { data, error } = await client
+        .from("characters")
+        .select("id, name, slug, character_type")
+        .in("id", otherIds);
+      if (error) throw error;
+      return (data ?? []) as OtherCharacterInfo[];
+    },
+    enabled: otherIds.length > 0,
+    staleTime: 60_000,
+  });
+
+  const nameById = React.useMemo(() => {
+    const map = new Map<string, OtherCharacterInfo>();
+    for (const c of otherChars) map.set(c.id, c);
+    return map;
+  }, [otherChars]);
+
+  const groups = React.useMemo(
+    () => groupRelationshipsByFamily(relationships as RelationshipLike[]),
+    [relationships],
+  );
+
+  // Collapsible group state — all expanded by default.
+  const [collapsed, setCollapsed] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+  function toggleGroup(key: string) {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  // Sheet + delete state.
+  const [sheetOpen, setSheetOpen] = React.useState(false);
+  const [editing, setEditing] = React.useState<RelationshipEditTarget | null>(
+    null,
+  );
+  const [initialOther, setInitialOther] = React.useState<{
+    id: string;
+    name: string;
+    characterType: string;
+  } | null>(null);
+  const [deleteTarget, setDeleteTarget] =
+    React.useState<RelationshipLike | null>(null);
+
+  const existingLinks = React.useMemo(
+    () =>
+      relationships.map((rel) => ({
+        otherId: otherCharacterId(rel, characterId),
+        type: rel.relationship_type,
+      })),
+    [relationships, characterId],
+  );
+
+  function openAdd() {
+    setEditing(null);
+    setInitialOther(null);
+    setSheetOpen(true);
+  }
+
+  function openEdit(rel: RelationshipLike) {
+    const otherId = otherCharacterId(rel, characterId);
+    setEditing({
+      id: rel.id,
+      otherId,
+      otherName: nameById.get(otherId)?.name ?? "Unknown character",
+      type: rel.relationship_type as RelationshipType,
+      role: rel.relationship_role,
+      description: rel.description,
+      startTemporal: (rel.start_temporal as TemporalData | null) ?? null,
+      endTemporal: (rel.end_temporal as TemporalData | null) ?? null,
+    });
+    setInitialOther(null);
+    setSheetOpen(true);
+  }
+
+  function openDuplicate(rel: RelationshipLike) {
+    const otherId = otherCharacterId(rel, characterId);
+    const info = nameById.get(otherId);
+    setEditing(null);
+    setInitialOther({
+      id: otherId,
+      name: info?.name ?? "Unknown character",
+      characterType: info?.character_type ?? "",
+    });
+    setSheetOpen(true);
+  }
+
+  function confirmDelete() {
+    if (!deleteTarget) return;
+    deleteRel.mutate(deleteTarget.id, {
+      onSuccess: () => {
+        toast.success("Relationship deleted.");
+        setDeleteTarget(null);
+        void refetch();
+      },
+      onError: (err) =>
+        toast.error(
+          err instanceof Error ? err.message : "Failed to delete relationship",
+        ),
+    });
+  }
+
+  if (isPending) {
+    return (
+      <div className="space-y-2 p-1">
+        {[1, 2, 3].map((step) => (
+          <Skeleton key={step} className="h-24 w-full rounded-md" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div
+        role="alert"
+        className="flex flex-col items-center gap-3 rounded-md border border-destructive/30 bg-destructive/10 p-8 text-center"
+      >
+        <p className="text-sm text-destructive">
+          Failed to load relationships.
+        </p>
+        <Button variant="secondary" size="sm" onClick={() => void refetch()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm text-muted-foreground">
+          Relationships ({relationships.length})
+        </p>
+        {canEdit && (
+          <Button size="sm" variant="secondary" onClick={openAdd}>
+            <Plus className="mr-1.5 h-4 w-4" />
+            Add relationship
+          </Button>
+        )}
+      </div>
+
+      {relationships.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-12 text-center text-muted-foreground">
+          <p className="text-sm">No relationships yet.</p>
+          {canEdit && (
+            <Button size="sm" variant="secondary" onClick={openAdd}>
+              <Plus className="mr-1.5 h-4 w-4" />
+              Add relationship
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {groups.map((group) => {
+            const isCollapsed = collapsed.has(group.key);
+            return (
+              <div key={group.key} className="space-y-2">
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(group.key)}
+                  className="flex w-full items-center gap-1.5 text-sm font-semibold text-foreground"
+                >
+                  {isCollapsed ? (
+                    <ChevronRight className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                  {group.legend}
+                  <span className="text-muted-foreground">
+                    ({group.items.length})
+                  </span>
+                </button>
+
+                {!isCollapsed && (
+                  <div className="space-y-2">
+                    {group.items.map((rel) => {
+                      const otherId = otherCharacterId(rel, characterId);
+                      const info = nameById.get(otherId);
+                      const otherName = info?.name ?? "Unknown character";
+                      // Direction narrative reads off the stored row's own
+                      // subject (character_id) → object (related_character_id).
+                      const subjectName =
+                        rel.character_id === characterId
+                          ? characterName
+                          : otherName;
+                      const objectName =
+                        rel.character_id === characterId
+                          ? otherName
+                          : characterName;
+                      return (
+                        <RelationshipCard
+                          key={rel.id}
+                          otherCharacter={{
+                            name: otherName,
+                            slug: info?.slug ?? "",
+                            characterType: info?.character_type ?? "",
+                            initials: initials(otherName),
+                          }}
+                          relationshipType={rel.relationship_type}
+                          relationshipRole={rel.relationship_role}
+                          startTemporal={
+                            (rel.start_temporal as TemporalData | null) ?? null
+                          }
+                          endTemporal={
+                            (rel.end_temporal as TemporalData | null) ?? null
+                          }
+                          description={rel.description}
+                          directionLabel={directionLabel(rel, {
+                            subjectName,
+                            objectName,
+                          })}
+                          onEdit={canEdit ? () => openEdit(rel) : undefined}
+                          onDuplicate={
+                            canEdit ? () => openDuplicate(rel) : undefined
+                          }
+                          onDelete={
+                            canEdit ? () => setDeleteTarget(rel) : undefined
+                          }
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <AddRelationshipSheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        client={client}
+        focalCharacterId={characterId}
+        focalCharacterName={characterName}
+        existingLinks={existingLinks}
+        editing={editing}
+        initialOther={initialOther}
+        onSaved={() => void refetch()}
+      />
+
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(o) => {
+          if (!o) setDeleteTarget(null);
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete relationship?</DialogTitle>
+            <DialogDescription>
+              This deletes the relationship and its automatically-created
+              reverse entry. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setDeleteTarget(null)}
+              disabled={deleteRel.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={confirmDelete}
+              disabled={deleteRel.isPending}
+            >
+              {deleteRel.isPending ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/characters/[slug]/_components/character-relationships-tab.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/_components/character-relationships-tab.tsx
@@ -247,6 +247,7 @@ export function CharacterRelationshipsTab({
               <div key={group.key} className="space-y-2">
                 <button
                   type="button"
+                  aria-expanded={!isCollapsed}
                   onClick={() => toggleGroup(group.key)}
                   className="flex w-full items-center gap-1.5 text-sm font-semibold text-foreground"
                 >

--- a/apps/admin/app/(protected)/characters/[slug]/page.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/page.tsx
@@ -1,0 +1,45 @@
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { getUser } from "../../../../lib/auth";
+import { getServerSupabaseClient } from "../../../auth/_lib/server-supabase";
+import { CharacterDetailClient } from "./_components/character-detail-client";
+
+export const metadata = {
+  title: "Character",
+};
+
+export default async function CharacterDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  // Resolve the owner id server-side (session already validated by the
+  // protected layout) so the client hook can build its (userId, slug) query
+  // key on first render without an auth round-trip / loading flash. Mirrors
+  // the character editor's edit/page.tsx.
+  const client = await getServerSupabaseClient();
+  const user = await getUser(client);
+  if (!user) redirect("/auth/login");
+
+  return (
+    <Suspense
+      fallback={
+        <div className="p-6 space-y-4">
+          <Skeleton className="h-8 w-64 rounded-md" />
+          <Skeleton className="h-4 w-96 rounded-md" />
+          <Skeleton className="h-4 w-32 rounded-md" />
+          <div className="mt-6 space-y-2">
+            {[1, 2, 3, 4].map((step) => (
+              <Skeleton key={step} className="h-14 w-full rounded-md" />
+            ))}
+          </div>
+        </div>
+      }
+    >
+      <CharacterDetailClient userId={user.id} slug={slug} />
+    </Suspense>
+  );
+}

--- a/apps/admin/app/(protected)/characters/_components/character-detail-helpers.test.ts
+++ b/apps/admin/app/(protected)/characters/_components/character-detail-helpers.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import {
+  directionLabel,
+  familyForType,
+  groupRelationshipsByFamily,
+  initials,
+  livedYears,
+  otherCharacterId,
+  type RelationshipLike,
+} from "./character-detail-helpers";
+
+function rel(overrides: Partial<RelationshipLike> = {}): RelationshipLike {
+  return {
+    id: "r1",
+    character_id: "a",
+    related_character_id: "b",
+    relationship_type: "family",
+    relationship_role: null,
+    start_temporal: null,
+    end_temporal: null,
+    description: null,
+    ...overrides,
+  };
+}
+
+const ce = (year: number): TemporalData => ({
+  year,
+  era: "CE",
+  precision: "exact",
+});
+
+describe("familyForType", () => {
+  it("maps each type to its wireframe family", () => {
+    expect(familyForType("family")).toBe("family");
+    expect(familyForType("professional")).toBe("professional");
+    expect(familyForType("collaboration")).toBe("professional");
+    expect(familyForType("friendship")).toBe("social");
+    expect(familyForType("rivalry")).toBe("social");
+    expect(familyForType("enemy")).toBe("antagonistic");
+    expect(familyForType("mentor_student")).toBe("asymmetric");
+    expect(familyForType("worship")).toBe("asymmetric");
+  });
+
+  it("falls back to social for unknown types", () => {
+    expect(familyForType("nonsense")).toBe("social");
+  });
+});
+
+describe("otherCharacterId", () => {
+  it("returns the non-focal end regardless of column position", () => {
+    expect(
+      otherCharacterId({ character_id: "a", related_character_id: "b" }, "a"),
+    ).toBe("b");
+    expect(
+      otherCharacterId({ character_id: "a", related_character_id: "b" }, "b"),
+    ).toBe("a");
+  });
+});
+
+describe("groupRelationshipsByFamily", () => {
+  it("groups into families in canonical order, dropping empty families", () => {
+    const groups = groupRelationshipsByFamily([
+      rel({ id: "1", relationship_type: "enemy" }),
+      rel({ id: "2", relationship_type: "family" }),
+      rel({ id: "3", relationship_type: "collaboration" }),
+    ]);
+    expect(groups.map((g) => g.key)).toEqual([
+      "family",
+      "professional",
+      "antagonistic",
+    ]);
+    expect(groups[0]!.items.map((i) => i.id)).toEqual(["2"]);
+    expect(groups[1]!.items.map((i) => i.id)).toEqual(["3"]);
+  });
+
+  it("preserves input order within a family", () => {
+    const groups = groupRelationshipsByFamily([
+      rel({ id: "x", relationship_type: "professional" }),
+      rel({ id: "y", relationship_type: "collaboration" }),
+    ]);
+    expect(groups[0]!.items.map((i) => i.id)).toEqual(["x", "y"]);
+  });
+
+  it("returns an empty array when there are no relationships", () => {
+    expect(groupRelationshipsByFamily([])).toEqual([]);
+  });
+});
+
+describe("directionLabel", () => {
+  const names = { subjectName: "Marie", objectName: "Irène" };
+
+  it("renders a verb phrase for asymmetric types", () => {
+    expect(
+      directionLabel(
+        {
+          relationship_type: "mentor_student",
+          relationship_role: null,
+          character_id: "a",
+        },
+        names,
+      ),
+    ).toBe("Marie mentors Irène");
+    expect(
+      directionLabel(
+        {
+          relationship_type: "worship",
+          relationship_role: null,
+          character_id: "a",
+        },
+        names,
+      ),
+    ).toBe("Marie worships Irène");
+  });
+
+  it("renders the role for directional paired roles", () => {
+    expect(
+      directionLabel(
+        {
+          relationship_type: "family",
+          relationship_role: "parent",
+          character_id: "a",
+        },
+        names,
+      ),
+    ).toBe("Marie is the parent of Irène");
+    expect(
+      directionLabel(
+        {
+          relationship_type: "professional",
+          relationship_role: "employer",
+          character_id: "a",
+        },
+        names,
+      ),
+    ).toBe("Marie is the employer of Irène");
+  });
+
+  it("humanizes underscored roles", () => {
+    expect(
+      directionLabel(
+        {
+          relationship_type: "family",
+          relationship_role: "aunt_uncle",
+          character_id: "a",
+        },
+        names,
+      ),
+    ).toBe("Marie is the aunt uncle of Irène");
+  });
+
+  it("returns undefined for symmetric roles and type-only symmetric relationships", () => {
+    expect(
+      directionLabel(
+        {
+          relationship_type: "family",
+          relationship_role: "spouse",
+          character_id: "a",
+        },
+        names,
+      ),
+    ).toBeUndefined();
+    expect(
+      directionLabel(
+        {
+          relationship_type: "friendship",
+          relationship_role: null,
+          character_id: "a",
+        },
+        names,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("initials", () => {
+  it("builds up to two initials", () => {
+    expect(initials("Marie Curie")).toBe("MC");
+    expect(initials("Cher")).toBe("CH");
+    expect(initials("Marie Skłodowska Curie")).toBe("MC");
+  });
+
+  it("handles empty input", () => {
+    expect(initials("   ")).toBe("?");
+  });
+});
+
+describe("livedYears", () => {
+  it("computes whole years between CE dates", () => {
+    expect(livedYears(ce(1867), ce(1934))).toBe(67);
+  });
+
+  it("spans BCE→CE", () => {
+    expect(
+      livedYears({ year: 100, era: "BCE", precision: "exact" }, ce(44)),
+    ).toBe(144);
+  });
+
+  it("returns null when a bound is missing", () => {
+    expect(livedYears(null, ce(1934))).toBeNull();
+    expect(livedYears(ce(1867), undefined)).toBeNull();
+  });
+
+  it("returns null for geological eras", () => {
+    expect(
+      livedYears(
+        { year: 3, era: "MYA", precision: "exact" },
+        { year: 1, era: "MYA", precision: "exact" },
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when death precedes birth", () => {
+    expect(livedYears(ce(1934), ce(1867))).toBeNull();
+  });
+});

--- a/apps/admin/app/(protected)/characters/_components/character-detail-helpers.test.ts
+++ b/apps/admin/app/(protected)/characters/_components/character-detail-helpers.test.ts
@@ -149,7 +149,7 @@ describe("directionLabel", () => {
     ).toBe("Marie is the aunt uncle of Irène");
   });
 
-  it("returns undefined for symmetric roles and type-only symmetric relationships", () => {
+  it("renders symmetric sub-roles as an 'is the <role> of' phrase", () => {
     expect(
       directionLabel(
         {
@@ -159,7 +159,10 @@ describe("directionLabel", () => {
         },
         names,
       ),
-    ).toBeUndefined();
+    ).toBe("Marie is the spouse of Irène");
+  });
+
+  it("renders type-only symmetric relationships as a plural noun phrase", () => {
     expect(
       directionLabel(
         {
@@ -169,7 +172,30 @@ describe("directionLabel", () => {
         },
         names,
       ),
-    ).toBeUndefined();
+    ).toBe("Marie and Irène are friends");
+    expect(
+      directionLabel(
+        {
+          relationship_type: "enemy",
+          relationship_role: null,
+          character_id: "a",
+        },
+        names,
+      ),
+    ).toBe("Marie and Irène are enemies");
+  });
+
+  it("treats the 'other' role as type-only (no 'is the other of' phrasing)", () => {
+    expect(
+      directionLabel(
+        {
+          relationship_type: "collaboration",
+          relationship_role: "other",
+          character_id: "a",
+        },
+        names,
+      ),
+    ).toBe("Marie and Irène are collaborators");
   });
 });
 

--- a/apps/admin/app/(protected)/characters/_components/character-detail-helpers.ts
+++ b/apps/admin/app/(protected)/characters/_components/character-detail-helpers.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure helpers for the Character detail page — grouping relationships by type
+ * family, computing narrative direction labels, and small display utilities.
+ * Kept free of React/Supabase so they can be unit-tested in isolation.
+ */
+import { TemporalService } from "@repo/services/modules/temporal-service";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+
+/**
+ * A minimally-typed relationship row — the fields the detail page reads off a
+ * `character_relationships` row. Kept structural so both the generated row type
+ * and test fixtures satisfy it.
+ */
+export interface RelationshipLike {
+  id: string;
+  character_id: string;
+  related_character_id: string;
+  relationship_type: string;
+  relationship_role: string | null;
+  start_temporal: unknown;
+  end_temporal: unknown;
+  description: string | null;
+}
+
+/**
+ * Relationship-type → family grouping for the collapsible Relationships tab.
+ * Mirrors `TYPE_FAMILIES` in `@repo/ui/components/relationship-type-selector`
+ * so the read view and the add sheet agree on where each type lives.
+ */
+export const RELATIONSHIP_FAMILIES = [
+  { key: "family", legend: "Family", types: ["family"] },
+  {
+    key: "professional",
+    legend: "Professional",
+    types: ["professional", "collaboration"],
+  },
+  {
+    key: "social",
+    legend: "Social / Personal",
+    types: ["friendship", "rivalry"],
+  },
+  { key: "antagonistic", legend: "Antagonistic", types: ["enemy"] },
+  {
+    key: "asymmetric",
+    legend: "Asymmetric",
+    types: [
+      "mentor_student",
+      "owner_pet",
+      "trainer_trainee",
+      "creator_creation",
+      "worship",
+    ],
+  },
+] as const;
+
+export type RelationshipFamilyKey =
+  (typeof RELATIONSHIP_FAMILIES)[number]["key"];
+
+const TYPE_TO_FAMILY: Record<string, RelationshipFamilyKey> =
+  Object.fromEntries(
+    RELATIONSHIP_FAMILIES.flatMap((f) => f.types.map((t) => [t, f.key])),
+  ) as Record<string, RelationshipFamilyKey>;
+
+/** Family key for a relationship type; falls back to "social" for unknowns. */
+export function familyForType(type: string): RelationshipFamilyKey {
+  return TYPE_TO_FAMILY[type] ?? "social";
+}
+
+/** The id of the character on the other end of a relationship from `focalId`. */
+export function otherCharacterId(
+  rel: Pick<RelationshipLike, "character_id" | "related_character_id">,
+  focalId: string,
+): string {
+  return rel.character_id === focalId
+    ? rel.related_character_id
+    : rel.character_id;
+}
+
+/**
+ * Groups relationships into families, preserving the input order within each
+ * family. Only families that have at least one relationship are returned, in
+ * the canonical `RELATIONSHIP_FAMILIES` order.
+ */
+export function groupRelationshipsByFamily<T extends RelationshipLike>(
+  relationships: T[],
+): Array<{ key: RelationshipFamilyKey; legend: string; items: T[] }> {
+  return RELATIONSHIP_FAMILIES.map((family) => ({
+    key: family.key,
+    legend: family.legend,
+    items: relationships.filter(
+      (rel) => familyForType(rel.relationship_type) === family.key,
+    ),
+  })).filter((group) => group.items.length > 0);
+}
+
+const humanize = (value: string): string => value.replace(/_/g, " ");
+
+/** Verb phrases for the five asymmetric types (subject → object). */
+const ASYMMETRIC_VERB: Record<string, string> = {
+  mentor_student: "mentors",
+  owner_pet: "owns",
+  trainer_trainee: "trains",
+  creator_creation: "created",
+  worship: "worships",
+};
+
+/** Sub-roles whose reciprocal differs from themselves (directional pairs). */
+const DIRECTIONAL_ROLES: ReadonlySet<string> = new Set([
+  "parent",
+  "child",
+  "grandparent",
+  "grandchild",
+  "aunt_uncle",
+  "niece_nephew",
+  "step_parent",
+  "step_child",
+  "adoptive_parent",
+  "adoptive_child",
+  "employer",
+  "employee",
+  "supervisor",
+  "subordinate",
+  "client",
+  "vendor",
+]);
+
+/**
+ * Narrative direction line for a relationship ("Marie is the parent of Irène",
+ * "Marie mentors Pierre"). Rendered from the stored row's own subject/object
+ * (character_id → related_character_id), so it reads correctly regardless of
+ * which end is the focal character. Returns `undefined` when there's no
+ * directional narrative worth showing (symmetric type with no directional role).
+ */
+export function directionLabel(
+  rel: Pick<
+    RelationshipLike,
+    "relationship_type" | "relationship_role" | "character_id"
+  >,
+  names: { subjectName: string; objectName: string },
+): string | undefined {
+  const { subjectName, objectName } = names;
+  const verb = ASYMMETRIC_VERB[rel.relationship_type];
+  if (verb) {
+    return `${subjectName} ${verb} ${objectName}`;
+  }
+  if (rel.relationship_role && DIRECTIONAL_ROLES.has(rel.relationship_role)) {
+    return `${subjectName} is the ${humanize(rel.relationship_role)} of ${objectName}`;
+  }
+  return undefined;
+}
+
+/** First-letter initials (max two) for an avatar fallback. */
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase();
+}
+
+/**
+ * Whole years lived between two temporal points, or `null` when it can't be
+ * meaningfully computed. Restricted to CE/BCE eras — a "lived N years" figure
+ * is meaningless at geological/cosmological (KYA/MYA/BYA) scale.
+ */
+export function livedYears(
+  birth: TemporalData | null | undefined,
+  death: TemporalData | null | undefined,
+): number | null {
+  if (!birth || !death) return null;
+  const yearScaleEras = new Set(["CE", "BCE"]);
+  if (!yearScaleEras.has(birth.era) || !yearScaleEras.has(death.era)) {
+    return null;
+  }
+  const span =
+    TemporalService.toSortableYears(death) -
+    TemporalService.toSortableYears(birth);
+  if (!Number.isFinite(span) || span < 0) return null;
+  return Math.floor(span);
+}

--- a/apps/admin/app/(protected)/characters/_components/character-detail-helpers.ts
+++ b/apps/admin/app/(protected)/characters/_components/character-detail-helpers.ts
@@ -104,32 +104,29 @@ const ASYMMETRIC_VERB: Record<string, string> = {
   worship: "worships",
 };
 
-/** Sub-roles whose reciprocal differs from themselves (directional pairs). */
-const DIRECTIONAL_ROLES: ReadonlySet<string> = new Set([
-  "parent",
-  "child",
-  "grandparent",
-  "grandchild",
-  "aunt_uncle",
-  "niece_nephew",
-  "step_parent",
-  "step_child",
-  "adoptive_parent",
-  "adoptive_child",
-  "employer",
-  "employee",
-  "supervisor",
-  "subordinate",
-  "client",
-  "vendor",
-]);
+/**
+ * Plural noun phrase for type-only symmetric relationships that carry no
+ * sub-role, e.g. friendship → "Marie and Pierre are friends".
+ */
+const SYMMETRIC_TYPE_NOUN: Record<string, string> = {
+  friendship: "friends",
+  rivalry: "rivals",
+  enemy: "enemies",
+  collaboration: "collaborators",
+  professional: "colleagues",
+  family: "relatives",
+};
 
 /**
- * Narrative direction line for a relationship ("Marie is the parent of Irène",
- * "Marie mentors Pierre"). Rendered from the stored row's own subject/object
- * (character_id → related_character_id), so it reads correctly regardless of
- * which end is the focal character. Returns `undefined` when there's no
- * directional narrative worth showing (symmetric type with no directional role).
+ * Narrative direction line for a relationship, rendered for *every* type per
+ * the #57 card contract ("direction as narrative text, never an arrow/glyph"):
+ * - asymmetric types use a verb phrase ("Marie mentors Pierre"),
+ * - any sub-role reads as "Marie is the parent of Irène" (paired or symmetric),
+ * - type-only symmetric types get a plural noun ("Marie and Pierre are friends").
+ *
+ * Rendered from the stored row's own subject/object (character_id →
+ * related_character_id), so it reads correctly regardless of which end is the
+ * focal character.
  */
 export function directionLabel(
   rel: Pick<
@@ -137,16 +134,22 @@ export function directionLabel(
     "relationship_type" | "relationship_role" | "character_id"
   >,
   names: { subjectName: string; objectName: string },
-): string | undefined {
+): string {
   const { subjectName, objectName } = names;
   const verb = ASYMMETRIC_VERB[rel.relationship_type];
   if (verb) {
     return `${subjectName} ${verb} ${objectName}`;
   }
-  if (rel.relationship_role && DIRECTIONAL_ROLES.has(rel.relationship_role)) {
+  // Any concrete sub-role reads naturally as "X is the <role> of Y". "other" is
+  // not a meaningful role name, so it falls through to the type-noun phrasing.
+  if (rel.relationship_role && rel.relationship_role !== "other") {
     return `${subjectName} is the ${humanize(rel.relationship_role)} of ${objectName}`;
   }
-  return undefined;
+  const noun = SYMMETRIC_TYPE_NOUN[rel.relationship_type];
+  if (noun) {
+    return `${subjectName} and ${objectName} are ${noun}`;
+  }
+  return `${subjectName} — ${objectName}`;
 }
 
 /** First-letter initials (max two) for an avatar fallback. */

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         "app/**/_components/media/attach-media-dialog.tsx",
         "app/**/_components/media/media-library.tsx",
         "app/**/_components/media/media-section.tsx",
+        "app/**/character-detail-helpers.ts",
         "app/**/character-form-mappers.ts",
         "app/**/event-form-mappers.ts",
         "app/**/timeline-form-mappers.ts",


### PR DESCRIPTION
Closes #57.

Adds the read-first **Character detail** route at `characters/[slug]` — the last major surface in the Characters & Relationships milestone. Modeled on the existing `timelines/[slug]` detail page; almost entirely UI assembly over primitives that already shipped in #49/#52/#53/#54.

## What's here
- **Route + shell** — server `page.tsx` (resolves `userId` server-side, Suspense skeleton) → `character-detail-client.tsx` (header: primary thumbnail + Replace, name, `CharacterTypeBadge`, significance, temporal summary, aliases, cultural context; Publish/Edit/⋯ actions; controlled Tabs; danger-zone delete).
- **Overview tab** — biography, physical description, temporal scope + computed "Lived N years", type-specific fields (species/breed, domain, pantheon, …), metadata; empty fields link to the editor.
- **Events tab** — chronological participation from `character_timeline_view` (which already carries `role` + `significance`, so no junction merge needed), chronological/reverse toggle, birth/death ghost markers, add-to-event dialog.
- **Relationships tab** — cards grouped into family/professional/social/antagonistic/asymmetric collapsible groups, narrative direction text ("Marie is the parent of Irène"), `[⋯]` Edit/Duplicate/Delete. Right-side add/edit **sheet** composes the shipped `RelationshipTypeSelector` + a character combobox (Command/Popover, excludes focal + already-linked-by-type) + `TemporalInput` + description. Reciprocal edge created implicitly by the service — no checkbox.
- **Media tab** — `MediaSection` with `ordering="primary"`: attach (Upload / External URL / Existing via `MediaPicker`), `is_primary` swap, detach.
- Pure grouping / direction-label / lived-years helpers extracted to `characters/_components/character-detail-helpers.ts` with 24 unit tests.

## Incidental fix
Fixes a latent **hydration error** in the shared `MediaSection`: the metadata line was a `<p>`, but `ordering="primary"` renders a "Primary" `Badge` (`<div>`) inside it — invalid nesting. This page is the first host to use that mode, so it only surfaced now. Changed the line to a `<div>` (visually identical; safe for the timeline/event hosts).

## Reuse
`RelationshipCard`, `RelationshipTypeSelector`, `MediaSection`/`AttachMediaDialog`/`MediaPicker`, `TemporalDisplay`, `PublishControl`, `CharacterTypeBadge`, and the character/relationship/media TanStack hooks — all drop-ins.

## Follow-up
- **#335** — wireframe-06 paired directional sub-role control ("`[parent ▾]` of the other character" + inverse hint). Reusing the shipped flat selector was the agreed approach for this PR; a `// DECISION NEEDED (#335)` comment marks the call site.

## Validation
`format` · `check-types` · `lint` (zero-warnings) · `test:coverage` (152 tests, helpers file counted) · `build` (`/characters/[slug]` registered). Manual end-to-end against seeded data still pending a live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)