### PR TITLE
feat(services): harden category service — cycle prevention, delete policy, tree ordering (#59)

### DIFF
--- a/packages/services/src/modules/category-service.test.ts
+++ b/packages/services/src/modules/category-service.test.ts
@@ -29,6 +29,7 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
     range: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     single: terminal,
+    maybeSingle: terminal,
     then: (resolve: (v: unknown) => unknown) =>
       Promise.resolve(result).then(resolve),
   };
@@ -71,8 +72,8 @@ function makeCreateClient(insertResult: { data: unknown; error: unknown }) {
 }
 
 // Returns a client whose successive `from()` calls yield successive builders,
-// so multi-query flows (ancestor walks, reparent-then-delete) can script each
-// step's result. Extra calls beyond the list reuse the last builder.
+// so a multi-query flow (e.g. an ancestor walk) can script each step's result.
+// Extra calls beyond the list reuse the last builder.
 function makeSequenceClient(results: { data: unknown; error: unknown }[]) {
   if (results.length === 0) {
     throw new Error("makeSequenceClient requires at least one result");

--- a/packages/services/src/modules/category-service.test.ts
+++ b/packages/services/src/modules/category-service.test.ts
@@ -74,6 +74,9 @@ function makeCreateClient(insertResult: { data: unknown; error: unknown }) {
 // so multi-query flows (ancestor walks, reparent-then-delete) can script each
 // step's result. Extra calls beyond the list reuse the last builder.
 function makeSequenceClient(results: { data: unknown; error: unknown }[]) {
+  if (results.length === 0) {
+    throw new Error("makeSequenceClient requires at least one result");
+  }
   const builders = results.map(makeBuilder);
   let callCount = 0;
   const client = {

--- a/packages/services/src/modules/category-service.test.ts
+++ b/packages/services/src/modules/category-service.test.ts
@@ -459,68 +459,32 @@ describe("updateCategory reparenting", () => {
 // ---------------------------------------------------------------------------
 
 describe("deleteCategoryReparentingChildren", () => {
-  it("moves children to the grandparent, then deletes the node", async () => {
-    const { client, builders } = makeSequenceClient([
-      { data: { parent_category_id: "grandparent" }, error: null }, // fetch
-      { data: null, error: null }, // reparent update
-      { data: null, error: null }, // delete
-    ]);
+  function makeRpcClient(result: { data: unknown; error: unknown }) {
+    return {
+      rpc: vi.fn().mockResolvedValue(result),
+    } as unknown as SupabaseClient<Database>;
+  }
+
+  it("invokes the atomic reparent-then-delete RPC with the category id", async () => {
+    const client = makeRpcClient({ data: null, error: null });
     await expect(
       deleteCategoryReparentingChildren(client, "cat-1"),
     ).resolves.toBeUndefined();
-    expect(builders[1]?.update).toHaveBeenCalledWith({
-      parent_category_id: "grandparent",
-    });
-    expect(builders[1]?.eq).toHaveBeenCalledWith("parent_category_id", "cat-1");
-    expect(builders[2]?.delete).toHaveBeenCalled();
-    expect(builders[2]?.eq).toHaveBeenCalledWith("id", "cat-1");
-  });
-
-  it("moves children of a root node to root (null parent)", async () => {
-    const { client, builders } = makeSequenceClient([
-      { data: { parent_category_id: null }, error: null },
-      { data: null, error: null },
-      { data: null, error: null },
-    ]);
-    await deleteCategoryReparentingChildren(client, "cat-1");
-    expect(builders[1]?.update).toHaveBeenCalledWith({
-      parent_category_id: null,
-    });
-  });
-
-  it("throws when the target fetch fails", async () => {
-    const { client } = makeSequenceClient([
-      { data: null, error: { message: "not found" } },
-    ]);
-    await expect(
-      deleteCategoryReparentingChildren(client, "cat-1"),
-    ).rejects.toThrow(
-      "CategoryService.deleteCategoryReparentingChildren(fetch): not found",
+    expect(client.rpc).toHaveBeenCalledWith(
+      "delete_category_reparenting_children",
+      { p_category_id: "cat-1" },
     );
   });
 
-  it("throws when the reparent update fails", async () => {
-    const { client } = makeSequenceClient([
-      { data: { parent_category_id: null }, error: null },
-      { data: null, error: { message: "reparent failed" } },
-    ]);
+  it("throws when the RPC returns an error", async () => {
+    const client = makeRpcClient({
+      data: null,
+      error: { message: "category not found" },
+    });
     await expect(
       deleteCategoryReparentingChildren(client, "cat-1"),
     ).rejects.toThrow(
-      "CategoryService.deleteCategoryReparentingChildren(reparent): reparent failed",
-    );
-  });
-
-  it("throws when the final delete fails", async () => {
-    const { client } = makeSequenceClient([
-      { data: { parent_category_id: null }, error: null },
-      { data: null, error: null },
-      { data: null, error: { message: "delete failed" } },
-    ]);
-    await expect(
-      deleteCategoryReparentingChildren(client, "cat-1"),
-    ).rejects.toThrow(
-      "CategoryService.deleteCategoryReparentingChildren(delete): delete failed",
+      "CategoryService.deleteCategoryReparentingChildren: category not found",
     );
   });
 });

--- a/packages/services/src/modules/category-service.test.ts
+++ b/packages/services/src/modules/category-service.test.ts
@@ -8,6 +8,8 @@ import {
   createCategory,
   updateCategory,
   deleteCategory,
+  deleteCategoryReparentingChildren,
+  assertNoCategoryCycle,
   getCategoryTree,
 } from "./category-service";
 
@@ -66,6 +68,22 @@ function makeCreateClient(insertResult: { data: unknown; error: unknown }) {
         .mockResolvedValue({ data: { user: { id: "user-123" } }, error: null }),
     },
   } as unknown as SupabaseClient<Database>;
+}
+
+// Returns a client whose successive `from()` calls yield successive builders,
+// so multi-query flows (ancestor walks, reparent-then-delete) can script each
+// step's result. Extra calls beyond the list reuse the last builder.
+function makeSequenceClient(results: { data: unknown; error: unknown }[]) {
+  const builders = results.map(makeBuilder);
+  let callCount = 0;
+  const client = {
+    from: vi.fn().mockImplementation(() => {
+      const builder = builders[Math.min(callCount, builders.length - 1)];
+      callCount++;
+      return builder;
+    }),
+  } as unknown as SupabaseClient<Database>;
+  return { client, builders };
 }
 
 // ---------------------------------------------------------------------------
@@ -331,6 +349,183 @@ describe("deleteCategory", () => {
 });
 
 // ---------------------------------------------------------------------------
+// assertNoCategoryCycle
+// ---------------------------------------------------------------------------
+
+describe("assertNoCategoryCycle", () => {
+  it("rejects making a category its own parent (no DB call needed)", async () => {
+    const { client } = makeSequenceClient([{ data: null, error: null }]);
+    await expect(
+      assertNoCategoryCycle(client, "cat-1", "cat-1"),
+    ).rejects.toThrow(
+      "CategoryService.assertNoCategoryCycle: a category cannot be its own ancestor",
+    );
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("rejects assigning a descendant as the new parent", async () => {
+    // Reparent cat-1 under cat-3, whose ancestor chain is cat-3 → cat-2 → cat-1.
+    const { client } = makeSequenceClient([
+      { data: { parent_category_id: "cat-2" }, error: null },
+      { data: { parent_category_id: "cat-1" }, error: null },
+    ]);
+    await expect(
+      assertNoCategoryCycle(client, "cat-1", "cat-3"),
+    ).rejects.toThrow("circular hierarchy");
+  });
+
+  it("allows a valid non-descendant parent (chain reaches root)", async () => {
+    const { client } = makeSequenceClient([
+      { data: { parent_category_id: null }, error: null },
+    ]);
+    await expect(
+      assertNoCategoryCycle(client, "cat-1", "cat-5"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("terminates on a pre-existing cycle not involving the moved node", async () => {
+    // Stored chain cat-3 → cat-4 → cat-3 loops but never reaches cat-1.
+    const { client } = makeSequenceClient([
+      { data: { parent_category_id: "cat-4" }, error: null },
+      { data: { parent_category_id: "cat-3" }, error: null },
+    ]);
+    await expect(
+      assertNoCategoryCycle(client, "cat-1", "cat-3"),
+    ).resolves.toBeUndefined();
+    // cat-3 and cat-4 each fetched once; the loop stops when cat-3 repeats.
+    expect(client.from).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on a DB error while walking the chain", async () => {
+    const { client } = makeSequenceClient([
+      { data: null, error: { message: "walk failed" } },
+    ]);
+    await expect(
+      assertNoCategoryCycle(client, "cat-1", "cat-9"),
+    ).rejects.toThrow("CategoryService.assertNoCategoryCycle: walk failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCategory — reparent / cycle behavior
+// ---------------------------------------------------------------------------
+
+describe("updateCategory reparenting", () => {
+  // parent_category_id is validated as a UUID by the Zod schema, so update
+  // inputs must use real UUIDs (mock DB return values are unvalidated).
+  const NEW_PARENT_UUID = "11111111-1111-4111-8111-111111111111";
+
+  it("rejects a reparent that would create a cycle", async () => {
+    // Reparent cat-1 under NEW_PARENT, whose parent is cat-1 → cycle.
+    const { client } = makeSequenceClient([
+      { data: { parent_category_id: "cat-1" }, error: null },
+    ]);
+    await expect(
+      updateCategory(client, "cat-1", { parent_category_id: NEW_PARENT_UUID }),
+    ).rejects.toThrow("circular hierarchy");
+    // The guard ran (1 call) but the UPDATE never did (still 1 call).
+    expect(client.from).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a safe reparent under a non-descendant", async () => {
+    const { client } = makeSequenceClient([
+      { data: { parent_category_id: null }, error: null },
+      { data: sampleCategory, error: null },
+    ]);
+    const result = await updateCategory(client, "cat-1", {
+      parent_category_id: NEW_PARENT_UUID,
+    });
+    expect(result).toEqual(sampleCategory);
+  });
+
+  it("allows reparenting to root (null) without a cycle check", async () => {
+    const { client, builders } = makeSequenceClient([
+      { data: sampleCategory, error: null },
+    ]);
+    const result = await updateCategory(client, "cat-1", {
+      parent_category_id: null,
+    });
+    expect(result).toEqual(sampleCategory);
+    // Only the UPDATE ran — no ancestor walk for a move to root.
+    expect(client.from).toHaveBeenCalledTimes(1);
+    expect(builders[0]?.update).toHaveBeenCalledWith({
+      parent_category_id: null,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteCategoryReparentingChildren
+// ---------------------------------------------------------------------------
+
+describe("deleteCategoryReparentingChildren", () => {
+  it("moves children to the grandparent, then deletes the node", async () => {
+    const { client, builders } = makeSequenceClient([
+      { data: { parent_category_id: "grandparent" }, error: null }, // fetch
+      { data: null, error: null }, // reparent update
+      { data: null, error: null }, // delete
+    ]);
+    await expect(
+      deleteCategoryReparentingChildren(client, "cat-1"),
+    ).resolves.toBeUndefined();
+    expect(builders[1]?.update).toHaveBeenCalledWith({
+      parent_category_id: "grandparent",
+    });
+    expect(builders[1]?.eq).toHaveBeenCalledWith("parent_category_id", "cat-1");
+    expect(builders[2]?.delete).toHaveBeenCalled();
+    expect(builders[2]?.eq).toHaveBeenCalledWith("id", "cat-1");
+  });
+
+  it("moves children of a root node to root (null parent)", async () => {
+    const { client, builders } = makeSequenceClient([
+      { data: { parent_category_id: null }, error: null },
+      { data: null, error: null },
+      { data: null, error: null },
+    ]);
+    await deleteCategoryReparentingChildren(client, "cat-1");
+    expect(builders[1]?.update).toHaveBeenCalledWith({
+      parent_category_id: null,
+    });
+  });
+
+  it("throws when the target fetch fails", async () => {
+    const { client } = makeSequenceClient([
+      { data: null, error: { message: "not found" } },
+    ]);
+    await expect(
+      deleteCategoryReparentingChildren(client, "cat-1"),
+    ).rejects.toThrow(
+      "CategoryService.deleteCategoryReparentingChildren(fetch): not found",
+    );
+  });
+
+  it("throws when the reparent update fails", async () => {
+    const { client } = makeSequenceClient([
+      { data: { parent_category_id: null }, error: null },
+      { data: null, error: { message: "reparent failed" } },
+    ]);
+    await expect(
+      deleteCategoryReparentingChildren(client, "cat-1"),
+    ).rejects.toThrow(
+      "CategoryService.deleteCategoryReparentingChildren(reparent): reparent failed",
+    );
+  });
+
+  it("throws when the final delete fails", async () => {
+    const { client } = makeSequenceClient([
+      { data: { parent_category_id: null }, error: null },
+      { data: null, error: null },
+      { data: null, error: { message: "delete failed" } },
+    ]);
+    await expect(
+      deleteCategoryReparentingChildren(client, "cat-1"),
+    ).rejects.toThrow(
+      "CategoryService.deleteCategoryReparentingChildren(delete): delete failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // getCategoryTree
 // ---------------------------------------------------------------------------
 
@@ -419,6 +614,18 @@ describe("getCategoryTree", () => {
     const tree = await getCategoryTree(client, "user-123");
     expect(tree).toHaveLength(1);
     expect(tree[0]?.id).toBe("orphan");
+  });
+
+  it("orders equal-title siblings deterministically by id", async () => {
+    // Two roots share a title; the id tie-break must place "aaa" before "zzz"
+    // regardless of the order the rows arrive in.
+    const cats = [
+      { ...sampleCategory, id: "zzz", title: "Same", parent_category_id: null },
+      { ...sampleCategory, id: "aaa", title: "Same", parent_category_id: null },
+    ];
+    const client = makeClient({ fromResult: { data: cats, error: null } });
+    const tree = await getCategoryTree(client, "user-123");
+    expect(tree.map((n) => n.id)).toEqual(["aaa", "zzz"]);
   });
 
   it("throws on DB error", async () => {

--- a/packages/services/src/modules/category-service.ts
+++ b/packages/services/src/modules/category-service.ts
@@ -310,10 +310,17 @@ export async function deleteCategory(
  * target's own parent (its grandparent, or `null` for root) before the target
  * is deleted, so descendants survive rather than cascading away.
  *
+ * The reparent and delete run atomically inside the
+ * `delete_category_reparenting_children` Postgres function
+ * (00026_delete_category_reparenting_children.sql): both commit or neither
+ * does, and a `FOR UPDATE` lock on the target serializes any concurrent child
+ * insert, so a child added mid-operation can't be silently cascade-deleted. The
+ * function is `SECURITY INVOKER`, so RLS restricts the caller to their own
+ * categories — deleting another owner's category raises a not-found error.
+ *
  * The target's own `event_categories` tags are still removed by the DB cascade
  * when it is deleted — only the subtree is preserved, not the target node's own
- * event associations. This is an application-layer operation: the database only
- * offers the raw cascade (`deleteCategory`).
+ * event associations.
  *
  * @param client - Supabase client instance
  * @param id - Category UUID to delete
@@ -322,29 +329,10 @@ export async function deleteCategoryReparentingChildren(
   client: SupabaseClient<Database>,
   id: string,
 ): Promise<void> {
-  // Resolve the target's parent — children inherit it (grandparent or root).
-  const { data: target, error: fetchError } = await client
-    .from("categories")
-    .select("parent_category_id")
-    .eq("id", id)
-    .single();
-  assertNoError(fetchError, "deleteCategoryReparentingChildren(fetch)");
-
-  // Move direct children up to the target's parent. Because they move to the
-  // target's own ancestor (never into the target's subtree), this reparent
-  // cannot introduce a cycle, so no assertNoCategoryCycle check is needed.
-  const { error: reparentError } = await client
-    .from("categories")
-    .update({ parent_category_id: target.parent_category_id })
-    .eq("parent_category_id", id);
-  assertNoError(reparentError, "deleteCategoryReparentingChildren(reparent)");
-
-  // The target is now childless; delete only it.
-  const { error: deleteError } = await client
-    .from("categories")
-    .delete()
-    .eq("id", id);
-  assertNoError(deleteError, "deleteCategoryReparentingChildren(delete)");
+  const { error } = await client.rpc("delete_category_reparenting_children", {
+    p_category_id: id,
+  });
+  assertNoError(error, "deleteCategoryReparentingChildren");
 }
 
 /**

--- a/packages/services/src/modules/category-service.ts
+++ b/packages/services/src/modules/category-service.ts
@@ -25,6 +25,10 @@ export type CreateCategoryInput = Omit<CategoryInput, "slug"> & {
   slug?: string;
 };
 
+// Fixed-locale collator for deterministic, host-independent title ordering in
+// getCategoryTree. Created once at module scope rather than per sort.
+const TITLE_COLLATOR = new Intl.Collator("en", { sensitivity: "variant" });
+
 function assertNoError(
   error: { message: string } | null,
   context: string,
@@ -231,6 +235,10 @@ export async function assertNoCategoryCycle(
     }
     visited.add(cursor);
 
+    // maybeSingle (not single): a non-existent `newParentId` returns no row
+    // without erroring, so the walk ends here and the guard passes. The real
+    // "parent does not exist" error is then raised cleanly by the FK on the
+    // subsequent UPDATE, rather than surfacing as a misleading cycle/fetch error.
     const {
       data,
       error,
@@ -241,7 +249,7 @@ export async function assertNoCategoryCycle(
       .from("categories")
       .select("parent_category_id")
       .eq("id", cursor)
-      .single();
+      .maybeSingle();
     assertNoError(error, "assertNoCategoryCycle");
     cursor = data?.parent_category_id ?? null;
   }
@@ -389,8 +397,11 @@ export async function getCategoryTree(
   }
 
   // Deterministic ordering: title ascending, then id as a stable tie-break.
+  // A fixed-locale Intl.Collator makes the title sort independent of the host's
+  // default locale; ids are UUIDs, so a plain code-point compare is enough.
   const byTitleThenId = (a: CategoryNode, b: CategoryNode) =>
-    a.title.localeCompare(b.title) || a.id.localeCompare(b.id);
+    TITLE_COLLATOR.compare(a.title, b.title) ||
+    (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
   roots.sort(byTitleThenId);
   for (const node of nodeMap.values()) {
     node.children?.sort(byTitleThenId);

--- a/packages/services/src/modules/category-service.ts
+++ b/packages/services/src/modules/category-service.ts
@@ -191,7 +191,69 @@ export async function createCategory(
 }
 
 /**
+ * Throws if assigning `newParentId` as the parent of `categoryId` would create
+ * a circular hierarchy — i.e. if `categoryId` is `newParentId` itself, or is an
+ * ancestor of `newParentId`.
+ *
+ * Detection walks the ancestor chain upward from `newParentId` via
+ * `parent_category_id`. A cycle would form exactly when `categoryId` appears on
+ * that chain, so a single upward walk is sufficient (and cheaper than
+ * enumerating `categoryId`'s descendants). A `visited` set guards against an
+ * already-corrupt chain looping forever.
+ *
+ * Detection is service-layer by design — `parent_category_id` is not
+ * cycle-constrained at the database level (docs/system-design.md §3.4),
+ * consistent with the other self-referential FK cycle guards
+ * (see `event-service.assertNoDetailTimelineCycle`).
+ *
+ * @param client - Supabase client instance
+ * @param categoryId - The category being reparented
+ * @param newParentId - The candidate parent
+ */
+export async function assertNoCategoryCycle(
+  client: SupabaseClient<Database>,
+  categoryId: string,
+  newParentId: string,
+): Promise<void> {
+  const visited = new Set<string>();
+  let cursor: string | null = newParentId;
+
+  while (cursor !== null) {
+    if (cursor === categoryId) {
+      throw new Error(
+        "CategoryService.assertNoCategoryCycle: a category cannot be its own " +
+          "ancestor (circular hierarchy)",
+      );
+    }
+    if (visited.has(cursor)) {
+      // Pre-existing cycle in the stored data; stop rather than loop forever.
+      return;
+    }
+    visited.add(cursor);
+
+    const {
+      data,
+      error,
+    }: {
+      data: { parent_category_id: string | null } | null;
+      error: { message: string } | null;
+    } = await client
+      .from("categories")
+      .select("parent_category_id")
+      .eq("id", cursor)
+      .single();
+    assertNoError(error, "assertNoCategoryCycle");
+    cursor = data?.parent_category_id ?? null;
+  }
+}
+
+/**
  * Apply a partial update to a category.
+ *
+ * When the patch reparents the node (sets `parent_category_id` to a non-null
+ * value), the assignment is checked against {@link assertNoCategoryCycle} first,
+ * so a category can never become its own ancestor. Setting
+ * `parent_category_id` to `null` moves the node to root and is always allowed.
  *
  * @param client - Supabase client instance
  * @param id - Category UUID
@@ -204,6 +266,14 @@ export async function updateCategory(
   data: Partial<CategoryInput>,
 ): Promise<CategoryRow> {
   const validated = categorySchema.partial().parse(data);
+
+  if (
+    validated.parent_category_id !== undefined &&
+    validated.parent_category_id !== null
+  ) {
+    await assertNoCategoryCycle(client, id, validated.parent_category_id);
+  }
+
   const { data: updated, error } = await client
     .from("categories")
     .update(validated)
@@ -215,8 +285,13 @@ export async function updateCategory(
 }
 
 /**
- * Delete a category by its UUID. Child categories cascade via the FK
- * constraint defined on `parent_category_id`.
+ * Delete a category and its entire subtree (wireframe 24 "Option B — delete
+ * subtree", the raw DB cascade). Descendants cascade via the
+ * `parent_category_id ... ON DELETE CASCADE` FK, and every affected event is
+ * untagged via `event_categories ... ON DELETE CASCADE`.
+ *
+ * For the safer "reparent children first" path that preserves the subtree, use
+ * {@link deleteCategoryReparentingChildren}.
  *
  * @param client - Supabase client instance
  * @param id - Category UUID
@@ -230,9 +305,58 @@ export async function deleteCategory(
 }
 
 /**
+ * Delete a single category while preserving its subtree (wireframe 24
+ * "Option A — reparent children first"). Direct children are re-pointed to the
+ * target's own parent (its grandparent, or `null` for root) before the target
+ * is deleted, so descendants survive rather than cascading away.
+ *
+ * The target's own `event_categories` tags are still removed by the DB cascade
+ * when it is deleted — only the subtree is preserved, not the target node's own
+ * event associations. This is an application-layer operation: the database only
+ * offers the raw cascade (`deleteCategory`).
+ *
+ * @param client - Supabase client instance
+ * @param id - Category UUID to delete
+ */
+export async function deleteCategoryReparentingChildren(
+  client: SupabaseClient<Database>,
+  id: string,
+): Promise<void> {
+  // Resolve the target's parent — children inherit it (grandparent or root).
+  const { data: target, error: fetchError } = await client
+    .from("categories")
+    .select("parent_category_id")
+    .eq("id", id)
+    .single();
+  assertNoError(fetchError, "deleteCategoryReparentingChildren(fetch)");
+
+  // Move direct children up to the target's parent. Because they move to the
+  // target's own ancestor (never into the target's subtree), this reparent
+  // cannot introduce a cycle, so no assertNoCategoryCycle check is needed.
+  const { error: reparentError } = await client
+    .from("categories")
+    .update({ parent_category_id: target.parent_category_id })
+    .eq("parent_category_id", id);
+  assertNoError(reparentError, "deleteCategoryReparentingChildren(reparent)");
+
+  // The target is now childless; delete only it.
+  const { error: deleteError } = await client
+    .from("categories")
+    .delete()
+    .eq("id", id);
+  assertNoError(deleteError, "deleteCategoryReparentingChildren(delete)");
+}
+
+/**
  * Fetch all categories for a user and assemble them into a nested tree.
  * Root nodes are those with `parent_category_id IS NULL`. The tree is built
  * entirely in-memory from a single DB query.
+ *
+ * Ordering within every level is deterministic: alphabetical by `title`, with a
+ * stable `id` tie-break for equal titles (categories have no `sort_order` and
+ * no temporal axis). We build children in the DB's title-ascending row order,
+ * then sort each level explicitly so equal-title siblings never reorder across
+ * fetches, regardless of the order the map iterates them in.
  *
  * @param client - Supabase client instance
  * @param userId - Owner's user UUID
@@ -274,6 +398,14 @@ export async function getCategoryTree(
     } else {
       roots.push(node);
     }
+  }
+
+  // Deterministic ordering: title ascending, then id as a stable tie-break.
+  const byTitleThenId = (a: CategoryNode, b: CategoryNode) =>
+    a.title.localeCompare(b.title) || a.id.localeCompare(b.id);
+  roots.sort(byTitleThenId);
+  for (const node of nodeMap.values()) {
+    node.children?.sort(byTitleThenId);
   }
 
   return roots;

--- a/packages/services/src/schemas/category.ts
+++ b/packages/services/src/schemas/category.ts
@@ -10,7 +10,10 @@ export const categorySchema = z.object({
     .regex(/^#[0-9a-fA-F]{6}$/, "color must be a 6-digit hex like #aabbcc")
     .optional(),
   icon: z.string().max(100).optional(),
-  parent_category_id: z.string().uuid().optional(),
+  // Nullable so an update can reparent a node to root (`null`); optional so a
+  // create/patch may omit it. Cycles are prevented in the service layer, not
+  // the DB (docs/system-design.md §3.4).
+  parent_category_id: z.string().uuid().nullable().optional(),
 });
 
 export type CategoryInput = z.infer<typeof categorySchema>;

--- a/packages/services/src/supabase/types.ts
+++ b/packages/services/src/supabase/types.ts
@@ -1329,6 +1329,10 @@ export type Database = {
           target_name: string;
         }[];
       };
+      delete_category_reparenting_children: {
+        Args: { p_category_id: string };
+        Returns: undefined;
+      };
       events_in_temporal_range: {
         Args: {
           p_end_years: number;

--- a/supabase/migrations/00026_delete_category_reparenting_children.sql
+++ b/supabase/migrations/00026_delete_category_reparenting_children.sql
@@ -1,0 +1,68 @@
+-- ============================================================================
+-- 00026_delete_category_reparenting_children.sql
+--
+-- Atomic "reparent children then delete" for the category taxonomy (issue #59,
+-- wireframe 24 annotation #6 "Option A"). The service previously performed this
+-- as two separate PostgREST calls (UPDATE then DELETE), which is not atomic:
+-- if the DELETE failed the node was left stranded among its former children,
+-- and a child inserted between the two statements could be cascade-deleted.
+--
+-- This function does both in a single transaction so they commit or roll back
+-- together. A FOR UPDATE lock on the target row serializes concurrent inserts
+-- of new children: such an insert takes a FOR KEY SHARE lock on the parent for
+-- the FK check, which blocks until this function commits (having deleted the
+-- row), after which the insert fails its FK check rather than being silently
+-- cascaded away.
+--
+-- SECURITY INVOKER (the default) so RLS applies — the caller can only reparent
+-- and delete categories they own; a target owned by another user is invisible
+-- and raises "not found". search_path='' + schema-qualified refs follow the
+-- hardening pattern from 00010_function_search_path_hardening.sql.
+--
+-- The raw subtree cascade ("Option B") remains available as a plain DELETE on
+-- categories (parent_category_id ... ON DELETE CASCADE); this function is the
+-- subtree-preserving alternative.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.delete_category_reparenting_children(
+  p_category_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_parent_id UUID;
+BEGIN
+  -- Resolve the target's own parent; children inherit it (grandparent, or NULL
+  -- for a root node). FOR UPDATE locks the row so a concurrent child insert is
+  -- serialized against the delete below.
+  SELECT parent_category_id INTO v_parent_id
+  FROM public.categories
+  WHERE id = p_category_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'category % not found', p_category_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- Move direct children up to the target's parent. They move to the target's
+  -- own ancestor (never into its subtree), so this cannot introduce a cycle.
+  UPDATE public.categories
+  SET parent_category_id = v_parent_id
+  WHERE parent_category_id = p_category_id;
+
+  -- The target is now childless; delete only it. Its own event_categories tags
+  -- are removed by the ON DELETE CASCADE on that junction.
+  DELETE FROM public.categories WHERE id = p_category_id;
+END;
+$$;
+
+-- Destructive mutation: keep it off the anonymous (read-only) role and grant
+-- least privilege to the writing roles. anon is read-only per ADR-0034.
+REVOKE ALL ON FUNCTION public.delete_category_reparenting_children(UUID)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.delete_category_reparenting_children(UUID)
+  TO authenticated, service_role;

--- a/supabase/migrations/00027_categories_same_owner_parent.sql
+++ b/supabase/migrations/00027_categories_same_owner_parent.sql
@@ -1,0 +1,43 @@
+-- ============================================================================
+-- 00027_categories_same_owner_parent.sql
+--
+-- Constrain category nesting to a single owner (issue #59 follow-up; PR #338
+-- review). `read_categories` is `USING (true)` (categories are globally
+-- readable organizational metadata), and the write policies only check
+-- `user_id = auth.uid()` on the mutated row — nothing stops a user from
+-- pointing their `parent_category_id` at *another* owner's category. Because
+-- that FK is `ON DELETE CASCADE` (00001_initial_schema.sql), a cross-owner
+-- parent link lets one owner's delete cascade into another owner's subtree —
+-- a cross-tenant data-integrity hole.
+--
+-- Close it at the schema level (stronger than an RLS `WITH CHECK`, which
+-- `service_role` bypasses): replace the single-column self-FK with a COMPOSITE
+-- FK that carries `user_id`, so a child can only reference a parent owned by
+-- the same user. Roots are unaffected — with the default MATCH SIMPLE, a NULL
+-- `parent_category_id` skips the check entirely.
+--
+-- Requires a UNIQUE key on the referenced columns `(user_id, id)`. `id` is
+-- already the PK (so this is trivially satisfiable), but Postgres requires an
+-- explicit unique constraint matching a composite FK's target columns.
+--
+-- Data note: if any pre-existing row already has a cross-owner parent link,
+-- the FK creation below will fail loudly (23503) — such rows must be repaired
+-- before this migration can apply. No migration seeds category rows, so a
+-- fresh `db:reset` applies cleanly.
+-- ============================================================================
+
+-- Referenced key for the composite FK. Redundant with the PK on `id`, but
+-- required so `(user_id, parent_category_id)` can reference `(user_id, id)`.
+ALTER TABLE public.categories
+  ADD CONSTRAINT categories_user_id_id_key UNIQUE (user_id, id);
+
+-- Swap the owner-agnostic self-FK for an owner-scoped one. ON DELETE CASCADE is
+-- preserved, so subtree deletes still cascade — but only ever within one owner.
+ALTER TABLE public.categories
+  DROP CONSTRAINT categories_parent_category_id_fkey;
+
+ALTER TABLE public.categories
+  ADD CONSTRAINT categories_parent_same_owner_fkey
+    FOREIGN KEY (user_id, parent_category_id)
+    REFERENCES public.categories (user_id, id)
+    ON DELETE CASCADE;

--- a/supabase/migrations/00027_categories_same_owner_parent.sql
+++ b/supabase/migrations/00027_categories_same_owner_parent.sql
@@ -1,8 +1,8 @@
 -- ============================================================================
 -- 00027_categories_same_owner_parent.sql
 --
--- Constrain category nesting to a single owner (issue #59 follow-up; PR #338
--- review). `read_categories` is `USING (true)` (categories are globally
+-- Constrain category nesting to a single owner (issue #59 hardening
+-- follow-up). `read_categories` is `USING (true)` (categories are globally
 -- readable organizational metadata), and the write policies only check
 -- `user_id = auth.uid()` on the mutated row — nothing stops a user from
 -- pointing their `parent_category_id` at *another* owner's category. Because

--- a/supabase/tests/database/00026_delete_category_reparenting_children_test.sql
+++ b/supabase/tests/database/00026_delete_category_reparenting_children_test.sql
@@ -1,0 +1,120 @@
+-- pgTAP tests for 00026_delete_category_reparenting_children.sql (issue #59 —
+-- atomic reparent-then-delete for the category taxonomy).
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(8);
+
+-- ============================================================================
+-- Function signature and security mode
+-- ============================================================================
+
+select has_function('public', 'delete_category_reparenting_children',
+  array['uuid'],
+  'delete_category_reparenting_children function exists');
+
+select is(
+  (select prosecdef from pg_proc
+    where proname='delete_category_reparenting_children'
+      and pronamespace='public'::regnamespace),
+  false,
+  'delete_category_reparenting_children is SECURITY INVOKER (RLS applies)'
+);
+
+-- ============================================================================
+-- Fixtures: two owners so RLS isolation can be exercised
+-- ============================================================================
+
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values
+  ('11111111-1111-1111-1111-111111111111'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'owner-a@local', '', now(), now(), now(), 'authenticated', 'authenticated'),
+  ('22222222-2222-2222-2222-222222222222'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'owner-b@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+-- Owner A's tree: gp → node → child, plus a root → rootChild pair.
+insert into categories (id, user_id, slug, title, parent_category_id) values
+  ('a0000000-0000-0000-0000-0000000000a1'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'gp', 'Grandparent', NULL),
+  ('a0000000-0000-0000-0000-0000000000a2'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'node', 'Node',
+   'a0000000-0000-0000-0000-0000000000a1'::uuid),
+  ('a0000000-0000-0000-0000-0000000000a3'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'child', 'Child',
+   'a0000000-0000-0000-0000-0000000000a2'::uuid),
+  ('a0000000-0000-0000-0000-0000000000a4'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'root', 'Root', NULL),
+  ('a0000000-0000-0000-0000-0000000000a5'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'rootchild', 'Root Child',
+   'a0000000-0000-0000-0000-0000000000a4'::uuid);
+
+-- Owner B's category (invisible to A under RLS).
+insert into categories (id, user_id, slug, title, parent_category_id) values
+  ('b0000000-0000-0000-0000-0000000000b1'::uuid,
+   '22222222-2222-2222-2222-222222222222', 'b-cat', 'B Category', NULL);
+
+-- ============================================================================
+-- Reparent-then-delete as owner A: node is removed, its child moves up to gp
+-- ============================================================================
+
+set local role authenticated;
+set local request.jwt.claims to '{"sub":"11111111-1111-1111-1111-111111111111"}';
+
+select lives_ok(
+  $$ select public.delete_category_reparenting_children(
+       'a0000000-0000-0000-0000-0000000000a2'::uuid) $$,
+  'owner can reparent-then-delete their own category'
+);
+
+select is(
+  (select count(*)::int from categories
+    where id = 'a0000000-0000-0000-0000-0000000000a2'::uuid),
+  0,
+  'the target node is deleted'
+);
+
+select is(
+  (select parent_category_id from categories
+    where id = 'a0000000-0000-0000-0000-0000000000a3'::uuid),
+  'a0000000-0000-0000-0000-0000000000a1'::uuid,
+  'the child is reparented to the grandparent, not cascade-deleted'
+);
+
+-- Deleting a root node moves its children to root (NULL parent).
+select public.delete_category_reparenting_children(
+  'a0000000-0000-0000-0000-0000000000a4'::uuid);
+
+select is(
+  (select parent_category_id from categories
+    where id = 'a0000000-0000-0000-0000-0000000000a5'::uuid),
+  NULL::uuid,
+  'a root node''s children are reparented to root (NULL)'
+);
+
+-- ============================================================================
+-- RLS isolation: A cannot delete B's category — it is invisible, so the
+-- function raises "not found" (SQLSTATE P0002) and B's row is untouched.
+-- ============================================================================
+
+select throws_ok(
+  $$ select public.delete_category_reparenting_children(
+       'b0000000-0000-0000-0000-0000000000b1'::uuid) $$,
+  'P0002',
+  NULL,
+  'deleting another owner''s category raises not-found (RLS hides it)'
+);
+
+reset role; reset request.jwt.claims;
+
+select is(
+  (select count(*)::int from categories
+    where id = 'b0000000-0000-0000-0000-0000000000b1'::uuid),
+  1,
+  'the other owner''s category is left untouched'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/00027_categories_same_owner_parent_test.sql
+++ b/supabase/tests/database/00027_categories_same_owner_parent_test.sql
@@ -1,4 +1,4 @@
--- pgTAP tests for 00027_categories_same_owner_parent.sql (issue #59 / PR #338 —
+-- pgTAP tests for 00027_categories_same_owner_parent.sql (issue #59 —
 -- category nesting is constrained to a single owner via a composite FK).
 begin;
 create extension if not exists pgtap with schema extensions;

--- a/supabase/tests/database/00027_categories_same_owner_parent_test.sql
+++ b/supabase/tests/database/00027_categories_same_owner_parent_test.sql
@@ -1,0 +1,82 @@
+-- pgTAP tests for 00027_categories_same_owner_parent.sql (issue #59 / PR #338 —
+-- category nesting is constrained to a single owner via a composite FK).
+begin;
+create extension if not exists pgtap with schema extensions;
+
+select plan(6);
+
+-- ============================================================================
+-- Constraint shape
+-- ============================================================================
+
+select col_is_unique('categories', array['user_id', 'id'],
+  'categories has a UNIQUE (user_id, id) key for the composite FK to target');
+
+select fk_ok(
+  'public', 'categories', array['user_id', 'parent_category_id'],
+  'public', 'categories', array['user_id', 'id'],
+  'parent link is an owner-scoped composite FK (user_id, parent_category_id)'
+    || ' -> (user_id, id)');
+
+-- ============================================================================
+-- Fixtures: two owners, each with a root category
+-- ============================================================================
+
+insert into auth.users (id, instance_id, email, encrypted_password,
+                        email_confirmed_at, created_at, updated_at, aud, role)
+  values
+  ('11111111-1111-1111-1111-111111111111'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'owner-a@local', '', now(), now(), now(), 'authenticated', 'authenticated'),
+  ('22222222-2222-2222-2222-222222222222'::uuid,
+   '00000000-0000-0000-0000-000000000000'::uuid,
+   'owner-b@local', '', now(), now(), now(), 'authenticated', 'authenticated');
+
+insert into categories (id, user_id, slug, title, parent_category_id) values
+  ('a0000000-0000-0000-0000-0000000000a1'::uuid,
+   '11111111-1111-1111-1111-111111111111', 'a-root', 'A Root', NULL),
+  ('b0000000-0000-0000-0000-0000000000b1'::uuid,
+   '22222222-2222-2222-2222-222222222222', 'b-root', 'B Root', NULL);
+
+-- ============================================================================
+-- Same-owner nesting and roots are still allowed
+-- ============================================================================
+
+select lives_ok(
+  $$ insert into categories (id, user_id, slug, title, parent_category_id)
+     values ('a0000000-0000-0000-0000-0000000000a2'::uuid,
+             '11111111-1111-1111-1111-111111111111', 'a-child', 'A Child',
+             'a0000000-0000-0000-0000-0000000000a1'::uuid) $$,
+  'a child may nest under a same-owner parent');
+
+select lives_ok(
+  $$ insert into categories (id, user_id, slug, title, parent_category_id)
+     values ('a0000000-0000-0000-0000-0000000000a3'::uuid,
+             '11111111-1111-1111-1111-111111111111', 'a-root2', 'A Root 2',
+             NULL) $$,
+  'a root category (NULL parent) is still allowed');
+
+-- ============================================================================
+-- Cross-owner nesting is rejected by the composite FK (23503) — on both INSERT
+-- of a new child and UPDATE re-pointing an existing one at another owner.
+-- ============================================================================
+
+select throws_ok(
+  $$ insert into categories (id, user_id, slug, title, parent_category_id)
+     values ('a0000000-0000-0000-0000-0000000000a4'::uuid,
+             '11111111-1111-1111-1111-111111111111', 'a-cross', 'A Cross',
+             'b0000000-0000-0000-0000-0000000000b1'::uuid) $$,
+  '23503',
+  NULL,
+  'inserting a child under another owner''s category is rejected');
+
+select throws_ok(
+  $$ update categories
+     set parent_category_id = 'b0000000-0000-0000-0000-0000000000b1'::uuid
+     where id = 'a0000000-0000-0000-0000-0000000000a2'::uuid $$,
+  '23503',
+  NULL,
+  're-pointing an existing child at another owner''s category is rejected');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #59.

Hardens the category service and closes the hierarchy-management edge cases from the issue's acceptance criteria. Follows the #58 story-service hardening as a template and the `assertNoDetailTimelineCycle` precedent for cycle detection.

Most of the work is service-layer, with two supporting migrations: an atomic reparent-then-delete Postgres function (`00026`) and an owner-scoped parent constraint (`00027`).

## Changes

**Cycle prevention** — new `assertNoCategoryCycle(client, categoryId, newParentId)` walks the ancestor chain upward from the candidate parent and throws if it reaches the node being moved. This catches both self-parenting and assigning a descendant as parent (an upward walk is sufficient and cheaper than enumerating descendants). A `visited` set guards against looping on already-corrupt data. `updateCategory` runs the guard before any reparent to a non-null parent. Service-layer by design, per [system-design §3.4](docs/system-design.md) — `parent_category_id` is intentionally not cycle-constrained at the DB level.

**Reparent-to-root** — `parent_category_id` is now `.nullable().optional()` in the schema, so `updateCategory({ parent_category_id: null })` moves a node to root. A move to root skips the cycle check (always safe).

**Delete policy** — new `deleteCategoryReparentingChildren` implements wireframe-24 "Option A": re-points direct children to the target's own parent (grandparent, or root) before deleting only the target, preserving the subtree. `deleteCategory` is documented as "Option B" — the raw DB cascade (subtree + `event_categories` untagging).

**Deterministic tree ordering** — `getCategoryTree` now sorts each level by title, then `id` as a stable tie-break, so equal-title siblings never reorder across fetches.

## Migrations

**`00026_delete_category_reparenting_children.sql`** — makes reparent-then-delete atomic. `deleteCategoryReparentingChildren` calls this `SECURITY INVOKER` Postgres function, which reparents children and deletes the target in a single transaction (both commit or neither). A `FOR UPDATE` lock on the target serializes concurrent child inserts, so a child added mid-operation fails its FK check cleanly instead of being silently cascade-deleted. `EXECUTE` revoked from `anon` (read-only per ADR-0034), granted to `authenticated` + `service_role`.

**`00027_categories_same_owner_parent.sql`** — constrains category nesting to a single owner (addresses a PR-review finding). `read_categories` is `USING (true)` and the write policies only check `user_id = auth.uid()` on the mutated row, so a user could point `parent_category_id` at another owner's category; combined with `ON DELETE CASCADE`, that let one owner's delete cascade into another owner's subtree. The single-column self-FK is replaced with a composite FK `(user_id, parent_category_id) → categories(user_id, id)` (backed by a `UNIQUE (user_id, id)` key), so a parent must be same-owner. Roots (NULL parent) are unaffected under MATCH SIMPLE. This is a DB-level guarantee (stronger than an RLS `WITH CHECK`, which `service_role` bypasses).

## Acceptance criteria

- [x] Circular-reference prevention enforced (service-layer; excludes self + descendants)
- [x] Delete behavior explicit: raw cascade vs. atomic reparent-then-delete
- [x] Tree query ordering deterministic (alphabetical by title, id tie-break)
- [x] Service + tests aligned with the events-only categories schema

## Testing

Service unit tests cover cycle detection (self, descendant, valid parent, pre-existing-cycle termination, DB error), the three reparent paths, the reparent-then-delete RPC, and the ordering tie-break. New pgTAP tests cover the atomic delete function (signature, reparent+delete, root-node case, RLS isolation) and the same-owner FK (composite-FK shape, same-owner nesting, root, cross-owner INSERT and UPDATE both rejected with 23503). Full DB suite green (442 tests); `format`, `check-types`, `lint`, `test:coverage`, `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)