### PR TITLE
feat(ui): add useEventsInPeriod query hook (#61)

### DIFF
--- a/packages/ui/src/hooks/use-periods.test.tsx
+++ b/packages/ui/src/hooks/use-periods.test.tsx
@@ -123,6 +123,10 @@ describe("useChildPeriods", () => {
 describe("useEventsInPeriod", () => {
   const mockEvents = [{ id: "event-1", title: "Fall of Rome" }];
 
+  beforeEach(() => {
+    vi.mocked(getEventsInPeriod).mockClear();
+  });
+
   it("calls getEventsInPeriod with client, periodId and default options", async () => {
     vi.mocked(getEventsInPeriod).mockResolvedValue(mockEvents as never);
     const { wrapper } = createWrapper();
@@ -150,7 +154,7 @@ describe("useEventsInPeriod", () => {
     });
   });
 
-  it("is refreshed when the parent period detail is invalidated", async () => {
+  it("refetches when the parent period detail is invalidated", async () => {
     vi.mocked(getEventsInPeriod).mockResolvedValue(mockEvents as never);
     const { wrapper, queryClient } = createWrapper();
     const { result } = renderHook(
@@ -159,14 +163,15 @@ describe("useEventsInPeriod", () => {
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getEventsInPeriod).toHaveBeenCalledTimes(1);
 
     // The events key nests under detail(periodId), so a detail invalidation
-    // (as issued by span edits / timeline association) matches it too.
-    const matched = queryClient
-      .getQueryCache()
-      .findAll({ queryKey: periodKeys.detail("period-1") })
-      .map((q) => q.queryKey);
-    expect(matched).toContainEqual(periodKeys.events("period-1", {}));
+    // (as issued by span edits / timeline association) refetches it too.
+    await queryClient.invalidateQueries({
+      queryKey: periodKeys.detail("period-1"),
+    });
+
+    await waitFor(() => expect(getEventsInPeriod).toHaveBeenCalledTimes(2));
   });
 });
 

--- a/packages/ui/src/hooks/use-periods.test.tsx
+++ b/packages/ui/src/hooks/use-periods.test.tsx
@@ -10,6 +10,7 @@ import {
   useUpdatePeriod,
   useDeletePeriod,
   useChildPeriods,
+  useEventsInPeriod,
   useAddPeriodToTimeline,
   useRemovePeriodFromTimeline,
   periodKeys,
@@ -23,6 +24,7 @@ vi.mock("@repo/services/period-service", () => ({
   updatePeriod: vi.fn(),
   deletePeriod: vi.fn(),
   getChildPeriods: vi.fn(),
+  getEventsInPeriod: vi.fn(),
   addPeriodToTimeline: vi.fn(),
   removePeriodFromTimeline: vi.fn(),
 }));
@@ -35,6 +37,7 @@ import {
   updatePeriod,
   deletePeriod,
   getChildPeriods,
+  getEventsInPeriod,
   addPeriodToTimeline,
   removePeriodFromTimeline,
 } from "@repo/services/period-service";
@@ -114,6 +117,56 @@ describe("useChildPeriods", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(getChildPeriods).toHaveBeenCalledWith(mockClient, "period-1");
+  });
+});
+
+describe("useEventsInPeriod", () => {
+  const mockEvents = [{ id: "event-1", title: "Fall of Rome" }];
+
+  it("calls getEventsInPeriod with client, periodId and default options", async () => {
+    vi.mocked(getEventsInPeriod).mockResolvedValue(mockEvents as never);
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useEventsInPeriod(mockClient, "period-1"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getEventsInPeriod).toHaveBeenCalledWith(mockClient, "period-1", {});
+    expect(result.current.data).toEqual(mockEvents);
+  });
+
+  it("forwards the timelineScoped option to the service", async () => {
+    vi.mocked(getEventsInPeriod).mockResolvedValue(mockEvents as never);
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useEventsInPeriod(mockClient, "period-1", { timelineScoped: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getEventsInPeriod).toHaveBeenCalledWith(mockClient, "period-1", {
+      timelineScoped: true,
+    });
+  });
+
+  it("is refreshed when the parent period detail is invalidated", async () => {
+    vi.mocked(getEventsInPeriod).mockResolvedValue(mockEvents as never);
+    const { wrapper, queryClient } = createWrapper();
+    const { result } = renderHook(
+      () => useEventsInPeriod(mockClient, "period-1"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The events key nests under detail(periodId), so a detail invalidation
+    // (as issued by span edits / timeline association) matches it too.
+    const matched = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: periodKeys.detail("period-1") })
+      .map((q) => q.queryKey);
+    expect(matched).toContainEqual(periodKeys.events("period-1", {}));
   });
 });
 
@@ -276,5 +329,24 @@ describe("periodKeys", () => {
       "user-1",
       "dark-ages",
     ]);
+    expect(periodKeys.events("period-1")).toEqual([
+      "periods",
+      "detail",
+      "period-1",
+      "events",
+      {},
+    ]);
+  });
+
+  it("includes options in the events key so scoped and unscoped queries do not collide", () => {
+    expect(periodKeys.events("period-1", { timelineScoped: true })).not.toEqual(
+      periodKeys.events("period-1", {}),
+    );
+  });
+
+  it("nests the events key under detail for prefix invalidation", () => {
+    const detail = periodKeys.detail("period-1");
+    const events = periodKeys.events("period-1", {});
+    expect(events.slice(0, detail.length)).toEqual([...detail]);
   });
 });

--- a/packages/ui/src/hooks/use-periods.tsx
+++ b/packages/ui/src/hooks/use-periods.tsx
@@ -19,11 +19,13 @@ import {
   getChildPeriods,
   addPeriodToTimeline,
   removePeriodFromTimeline,
+  getEventsInPeriod,
 } from "@repo/services/period-service";
 import type {
   PeriodFilters,
   PeriodWithRelations,
   CreatePeriodInput,
+  EventsInPeriodOptions,
 } from "@repo/services/period-service";
 
 type ServiceClient = Parameters<typeof getPeriods>[0];
@@ -42,6 +44,8 @@ export const periodKeys = {
   bySlug: (userId: string, slug: string) =>
     [...periodKeys.all, "slug", userId, slug] as const,
   children: (id: string) => [...periodKeys.all, "children", id] as const,
+  events: (id: string, options: EventsInPeriodOptions = {}) =>
+    [...periodKeys.detail(id), "events", options] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -108,6 +112,30 @@ export function useChildPeriods(
     queryFn: () => getChildPeriods(client, parentPeriodId),
     staleTime: 30_000,
     ...options,
+  });
+}
+
+/**
+ * Fetch the events falling within a period's temporal span (span-overlay model —
+ * there is no `period_events` junction). Pass `{ timelineScoped: true }` to limit
+ * results to the timelines the period overlays. The query key nests under
+ * `detail(periodId)`, so any invalidation of the period detail (span edits,
+ * timeline association changes) refreshes this query automatically.
+ */
+export function useEventsInPeriod(
+  client: ServiceClient,
+  periodId: string,
+  serviceOptions: EventsInPeriodOptions = {},
+  queryOptions?: Omit<
+    UseQueryOptions<Awaited<ReturnType<typeof getEventsInPeriod>>>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery({
+    queryKey: periodKeys.events(periodId, serviceOptions),
+    queryFn: () => getEventsInPeriod(client, periodId, serviceOptions),
+    staleTime: 30_000,
+    ...queryOptions,
   });
 }
 


### PR DESCRIPTION
## Summary

Closes #61

Verify & consolidate Stories/Categories/Periods hooks + Zustand stores.

The issue's 2026-06-17 scope described three hook-layer work items and gated two on then-open service issues. Verifying against the current tree (all deps #58/#59/#60/#183/#33/#34 now **closed**) showed two already shipped:

| Item | State |
|---|---|
| `useReorderStoryEvent` | Already shipped (`use-stories.tsx`) |
| Category tree + reparent (`useCategoryTree`, `useUpdateCategory` + service cycle guard) | Already shipped |
| **Period events-in-range hook** | **This PR** — service `getEventsInPeriod` existed (#60) but had no consuming hook |

## Changes (`packages/ui`)

- Add `useEventsInPeriod(client, periodId, serviceOptions?, queryOptions?)` wrapping the span-overlay events-in-range service, with `timelineScoped` passthrough.
- Add `periodKeys.events(id, options)` **nested under `detail(id)`** — existing detail-prefix invalidations (span edits via `useUpdatePeriod`, timeline association via `useAdd/RemovePeriodToTimeline`) refresh it for free, so no mutation code changed. `options` participates in the key so scoped/unscoped queries don't collide.
- Tests: default + `timelineScoped` args, data assertion, nested-key invalidation contract, and key-shape assertions.

## Zustand stores

No new store — the two existing stores (`ui-store`, `navigation-store`) cover per-route UI state (modals/toasts, `selectedPeriodId`). Per-route UI reuses `ui-store`.

## Verification

All gates pass: `format` · `check-types` · `lint` (0 warnings) · `test:coverage` (455 UI tests, `use-periods.tsx` **100%**) · `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)