### PR TITLE
feat(admin): build Story CRUD pages — list, editor, detail (#62)

### DIFF
--- a/apps/admin/app/(protected)/characters/[slug]/_components/character-detail-client.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/_components/character-detail-client.tsx
@@ -42,7 +42,7 @@ import {
   CharacterTypeBadge,
   CHARACTER_TYPE_ICON,
   type CharacterType,
-} from "../../_components/character-type-badge";
+} from "@repo/ui/components/character-type-badge";
 import { CharacterOverviewTab } from "./character-overview-tab";
 import { CharacterEventsTab } from "./character-events-tab";
 import { CharacterRelationshipsTab } from "./character-relationships-tab";

--- a/apps/admin/app/(protected)/stories/[slug]/_components/story-characters-tab.tsx
+++ b/apps/admin/app/(protected)/stories/[slug]/_components/story-characters-tab.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import * as React from "react";
+import { Plus, X } from "lucide-react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@repo/services/supabase/types";
+import type {
+  StoryCharacterRole,
+  StoryWithRelations,
+} from "@repo/services/story-service";
+import {
+  useAddCharacterToStory,
+  useRemoveCharacterFromStory,
+  useUpdateStoryCharacterRole,
+} from "@repo/ui/hooks/use-stories";
+import { useCharacters } from "@repo/ui/hooks/use-characters";
+import { toast } from "@repo/ui/components/sonner";
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import {
+  CharacterTypeBadge,
+  type CharacterType,
+} from "@repo/ui/components/character-type-badge";
+
+type ServiceClient = SupabaseClient<Database>;
+type StoryCharacterRow = NonNullable<
+  StoryWithRelations["story_characters"]
+>[number];
+
+const ROLE_OPTIONS: { value: StoryCharacterRole; label: string }[] = [
+  { value: "protagonist", label: "Protagonist" },
+  { value: "supporting", label: "Supporting" },
+  { value: "mentioned", label: "Mentioned" },
+  { value: "narrator", label: "Narrator" },
+];
+
+type CharacterInfo = { name: string; character_type: CharacterType };
+
+export function StoryCharactersTab({
+  client,
+  storyId,
+  userId,
+  canEdit,
+  storyCharacters,
+  isFirstPerson,
+  onMutated,
+}: {
+  client: ServiceClient;
+  storyId: string;
+  userId: string;
+  canEdit: boolean;
+  storyCharacters: StoryCharacterRow[];
+  isFirstPerson: boolean;
+  onMutated: () => void;
+}) {
+  const { data: characters = [], isPending } = useCharacters(
+    client,
+    { userId, pageSize: 100, sortBy: "name" },
+    { enabled: userId !== "" },
+  );
+
+  const infoMap = React.useMemo(() => {
+    const map = new Map<string, CharacterInfo>();
+    for (const c of characters) {
+      map.set(c.id, {
+        name: c.name,
+        character_type: c.character_type as CharacterType,
+      });
+    }
+    return map;
+  }, [characters]);
+
+  const addCharacter = useAddCharacterToStory(client);
+  const removeCharacter = useRemoveCharacterFromStory(client);
+  const updateRole = useUpdateStoryCharacterRole(client);
+
+  const linkedIds = React.useMemo(
+    () => new Set(storyCharacters.map((sc) => sc.character_id)),
+    [storyCharacters],
+  );
+  const [pickerOpen, setPickerOpen] = React.useState(false);
+  const candidates = characters.filter((c) => !linkedIds.has(c.id));
+
+  function handleAdd(characterId: string) {
+    addCharacter.mutate(
+      { storyId, characterId, role: "mentioned" },
+      {
+        onSuccess: () => {
+          toast.success("Character added to story.");
+          onMutated();
+        },
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Couldn't add character.",
+          ),
+      },
+    );
+  }
+
+  function handleRoleChange(characterId: string, role: StoryCharacterRole) {
+    updateRole.mutate(
+      { storyId, characterId, role },
+      {
+        onSuccess: onMutated,
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Couldn't update role.",
+          ),
+      },
+    );
+  }
+
+  function handleRemove(sc: StoryCharacterRow) {
+    removeCharacter.mutate(
+      { storyId, characterId: sc.character_id },
+      {
+        onSuccess: () => {
+          // Soft, non-blocking warning: removing the narrator of a first-person
+          // story leaves the voice without its point-of-view character.
+          if (isFirstPerson && sc.role_in_story === "narrator") {
+            toast.warning(
+              "Removed the narrator of a first-person story — set a new perspective character in the editor.",
+            );
+          } else {
+            toast.success("Character removed from story.");
+          }
+          onMutated();
+        },
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Couldn't remove character.",
+          ),
+      },
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {canEdit && (
+        <div className="flex justify-end">
+          <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+            <PopoverTrigger asChild>
+              <Button size="sm" variant="secondary">
+                <Plus className="mr-1.5 h-4 w-4" />
+                Add character
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-80 p-0" align="end">
+              <Command>
+                <CommandInput placeholder="Search characters…" />
+                <CommandList>
+                  <CommandEmpty>
+                    {isPending ? "Loading…" : "No characters found."}
+                  </CommandEmpty>
+                  <CommandGroup>
+                    {candidates.map((c) => (
+                      <CommandItem
+                        key={c.id}
+                        value={c.name}
+                        onSelect={() => {
+                          handleAdd(c.id);
+                          setPickerOpen(false);
+                        }}
+                      >
+                        <CharacterTypeBadge
+                          type={c.character_type as CharacterType}
+                          label={c.name}
+                        />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+      )}
+
+      {storyCharacters.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 py-12 text-center text-muted-foreground">
+          <p className="text-sm">No characters in this story yet.</p>
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {storyCharacters.map((sc) => {
+            const info = infoMap.get(sc.character_id);
+            const role = (sc.role_in_story ??
+              "mentioned") as StoryCharacterRole;
+            return (
+              <div
+                key={sc.character_id}
+                className="flex items-center gap-3 rounded-md border border-border bg-background px-4 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  {info ? (
+                    <CharacterTypeBadge
+                      type={info.character_type}
+                      label={info.name}
+                    />
+                  ) : (
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {sc.character_id}
+                    </span>
+                  )}
+                </div>
+                {canEdit ? (
+                  <select
+                    value={role}
+                    onChange={(e) =>
+                      handleRoleChange(
+                        sc.character_id,
+                        e.target.value as StoryCharacterRole,
+                      )
+                    }
+                    aria-label="Role in story"
+                    className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                  >
+                    {ROLE_OPTIONS.map((r) => (
+                      <option key={r.value} value={r.value}>
+                        {r.label}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <span className="text-xs capitalize text-muted-foreground">
+                    {role}
+                  </span>
+                )}
+                {canEdit && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(sc)}
+                    aria-label="Remove character"
+                    className="rounded p-1 text-muted-foreground hover:text-destructive"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/stories/[slug]/_components/story-detail-client.tsx
+++ b/apps/admin/app/(protected)/stories/[slug]/_components/story-detail-client.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronUp, MoreHorizontal } from "lucide-react";
+import { toast } from "@repo/ui/components/sonner";
+
+import {
+  storyKeys,
+  useStoryBySlug,
+  usePublishStory,
+  useUnpublishStory,
+  useDeleteStory,
+} from "@repo/ui/hooks/use-stories";
+import { useCharacters } from "@repo/ui/hooks/use-characters";
+import { getBrowserSupabaseClient } from "../../../../../lib/auth/browser-client";
+
+import { Button, buttonVariants } from "@repo/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@repo/ui/components/dropdown-menu";
+import { PublishControl } from "@repo/ui/components/publish-control";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@repo/ui/components/tabs";
+import {
+  CharacterTypeBadge,
+  type CharacterType,
+} from "@repo/ui/components/character-type-badge";
+
+import { StoryEventsTab } from "./story-events-tab";
+import { StoryCharactersTab } from "./story-characters-tab";
+import { StoryPeriodsTab } from "./story-periods-tab";
+
+const NARRATOR_LABEL: Record<string, string> = {
+  first_person: "First-person",
+  third_person: "Third-person",
+  omniscient: "Omniscient",
+};
+
+export function StoryDetailClient({
+  userId,
+  slug,
+}: {
+  userId: string;
+  slug: string;
+}) {
+  const router = useRouter();
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+  const queryClient = useQueryClient();
+
+  const {
+    data: story,
+    isPending,
+    isError,
+  } = useStoryBySlug(client, userId, slug);
+
+  // Resolve the perspective character's identity for the header voice line.
+  // Shares the cache key with the tabs' character query.
+  const { data: characters = [] } = useCharacters(
+    client,
+    { userId, pageSize: 100, sortBy: "name" },
+    { enabled: userId !== "" },
+  );
+
+  const [tab, setTab] = React.useState("events");
+  const [showDelete, setShowDelete] = React.useState(false);
+  const [showDangerZone, setShowDangerZone] = React.useState(false);
+
+  const publish = usePublishStory(client);
+  const unpublish = useUnpublishStory(client);
+  const deleteStory = useDeleteStory(client);
+
+  // Junction mutations invalidate storyKeys.detail(id), but this page reads via
+  // bySlug — refresh that query after a tab mutation.
+  const refreshStory = React.useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: storyKeys.bySlug(userId, slug),
+    });
+  }, [queryClient, userId, slug]);
+
+  if (isPending) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-8 w-64 rounded-md" />
+        <Skeleton className="h-4 w-96 rounded-md" />
+        <Skeleton className="h-4 w-48 rounded-md" />
+        <div className="mt-6 space-y-2">
+          {[1, 2, 3, 4].map((step) => (
+            <Skeleton key={step} className="h-14 w-full rounded-md" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !story) {
+    return (
+      <div className="p-6 text-center space-y-4">
+        <p className="text-muted-foreground">Story not found.</p>
+        <Link
+          href="/stories"
+          className={buttonVariants({ variant: "secondary", size: "sm" })}
+        >
+          Back to stories
+        </Link>
+      </div>
+    );
+  }
+
+  const isOwner = story.user_id === userId;
+  const canEdit = isOwner;
+  const editHref = `/stories/${slug}/edit`;
+  const isFirstPerson = story.narrator_type === "first_person";
+
+  const perspective =
+    story.perspective_character_id !== null
+      ? (characters.find((c) => c.id === story.perspective_character_id) ??
+        null)
+      : null;
+
+  const storyCharacters = story.story_characters ?? [];
+  const storyPeriods = story.story_periods ?? [];
+  const eventCount = story.story_events?.length ?? 0;
+
+  const hasProse =
+    (story.summary && story.summary.length > 0) ||
+    (story.detail && story.detail.length > 0);
+
+  return (
+    <div className="p-6 space-y-6 max-w-4xl">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 space-y-1">
+          <nav className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Link href="/stories" className="hover:text-foreground">
+              Stories
+            </Link>
+            <span aria-hidden>▸</span>
+          </nav>
+          <h1 className="truncate text-2xl font-bold tracking-tight">
+            {story.title}
+          </h1>
+          {story.sub_title && (
+            <p className="truncate text-sm text-muted-foreground">
+              {story.sub_title}
+            </p>
+          )}
+          {/* Voice line. Publication state is carried by PublishControl on the
+              right, so it is intentionally not repeated here. */}
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span>
+              {story.narrator_type
+                ? (NARRATOR_LABEL[story.narrator_type] ?? story.narrator_type)
+                : "—"}
+            </span>
+            {perspective && (
+              <>
+                <span aria-hidden>· through</span>
+                <CharacterTypeBadge
+                  type={perspective.character_type as CharacterType}
+                  label={perspective.name}
+                />
+              </>
+            )}
+            <span className="font-mono">· {story.slug}</span>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <PublishControl
+            published={story.published ?? false}
+            entityLabel="story"
+            canPublish={isOwner}
+            onPublish={() =>
+              publish.mutate(story.id, {
+                onSuccess: () => toast.success("Story published."),
+                onError: (err) =>
+                  toast.error(
+                    err instanceof Error ? err.message : "Publish failed",
+                  ),
+              })
+            }
+            onUnpublish={() =>
+              unpublish.mutate(story.id, {
+                onSuccess: () => toast.success("Story unpublished."),
+                onError: (err) =>
+                  toast.error(
+                    err instanceof Error ? err.message : "Unpublish failed",
+                  ),
+              })
+            }
+          />
+          {canEdit && (
+            <Link
+              href={editHref}
+              className={buttonVariants({ variant: "secondary", size: "sm" })}
+            >
+              Edit
+            </Link>
+          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+                aria-label="More actions"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => void navigator.clipboard.writeText(story.id)}
+              >
+                Copy ID
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Prose body (summary + detail). Rendered as plain text with preserved
+          whitespace — rich Markdown rendering is a non-goal for the admin app. */}
+      {hasProse ? (
+        <div className="space-y-3">
+          {story.summary && (
+            <p className="whitespace-pre-wrap text-sm text-foreground">
+              {story.summary}
+            </p>
+          )}
+          {story.detail && (
+            <p className="whitespace-pre-wrap text-sm text-muted-foreground">
+              {story.detail}
+            </p>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No prose written yet.</p>
+      )}
+
+      {/* Tabs */}
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList>
+          <TabsTrigger value="events">Events ({eventCount})</TabsTrigger>
+          <TabsTrigger value="characters">
+            Characters ({storyCharacters.length})
+          </TabsTrigger>
+          <TabsTrigger value="periods">
+            Periods ({storyPeriods.length})
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="events" className="pt-4">
+          <StoryEventsTab
+            client={client}
+            storyId={story.id}
+            userId={userId}
+            canEdit={canEdit}
+            onMutated={refreshStory}
+          />
+        </TabsContent>
+
+        <TabsContent value="characters" className="pt-4">
+          <StoryCharactersTab
+            client={client}
+            storyId={story.id}
+            userId={userId}
+            canEdit={canEdit}
+            storyCharacters={storyCharacters}
+            isFirstPerson={isFirstPerson}
+            onMutated={refreshStory}
+          />
+        </TabsContent>
+
+        <TabsContent value="periods" className="pt-4">
+          <StoryPeriodsTab
+            client={client}
+            storyId={story.id}
+            userId={userId}
+            canEdit={canEdit}
+            storyPeriods={storyPeriods}
+            onMutated={refreshStory}
+          />
+        </TabsContent>
+      </Tabs>
+
+      {/* Danger zone */}
+      {isOwner && (
+        <div className="rounded-md border border-destructive/30">
+          <button
+            type="button"
+            aria-expanded={showDangerZone}
+            className="flex w-full items-center gap-2 px-4 py-3 text-sm text-destructive transition-colors hover:bg-destructive/5"
+            onClick={() => setShowDangerZone((v) => !v)}
+          >
+            {showDangerZone ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+            Danger zone
+          </button>
+          {showDangerZone && (
+            <div className="border-t border-destructive/20 px-4 pb-4 pt-1">
+              <p className="mb-3 text-xs text-muted-foreground">
+                Deleting a story is permanent and cannot be undone. Its event,
+                character, and period associations will be removed (the events,
+                characters, and periods themselves are untouched).
+              </p>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setShowDelete(true)}
+              >
+                Delete story
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Delete confirmation */}
+      <Dialog
+        open={showDelete}
+        onOpenChange={(o) => {
+          if (!o) setShowDelete(false);
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete story?</DialogTitle>
+            <DialogDescription>
+              <strong>{story.title}</strong> and all its associations will be
+              permanently deleted. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowDelete(false)}
+              disabled={deleteStory.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={deleteStory.isPending}
+              onClick={() =>
+                deleteStory.mutate(story.id, {
+                  onSuccess: () => {
+                    toast.success("Story deleted.");
+                    router.push("/stories");
+                  },
+                  onError: (err) =>
+                    toast.error(
+                      err instanceof Error ? err.message : "Delete failed",
+                    ),
+                })
+              }
+            >
+              {deleteStory.isPending ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/stories/[slug]/_components/story-events-tab.tsx
+++ b/apps/admin/app/(protected)/stories/[slug]/_components/story-events-tab.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { ChevronDown, ChevronUp, Plus, X } from "lucide-react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@repo/services/supabase/types";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import {
+  useStoryEvents,
+  useAddEventToStory,
+  useRemoveEventFromStory,
+  useReorderStoryEvent,
+} from "@repo/ui/hooks/use-stories";
+import { useEvents } from "@repo/ui/hooks/use-events";
+import { toast } from "@repo/ui/components/sonner";
+import { Badge } from "@repo/ui/components/badge";
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+import type { StoryEventWithOrder } from "@repo/services/story-service";
+
+type ServiceClient = SupabaseClient<Database>;
+
+function EventRow({
+  event,
+  index,
+  total,
+  canEdit,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+  onOpen,
+}: {
+  event: StoryEventWithOrder;
+  index: number;
+  total: number;
+  canEdit: boolean;
+  onMoveUp: (id: string) => void;
+  onMoveDown: (id: string) => void;
+  onRemove: (id: string) => void;
+  onOpen: (slug: string) => void;
+}) {
+  const importance = event.importance ?? 0;
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-background px-4 py-3 transition-colors hover:bg-muted/30">
+      {/* Narrative order index */}
+      <span className="w-6 shrink-0 text-right font-mono text-xs text-muted-foreground">
+        {index + 1}
+      </span>
+
+      {canEdit && (
+        <div className="flex shrink-0 flex-col gap-0.5">
+          <button
+            type="button"
+            disabled={index === 0}
+            onClick={() => onMoveUp(event.id)}
+            aria-label="Move up"
+            className="rounded p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+          >
+            <ChevronUp className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            disabled={index === total - 1}
+            onClick={() => onMoveDown(event.id)}
+            aria-label="Move down"
+            className="rounded p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+          >
+            <ChevronDown className="h-3 w-3" />
+          </button>
+        </div>
+      )}
+
+      {/* Chronological date, shown alongside the narrative index so flashbacks
+          stay legible. */}
+      <div className="w-28 shrink-0 text-xs text-muted-foreground">
+        <TemporalDisplay
+          value={event.temporal_data as TemporalData}
+          format="compact"
+        />
+      </div>
+
+      <button
+        type="button"
+        className="min-w-0 flex-1 truncate text-left text-sm font-medium hover:underline"
+        onClick={() => onOpen(event.slug)}
+        title={event.title}
+      >
+        {event.title}
+      </button>
+
+      <div className="flex shrink-0 items-center gap-1.5">
+        {event.event_type && (
+          <Badge variant="outline" className="text-xs capitalize">
+            {event.event_type}
+          </Badge>
+        )}
+        {importance > 0 && (
+          <span
+            className="font-mono text-xs tracking-tighter text-yellow-500"
+            title={`Importance: ${importance}/10`}
+          >
+            ★{importance}
+          </span>
+        )}
+        {canEdit && (
+          <button
+            type="button"
+            onClick={() => onRemove(event.id)}
+            aria-label="Remove from story"
+            className="ml-1 rounded p-1 text-muted-foreground hover:text-destructive"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AddEventPicker({
+  client,
+  userId,
+  linkedIds,
+  onAdd,
+}: {
+  client: ServiceClient;
+  userId: string;
+  linkedIds: Set<string>;
+  onAdd: (eventId: string) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const { data: events = [], isPending } = useEvents(
+    client,
+    { userId, pageSize: 100 },
+    { enabled: userId !== "" && open },
+  );
+  const candidates = events.filter((e) => !linkedIds.has(e.id));
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button size="sm" variant="secondary">
+          <Plus className="mr-1.5 h-4 w-4" />
+          Add event
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-0" align="end">
+        <Command>
+          <CommandInput placeholder="Search events…" />
+          <CommandList>
+            <CommandEmpty>
+              {isPending ? "Loading…" : "No events found."}
+            </CommandEmpty>
+            <CommandGroup>
+              {candidates.map((event) => (
+                <CommandItem
+                  key={event.id}
+                  value={event.title}
+                  onSelect={() => {
+                    onAdd(event.id);
+                    setOpen(false);
+                  }}
+                >
+                  {event.title}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function StoryEventsTab({
+  client,
+  storyId,
+  userId,
+  canEdit,
+  onMutated,
+}: {
+  client: ServiceClient;
+  storyId: string;
+  userId: string;
+  canEdit: boolean;
+  /** Refresh the parent's bySlug story so the tab's "(N)" count stays in sync. */
+  onMutated: () => void;
+}) {
+  const router = useRouter();
+  const { data: events = [], isPending } = useStoryEvents(client, storyId);
+
+  const addEvent = useAddEventToStory(client);
+  const removeEvent = useRemoveEventFromStory(client);
+  const reorderEvent = useReorderStoryEvent(client);
+
+  // Local order for a snappy reorder UI; re-synced whenever the query data
+  // changes (e.g. after add/remove or a background refetch).
+  const [localEvents, setLocalEvents] = React.useState<StoryEventWithOrder[]>(
+    [],
+  );
+  const [prevKey, setPrevKey] = React.useState<string>("");
+  const dataKey = events.map((e) => e.id).join(",");
+  if (dataKey !== prevKey) {
+    setPrevKey(dataKey);
+    setLocalEvents(events);
+  }
+
+  const linkedIds = React.useMemo(
+    () => new Set(localEvents.map((e) => e.id)),
+    [localEvents],
+  );
+
+  function persistOrder(next: StoryEventWithOrder[]) {
+    setLocalEvents(next);
+    // Assign a 1-based editorial sort_order to every event (mirrors the
+    // timeline detail's reorder). Narrative order is the whole point here.
+    next.forEach((event, idx) => {
+      reorderEvent.mutate({ storyId, eventId: event.id, sortOrder: idx + 1 });
+    });
+  }
+
+  function handleMoveUp(eventId: string) {
+    const idx = localEvents.findIndex((e) => e.id === eventId);
+    if (idx <= 0) return;
+    const next = [...localEvents];
+    const [item] = next.splice(idx, 1);
+    next.splice(idx - 1, 0, item!);
+    persistOrder(next);
+  }
+
+  function handleMoveDown(eventId: string) {
+    const idx = localEvents.findIndex((e) => e.id === eventId);
+    if (idx < 0 || idx >= localEvents.length - 1) return;
+    const next = [...localEvents];
+    const [item] = next.splice(idx, 1);
+    next.splice(idx + 1, 0, item!);
+    persistOrder(next);
+  }
+
+  function handleAdd(eventId: string) {
+    // Append at the end of the current narrative order.
+    const nextOrder =
+      localEvents.reduce((max, e) => Math.max(max, e.junction_sort_order), 0) +
+      1;
+    addEvent.mutate(
+      { storyId, eventId, sortOrder: nextOrder },
+      {
+        onSuccess: () => {
+          toast.success("Event added to story.");
+          onMutated();
+        },
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Couldn't add event.",
+          ),
+      },
+    );
+  }
+
+  function handleRemove(eventId: string) {
+    removeEvent.mutate(
+      { storyId, eventId },
+      {
+        onSuccess: () => {
+          toast.success("Event removed from story.");
+          onMutated();
+        },
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Couldn't remove event.",
+          ),
+      },
+    );
+  }
+
+  if (isPending) {
+    return (
+      <div className="space-y-2 p-1">
+        {[1, 2, 3].map((step) => (
+          <Skeleton key={step} className="h-14 w-full rounded-md" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {canEdit && (
+        <div className="flex justify-end">
+          <AddEventPicker
+            client={client}
+            userId={userId}
+            linkedIds={linkedIds}
+            onAdd={handleAdd}
+          />
+        </div>
+      )}
+
+      {localEvents.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-12 text-center text-muted-foreground">
+          <p className="text-sm">
+            No events in this story yet. A story is the order you tell them in.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {localEvents.map((event, idx) => (
+            <EventRow
+              key={event.id}
+              event={event}
+              index={idx}
+              total={localEvents.length}
+              canEdit={canEdit}
+              onMoveUp={handleMoveUp}
+              onMoveDown={handleMoveDown}
+              onRemove={handleRemove}
+              onOpen={(slug) => router.push(`/events/${slug}`)}
+            />
+          ))}
+        </div>
+      )}
+
+      {localEvents.length > 0 && (
+        <p className="text-right text-xs text-muted-foreground">
+          {localEvents.length} event{localEvents.length !== 1 ? "s" : ""} ·
+          narrative order
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/stories/[slug]/_components/story-events-tab.tsx
+++ b/apps/admin/app/(protected)/stories/[slug]/_components/story-events-tab.tsx
@@ -225,31 +225,52 @@ export function StoryEventsTab({
     [localEvents],
   );
 
-  function persistOrder(next: StoryEventWithOrder[]) {
+  // The UI only supports adjacent up/down moves, so a move never touches more
+  // than two rows: swap the moved event with its neighbour and persist just the
+  // two affected sort_order values (2 writes, not N). This keeps every other
+  // row's sort_order untouched and avoids the partial-failure inconsistency a
+  // full-list renumber would risk on each click.
+  function moveEvent(eventId: string, dir: -1 | 1) {
+    const idx = localEvents.findIndex((e) => e.id === eventId);
+    const swapIdx = idx + dir;
+    if (idx < 0 || swapIdx < 0 || swapIdx >= localEvents.length) return;
+
+    const current = localEvents[idx]!;
+    const neighbor = localEvents[swapIdx]!;
+
+    // Swap the two rows' positions and their editorial sort_order values in one
+    // pass so rapid successive moves (before a refetch lands) stay consistent.
+    const nextCurrent: StoryEventWithOrder = {
+      ...current,
+      junction_sort_order: neighbor.junction_sort_order,
+    };
+    const nextNeighbor: StoryEventWithOrder = {
+      ...neighbor,
+      junction_sort_order: current.junction_sort_order,
+    };
+    const next = [...localEvents];
+    next[swapIdx] = nextCurrent;
+    next[idx] = nextNeighbor;
     setLocalEvents(next);
-    // Assign a 1-based editorial sort_order to every event (mirrors the
-    // timeline detail's reorder). Narrative order is the whole point here.
-    next.forEach((event, idx) => {
-      reorderEvent.mutate({ storyId, eventId: event.id, sortOrder: idx + 1 });
+
+    reorderEvent.mutate({
+      storyId,
+      eventId: current.id,
+      sortOrder: nextCurrent.junction_sort_order,
+    });
+    reorderEvent.mutate({
+      storyId,
+      eventId: neighbor.id,
+      sortOrder: nextNeighbor.junction_sort_order,
     });
   }
 
   function handleMoveUp(eventId: string) {
-    const idx = localEvents.findIndex((e) => e.id === eventId);
-    if (idx <= 0) return;
-    const next = [...localEvents];
-    const [item] = next.splice(idx, 1);
-    next.splice(idx - 1, 0, item!);
-    persistOrder(next);
+    moveEvent(eventId, -1);
   }
 
   function handleMoveDown(eventId: string) {
-    const idx = localEvents.findIndex((e) => e.id === eventId);
-    if (idx < 0 || idx >= localEvents.length - 1) return;
-    const next = [...localEvents];
-    const [item] = next.splice(idx, 1);
-    next.splice(idx + 1, 0, item!);
-    persistOrder(next);
+    moveEvent(eventId, 1);
   }
 
   function handleAdd(eventId: string) {

--- a/apps/admin/app/(protected)/stories/[slug]/_components/story-periods-tab.tsx
+++ b/apps/admin/app/(protected)/stories/[slug]/_components/story-periods-tab.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Plus, X } from "lucide-react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@repo/services/supabase/types";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import type { StoryWithRelations } from "@repo/services/story-service";
+import {
+  useAddPeriodToStory,
+  useRemovePeriodFromStory,
+} from "@repo/ui/hooks/use-stories";
+import { usePeriods } from "@repo/ui/hooks/use-periods";
+import { toast } from "@repo/ui/components/sonner";
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+
+type ServiceClient = SupabaseClient<Database>;
+type StoryPeriodRow = NonNullable<StoryWithRelations["story_periods"]>[number];
+type PeriodInfo = {
+  title: string;
+  slug: string;
+  temporal_data: TemporalData;
+  end_temporal_data: TemporalData | null;
+};
+
+export function StoryPeriodsTab({
+  client,
+  storyId,
+  userId,
+  canEdit,
+  storyPeriods,
+  onMutated,
+}: {
+  client: ServiceClient;
+  storyId: string;
+  userId: string;
+  canEdit: boolean;
+  storyPeriods: StoryPeriodRow[];
+  onMutated: () => void;
+}) {
+  const router = useRouter();
+  const { data: periods = [], isPending } = usePeriods(
+    client,
+    { userId, pageSize: 100 },
+    { enabled: userId !== "" },
+  );
+
+  const infoMap = React.useMemo(() => {
+    const map = new Map<string, PeriodInfo>();
+    for (const p of periods) {
+      map.set(p.id, {
+        title: p.title,
+        slug: p.slug,
+        temporal_data: p.temporal_data as TemporalData,
+        end_temporal_data: (p.end_temporal_data as TemporalData | null) ?? null,
+      });
+    }
+    return map;
+  }, [periods]);
+
+  const addPeriod = useAddPeriodToStory(client);
+  const removePeriod = useRemovePeriodFromStory(client);
+
+  const linkedIds = React.useMemo(
+    () => new Set(storyPeriods.map((sp) => sp.period_id)),
+    [storyPeriods],
+  );
+  const [pickerOpen, setPickerOpen] = React.useState(false);
+  const candidates = periods.filter((p) => !linkedIds.has(p.id));
+
+  function handleAdd(periodId: string) {
+    addPeriod.mutate(
+      { storyId, periodId },
+      {
+        onSuccess: () => {
+          toast.success("Period added to story.");
+          onMutated();
+        },
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Couldn't add period.",
+          ),
+      },
+    );
+  }
+
+  function handleRemove(periodId: string) {
+    removePeriod.mutate(
+      { storyId, periodId },
+      {
+        onSuccess: () => {
+          toast.success("Period removed from story.");
+          onMutated();
+        },
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : "Couldn't remove period.",
+          ),
+      },
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {canEdit && (
+        <div className="flex justify-end">
+          <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+            <PopoverTrigger asChild>
+              <Button size="sm" variant="secondary">
+                <Plus className="mr-1.5 h-4 w-4" />
+                Add period
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-80 p-0" align="end">
+              <Command>
+                <CommandInput placeholder="Search periods…" />
+                <CommandList>
+                  <CommandEmpty>
+                    {isPending ? "Loading…" : "No periods found."}
+                  </CommandEmpty>
+                  <CommandGroup>
+                    {candidates.map((p) => (
+                      <CommandItem
+                        key={p.id}
+                        value={p.title}
+                        onSelect={() => {
+                          handleAdd(p.id);
+                          setPickerOpen(false);
+                        }}
+                      >
+                        {p.title}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+      )}
+
+      {storyPeriods.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 py-12 text-center text-muted-foreground">
+          <p className="text-sm">No periods associated with this story.</p>
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {storyPeriods.map((sp) => {
+            const info = infoMap.get(sp.period_id);
+            return (
+              <div
+                key={sp.period_id}
+                className="flex items-center gap-3 rounded-md border border-border bg-background px-4 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  {info ? (
+                    <button
+                      type="button"
+                      className="text-sm font-medium hover:underline"
+                      onClick={() => router.push(`/periods/${info.slug}`)}
+                    >
+                      {info.title}
+                    </button>
+                  ) : (
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {sp.period_id}
+                    </span>
+                  )}
+                </div>
+                {info && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    <TemporalDisplay
+                      value={info.temporal_data}
+                      endValue={info.end_temporal_data ?? undefined}
+                      format="compact"
+                    />
+                  </span>
+                )}
+                {canEdit && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(sp.period_id)}
+                    aria-label="Remove period"
+                    className="rounded p-1 text-muted-foreground hover:text-destructive"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/stories/[slug]/edit/page.tsx
+++ b/apps/admin/app/(protected)/stories/[slug]/edit/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { getUser } from "../../../../../lib/auth";
+import { getServerSupabaseClient } from "../../../../auth/_lib/server-supabase";
+import { StoryFormClient } from "../../_components/story-form-client";
+
+interface EditStoryPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function EditStoryPage({ params }: EditStoryPageProps) {
+  const { slug } = await params;
+
+  // Resolve the owner id server-side (session already validated by the
+  // protected layout) so the client hook can build its (userId, slug) query
+  // key on first render without an auth round-trip / loading flash.
+  const client = await getServerSupabaseClient();
+  const user = await getUser(client);
+  if (!user) redirect("/auth/login");
+
+  return <StoryFormClient mode="edit" userId={user.id} slug={slug} />;
+}

--- a/apps/admin/app/(protected)/stories/[slug]/page.tsx
+++ b/apps/admin/app/(protected)/stories/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { getUser } from "../../../../lib/auth";
+import { getServerSupabaseClient } from "../../../auth/_lib/server-supabase";
+import { StoryDetailClient } from "./_components/story-detail-client";
+
+export const metadata = {
+  title: "Story",
+};
+
+export default async function StoryDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  // Resolve the owner id server-side (session already validated by the
+  // protected layout) so the client hook can build its (userId, slug) query
+  // key on first render without an auth round-trip / loading flash.
+  const client = await getServerSupabaseClient();
+  const user = await getUser(client);
+  if (!user) redirect("/auth/login");
+
+  return (
+    <Suspense
+      fallback={
+        <div className="p-6 space-y-4">
+          <Skeleton className="h-8 w-64 rounded-md" />
+          <Skeleton className="h-4 w-96 rounded-md" />
+          <Skeleton className="h-4 w-32 rounded-md" />
+          <div className="mt-6 space-y-2">
+            {[1, 2, 3, 4].map((step) => (
+              <Skeleton key={step} className="h-14 w-full rounded-md" />
+            ))}
+          </div>
+        </div>
+      }
+    >
+      <StoryDetailClient userId={user.id} slug={slug} />
+    </Suspense>
+  );
+}

--- a/apps/admin/app/(protected)/stories/_components/story-form-client.tsx
+++ b/apps/admin/app/(protected)/stories/_components/story-form-client.tsx
@@ -494,11 +494,7 @@ export function StoryFormClient(props: Props) {
                 <FormItem>
                   <FormLabel>Summary</FormLabel>
                   <FormControl>
-                    <Textarea
-                      rows={3}
-                      placeholder="A short hook (Markdown)"
-                      {...field}
-                    />
+                    <Textarea rows={3} placeholder="A short hook" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -514,7 +510,7 @@ export function StoryFormClient(props: Props) {
                   <FormControl>
                     <Textarea
                       rows={16}
-                      placeholder="The long-form narrative (Markdown)"
+                      placeholder="The long-form narrative"
                       className="font-mono text-sm"
                       {...field}
                     />

--- a/apps/admin/app/(protected)/stories/_components/story-form-client.tsx
+++ b/apps/admin/app/(protected)/stories/_components/story-form-client.tsx
@@ -1,0 +1,650 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { useForm, useWatch, Controller, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { generateSlug } from "@repo/services/utils/slug";
+
+import {
+  useStoryBySlug,
+  useCreateStory,
+  useUpdateStory,
+} from "@repo/ui/hooks/use-stories";
+import { useCharacters } from "@repo/ui/hooks/use-characters";
+import { useUiStore } from "@repo/ui/stores";
+
+import { Alert, AlertDescription, AlertTitle } from "@repo/ui/components/alert";
+import { AutosaveIndicator } from "@repo/ui/components/autosave-indicator";
+import { Button } from "@repo/ui/components/button";
+import { ChipInput } from "@repo/ui/components/chip-input";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/form";
+import { Input } from "@repo/ui/components/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import { SaveDropdown } from "@repo/ui/components/save-dropdown";
+import { SlugField } from "@repo/ui/components/slug-field";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { Textarea } from "@repo/ui/components/textarea";
+import {
+  CharacterTypeBadge,
+  type CharacterType,
+} from "@repo/ui/components/character-type-badge";
+import { cn } from "@repo/ui/lib/utils";
+
+import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import { useUnsavedChangesGuard } from "./use-unsaved-changes-guard";
+import {
+  storyFormSchema,
+  BLANK_VALUES,
+  mapRowToFormValues,
+  toCreateInput,
+  toUpdateData,
+  seedForAddAnother,
+  type StoryFormValues,
+  type NarratorType,
+} from "./story-form-mappers";
+
+const NARRATOR_OPTIONS: { value: NarratorType; label: string }[] = [
+  { value: "first_person", label: "First-person" },
+  { value: "third_person", label: "Third-person" },
+  { value: "omniscient", label: "Omniscient" },
+];
+
+type CharacterOption = {
+  id: string;
+  name: string;
+  character_type: CharacterType;
+};
+
+/** Searchable single-select over the user's characters, rendering type identity. */
+function PerspectivePicker({
+  options,
+  value,
+  onChange,
+  isPending,
+}: {
+  options: CharacterOption[];
+  value: string | null;
+  onChange: (id: string | null) => void;
+  isPending: boolean;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const selected = options.find((o) => o.id === value) ?? null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="secondary"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "w-full justify-between font-normal",
+            !selected && "text-foreground-muted",
+          )}
+        >
+          {selected ? (
+            <CharacterTypeBadge
+              type={selected.character_type}
+              label={selected.name}
+            />
+          ) : (
+            "Choose a character"
+          )}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput placeholder="Search characters…" />
+          <CommandList>
+            <CommandEmpty>
+              {isPending ? "Loading…" : "No characters found."}
+            </CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="__none__"
+                onSelect={() => {
+                  onChange(null);
+                  setOpen(false);
+                }}
+              >
+                <Check
+                  className={cn(
+                    "mr-2 h-4 w-4",
+                    value === null ? "opacity-100" : "opacity-0",
+                  )}
+                />
+                — none —
+              </CommandItem>
+              {options.map((option) => (
+                <CommandItem
+                  key={option.id}
+                  value={option.name}
+                  onSelect={() => {
+                    onChange(option.id === value ? null : option.id);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === option.id ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <CharacterTypeBadge
+                    type={option.character_type}
+                    label={option.name}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+type Props =
+  { mode: "create" } | { mode: "edit"; userId: string; slug: string };
+
+export function StoryFormClient(props: Props) {
+  const router = useRouter();
+  const addToast = useUiStore((s) => s.addToast);
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+
+  const createStory = useCreateStory(client);
+  const updateStory = useUpdateStory(client);
+  // A separate observer for the 30s auto-save so its pending state doesn't
+  // flicker the deliberate Save button.
+  const autosave = useUpdateStory(client);
+
+  const isEdit = props.mode === "edit";
+  const editQuery = useStoryBySlug(
+    client,
+    isEdit ? props.userId : "",
+    isEdit ? props.slug : "",
+    { enabled: isEdit },
+  );
+  const editRow = editQuery.data;
+
+  const cancelHref = isEdit ? `/stories/${props.slug}` : "/stories";
+
+  const form = useForm<StoryFormValues>({
+    resolver: zodResolver(storyFormSchema) as Resolver<StoryFormValues>,
+    defaultValues: BLANK_VALUES,
+    mode: "onTouched",
+  });
+
+  // Hydrate once from the fetched row; a background refetch must not clobber
+  // in-progress edits.
+  const hydratedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!isEdit || hydratedRef.current || editRow === undefined) return;
+    form.reset(mapRowToFormValues(editRow));
+    hydratedRef.current = true;
+  }, [isEdit, editRow, form]);
+
+  const isDirty = form.formState.isDirty;
+  const guard = useUnsavedChangesGuard(isDirty);
+
+  const [autosaveAt, setAutosaveAt] = React.useState<Date | null>(null);
+  const [addAnotherNote, setAddAnotherNote] = React.useState(false);
+  const addAnotherRef = React.useRef(false);
+
+  // Perspective options: the user's characters. Fetched via the auth user id
+  // (works for both create and edit).
+  const { data: userId = "" } = useQuery({
+    queryKey: ["auth", "user-id"],
+    queryFn: async () => {
+      const {
+        data: { user },
+      } = await client.auth.getUser();
+      return user?.id ?? "";
+    },
+    staleTime: 5 * 60_000,
+  });
+  const { data: characters = [], isPending: charactersPending } = useCharacters(
+    client,
+    { userId, pageSize: 100, sortBy: "name" },
+    { enabled: userId !== "" },
+  );
+  const characterOptions = React.useMemo<CharacterOption[]>(
+    () =>
+      characters.map((c) => ({
+        id: c.id,
+        name: c.name,
+        character_type: c.character_type as CharacterType,
+      })),
+    [characters],
+  );
+
+  // -------------------------------------------------------------------------
+  // Save flow (draft-only — publish lives on the detail page)
+  // -------------------------------------------------------------------------
+
+  const onValid = React.useCallback(
+    async (values: StoryFormValues) => {
+      const addAnother = addAnotherRef.current;
+      addAnotherRef.current = false;
+
+      try {
+        let savedSlug: string;
+        if (isEdit && editRow) {
+          const row = await updateStory.mutateAsync({
+            id: editRow.id,
+            data: toUpdateData(values),
+          });
+          savedSlug = row.slug;
+        } else {
+          const row = await createStory.mutateAsync(toCreateInput(values));
+          savedSlug = row.slug;
+        }
+
+        addToast({
+          id: `story-saved-${Date.now()}`,
+          message: isEdit ? "Story updated." : "Story created.",
+          variant: "success",
+        });
+
+        if (addAnother && !isEdit) {
+          form.reset(seedForAddAnother(values));
+          setAutosaveAt(null);
+          setAddAnotherNote(true);
+          return;
+        }
+
+        // Reset to the saved state so isDirty clears before redirect.
+        form.reset({ ...values, slug: savedSlug });
+        router.push(`/stories/${savedSlug}`);
+      } catch {
+        // Surfaced via the form-level Alert below.
+      }
+    },
+    [isEdit, editRow, updateStory, createStory, form, addToast, router],
+  );
+
+  const submit = React.useCallback(
+    (opts?: { addAnother?: boolean }) => {
+      // Flush the slug synchronously: SlugField debounces generation, so a fast
+      // title→Save can fire before it lands and trip the schema's slug rule.
+      const { slug, title } = form.getValues();
+      if (slug.trim().length === 0 && title.trim().length > 0) {
+        try {
+          form.setValue("slug", generateSlug(title), { shouldValidate: false });
+        } catch {
+          // Non-sluggable title — let validation surface it.
+        }
+      }
+      addAnotherRef.current = opts?.addAnother ?? false;
+      setAddAnotherNote(false);
+      void form.handleSubmit(onValid)();
+    },
+    [form, onValid],
+  );
+
+  // -------------------------------------------------------------------------
+  // Auto-save (edit only): every 30s while dirty. Never publishes.
+  // -------------------------------------------------------------------------
+
+  React.useEffect(() => {
+    if (!isEdit || editRow === undefined) return;
+    const id = editRow.id;
+    const interval = window.setInterval(() => {
+      if (!form.formState.isDirty) return;
+      const values = form.getValues();
+      autosave.mutate(
+        { id, data: toUpdateData(values) },
+        { onSuccess: () => setAutosaveAt(new Date()) },
+      );
+    }, 30_000);
+    return () => window.clearInterval(interval);
+  }, [isEdit, editRow, form, autosave]);
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  const watchedTitle = useWatch({ control: form.control, name: "title" });
+
+  const isSaving = createStory.isPending || updateStory.isPending;
+  const mutationError = createStory.error ?? updateStory.error;
+  const hasFieldErrors = Object.keys(form.formState.errors).length > 0;
+
+  if (isEdit && editQuery.isPending) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-8 w-64 rounded-md" />
+        <Skeleton className="h-4 w-96 rounded-md" />
+        <div className="mt-6 space-y-2">
+          {[1, 2, 3, 4].map((step) => (
+            <Skeleton key={step} className="h-14 w-full rounded-md" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isEdit && editQuery.isError) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
+        <p className="text-sm text-foreground-muted">
+          This story could not be found.
+        </p>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => router.push("/stories")}
+        >
+          Back to stories
+        </Button>
+      </div>
+    );
+  }
+
+  const crumbLabel = isEdit ? (editRow?.title ?? "Story") : "New story";
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex h-full flex-col"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        {/* ── Header ──────────────────────────────────────────────────── */}
+        <div className="flex items-center justify-between border-b border-border px-6 py-4 shrink-0">
+          <nav className="flex items-center gap-2 text-sm text-foreground-muted">
+            <button
+              type="button"
+              className="hover:text-foreground"
+              onClick={() => guard.requestNavigate("/stories")}
+            >
+              Stories
+            </button>
+            <span aria-hidden>▸</span>
+            <span className="text-foreground">{crumbLabel}</span>
+          </nav>
+
+          <div className="flex items-center gap-3">
+            {isEdit && (
+              <AutosaveIndicator
+                isSaving={autosave.isPending}
+                savedAt={autosaveAt}
+              />
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => guard.requestNavigate(cancelHref)}
+            >
+              Cancel
+            </Button>
+            <SaveDropdown
+              onSave={() => submit()}
+              disabled={isSaving}
+              onSaveAndAddAnother={
+                isEdit ? undefined : () => submit({ addAnother: true })
+              }
+            />
+          </div>
+        </div>
+
+        {/* ── Body ────────────────────────────────────────────────────── */}
+        <div className="flex flex-1 overflow-auto">
+          {/* Left column — narrative content */}
+          <div className="flex-1 space-y-6 overflow-auto px-6 py-6">
+            {(hasFieldErrors || mutationError) && (
+              <Alert variant="destructive" role="alert">
+                <AlertTitle>
+                  {mutationError
+                    ? "Couldn’t save this story"
+                    : "Please fix the highlighted fields"}
+                </AlertTitle>
+                <AlertDescription>
+                  {mutationError instanceof Error
+                    ? mutationError.message
+                    : "Some fields need your attention before saving."}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {addAnotherNote && (
+              <Alert role="status">
+                <AlertDescription>
+                  Saved. The narrator voice carried into this new story;
+                  everything else was cleared.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input placeholder="The story's title" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="sub_title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Sub-title</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="An optional secondary line"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="summary"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Summary</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={3}
+                      placeholder="A short hook (Markdown)"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="detail"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Detail</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={16}
+                      placeholder="The long-form narrative (Markdown)"
+                      className="font-mono text-sm"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="tags"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Tags</FormLabel>
+                  <FormControl>
+                    <ChipInput
+                      value={field.value}
+                      onChange={field.onChange}
+                      placeholder="Add tag"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* Right column — narrative voice + slug */}
+          <div className="w-80 shrink-0 space-y-6 overflow-auto border-l border-border px-6 py-6">
+            <section className="space-y-4">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-foreground-muted">
+                Narrative voice
+              </h2>
+
+              <FormField
+                control={form.control}
+                name="narrator_type"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Narrator</FormLabel>
+                    <FormControl>
+                      <select
+                        value={field.value}
+                        onChange={field.onChange}
+                        className="w-full rounded-md border border-border bg-background px-2 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                      >
+                        {NARRATOR_OPTIONS.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))}
+                      </select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="perspective_character_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Perspective character</FormLabel>
+                    <FormControl>
+                      <PerspectivePicker
+                        options={characterOptions}
+                        value={field.value}
+                        onChange={field.onChange}
+                        isPending={charactersPending}
+                      />
+                    </FormControl>
+                    <p className="text-xs text-foreground-muted">
+                      Whose eyes we see through (required for first-person).
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </section>
+
+            <Controller
+              control={form.control}
+              name="slug"
+              render={({ field }) => (
+                <SlugField
+                  label="Slug"
+                  value={field.value}
+                  onChange={field.onChange}
+                  sourceValue={watchedTitle}
+                  mode={isEdit ? "edit" : "create"}
+                  warning={
+                    isEdit
+                      ? "Changing the slug will break existing links to this story."
+                      : undefined
+                  }
+                  description="Auto-generated from title."
+                />
+              )}
+            />
+          </div>
+        </div>
+      </form>
+
+      {/* Discard-changes confirmation */}
+      <Dialog
+        open={guard.isConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) guard.cancelNavigation();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Discard unsaved changes?</DialogTitle>
+            <DialogDescription>
+              You have unsaved changes to this story. Leaving now will lose
+              them.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={guard.cancelNavigation}>
+              Keep editing
+            </Button>
+            <Button variant="destructive" onClick={guard.confirmNavigation}>
+              Discard
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Form>
+  );
+}

--- a/apps/admin/app/(protected)/stories/_components/story-form-mappers.test.ts
+++ b/apps/admin/app/(protected)/stories/_components/story-form-mappers.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+
+import type { StoryWithRelations } from "@repo/services/story-service";
+
+import {
+  storyFormSchema,
+  BLANK_VALUES,
+  mapRowToFormValues,
+  toCreateInput,
+  toUpdateData,
+  seedForAddAnother,
+  type StoryFormValues,
+} from "./story-form-mappers";
+
+function makeValues(overrides: Partial<StoryFormValues> = {}): StoryFormValues {
+  return {
+    ...BLANK_VALUES,
+    title: "The Silmarillion",
+    slug: "the-silmarillion",
+    ...overrides,
+  };
+}
+
+function makeRow(
+  overrides: Partial<StoryWithRelations> = {},
+): StoryWithRelations {
+  return {
+    id: "story-1",
+    user_id: "user-1",
+    slug: "the-silmarillion",
+    title: "The Silmarillion",
+    sub_title: null,
+    summary: null,
+    detail: null,
+    narrator_type: "third_person",
+    perspective_character_id: null,
+    tags: null,
+    published: false,
+    published_at: null,
+    search_vector: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  } as StoryWithRelations;
+}
+
+describe("storyFormSchema", () => {
+  it("accepts a valid third-person story with no perspective character", () => {
+    const result = storyFormSchema.safeParse(makeValues());
+    expect(result.success).toBe(true);
+  });
+
+  it("requires a title", () => {
+    const result = storyFormSchema.safeParse(makeValues({ title: "" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects first-person without a perspective character", () => {
+    const result = storyFormSchema.safeParse(
+      makeValues({
+        narrator_type: "first_person",
+        perspective_character_id: null,
+      }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual([
+        "perspective_character_id",
+      ]);
+    }
+  });
+
+  it("accepts first-person with a perspective character", () => {
+    const result = storyFormSchema.safeParse(
+      makeValues({
+        narrator_type: "first_person",
+        perspective_character_id: "11111111-1111-4111-8111-111111111111",
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("mapRowToFormValues", () => {
+  it("maps nullable columns to editor defaults", () => {
+    const values = mapRowToFormValues(makeRow());
+    expect(values).toEqual({
+      title: "The Silmarillion",
+      sub_title: "",
+      slug: "the-silmarillion",
+      summary: "",
+      detail: "",
+      narrator_type: "third_person",
+      perspective_character_id: null,
+      tags: [],
+    });
+  });
+
+  it("defaults a null narrator_type to third_person", () => {
+    const values = mapRowToFormValues(makeRow({ narrator_type: null }));
+    expect(values.narrator_type).toBe("third_person");
+  });
+
+  it("preserves populated fields", () => {
+    const values = mapRowToFormValues(
+      makeRow({
+        sub_title: "Quenta Silmarillion",
+        summary: "The elder days",
+        detail: "# Chapter",
+        narrator_type: "first_person",
+        perspective_character_id: "char-9",
+        tags: ["myth", "elves"],
+      }),
+    );
+    expect(values.sub_title).toBe("Quenta Silmarillion");
+    expect(values.narrator_type).toBe("first_person");
+    expect(values.perspective_character_id).toBe("char-9");
+    expect(values.tags).toEqual(["myth", "elves"]);
+  });
+});
+
+describe("toCreateInput", () => {
+  it("omits blank optional fields and an empty slug", () => {
+    const input = toCreateInput(makeValues({ slug: "" }));
+    expect(input.slug).toBeUndefined();
+    expect(input.sub_title).toBeUndefined();
+    expect(input.summary).toBeUndefined();
+    expect(input.tags).toBeUndefined();
+    expect(input.perspective_character_id).toBeUndefined();
+    expect(input.title).toBe("The Silmarillion");
+    expect(input.narrator_type).toBe("third_person");
+  });
+
+  it("passes through populated fields", () => {
+    const input = toCreateInput(
+      makeValues({
+        sub_title: "Sub",
+        tags: ["a"],
+        narrator_type: "first_person",
+        perspective_character_id: "char-1",
+      }),
+    );
+    expect(input.sub_title).toBe("Sub");
+    expect(input.tags).toEqual(["a"]);
+    expect(input.perspective_character_id).toBe("char-1");
+  });
+});
+
+describe("toUpdateData", () => {
+  it("sends text fields as-is (including empty) so clears persist", () => {
+    const data = toUpdateData(makeValues({ sub_title: "", summary: "" }));
+    expect(data.sub_title).toBe("");
+    expect(data.summary).toBe("");
+  });
+
+  it("always includes narrator_type and the perspective value", () => {
+    const data = toUpdateData(
+      makeValues({
+        narrator_type: "omniscient",
+        perspective_character_id: null,
+      }),
+    );
+    expect(data.narrator_type).toBe("omniscient");
+    expect(data.perspective_character_id).toBeNull();
+  });
+});
+
+describe("seedForAddAnother", () => {
+  it("carries a non-first-person narrator voice into a blank form", () => {
+    const seeded = seedForAddAnother(
+      makeValues({ narrator_type: "omniscient", tags: ["x"] }),
+    );
+    expect(seeded.narrator_type).toBe("omniscient");
+    expect(seeded.title).toBe("");
+    expect(seeded.tags).toEqual([]);
+  });
+
+  it("coerces a first-person voice back to third-person so the form stays valid", () => {
+    const seeded = seedForAddAnother(
+      makeValues({
+        narrator_type: "first_person",
+        perspective_character_id: "char-1",
+      }),
+    );
+    expect(seeded.narrator_type).toBe("third_person");
+    expect(seeded.perspective_character_id).toBeNull();
+  });
+});

--- a/apps/admin/app/(protected)/stories/_components/story-form-mappers.ts
+++ b/apps/admin/app/(protected)/stories/_components/story-form-mappers.ts
@@ -1,0 +1,147 @@
+import { z } from "zod";
+
+import { narratorTypeEnum } from "@repo/services/schemas/story";
+import { slugSchema } from "@repo/services/schemas/slug";
+import type { StoryInput } from "@repo/services/schemas/story";
+import type {
+  CreateStoryInput,
+  StoryWithRelations,
+} from "@repo/services/story-service";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type NarratorType = z.infer<typeof narratorTypeEnum>;
+
+/**
+ * The story editor's working value type. Field names mirror the persisted
+ * `stories` row (snake_case) so `zodResolver` validates a shape close to what
+ * is stored.
+ *
+ * `narrator_type` is always concrete in the form (defaults to `third_person`)
+ * even though the column is nullable. `published` is intentionally absent —
+ * the editor is draft-only; publication runs through the dedicated
+ * publish/unpublish service calls on the detail page (wireframe 16 + 19).
+ */
+export interface StoryFormValues {
+  title: string;
+  sub_title: string;
+  slug: string;
+  summary: string;
+  detail: string;
+  narrator_type: NarratorType;
+  perspective_character_id: string | null;
+  tags: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Validation — purpose-built form schema (mirrors storySchema's cross-field rule)
+// ---------------------------------------------------------------------------
+
+/**
+ * Form-only schema. The canonical `storySchema` still runs server-side in
+ * `createStory`/`updateStory`; this validates the editor's own value shape and
+ * surfaces the first-person rule inline before the round-trip: a first-person
+ * story must name the perspective character (whose eyes we see through).
+ */
+export const storyFormSchema = z
+  .object({
+    title: z.string().min(1, "Title is required.").max(2000),
+    sub_title: z.string().max(2000),
+    slug: slugSchema,
+    summary: z.string(),
+    detail: z.string(),
+    narrator_type: narratorTypeEnum,
+    perspective_character_id: z.string().uuid().nullable(),
+    tags: z.array(z.string()),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.narrator_type === "first_person" &&
+      data.perspective_character_id === null
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["perspective_character_id"],
+        message:
+          "First-person stories need a perspective character (whose eyes).",
+      });
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Pure mappers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+export const BLANK_VALUES: StoryFormValues = {
+  title: "",
+  sub_title: "",
+  slug: "",
+  summary: "",
+  detail: "",
+  narrator_type: "third_person",
+  perspective_character_id: null,
+  tags: [],
+};
+
+export function mapRowToFormValues(row: StoryWithRelations): StoryFormValues {
+  return {
+    title: row.title,
+    sub_title: row.sub_title ?? "",
+    slug: row.slug,
+    summary: row.summary ?? "",
+    detail: row.detail ?? "",
+    narrator_type: (row.narrator_type as NarratorType | null) ?? "third_person",
+    perspective_character_id: row.perspective_character_id,
+    tags: row.tags ?? [],
+  };
+}
+
+export function toCreateInput(values: StoryFormValues): CreateStoryInput {
+  return {
+    title: values.title,
+    // The service generates + collision-resolves the slug; only pass a base
+    // when the user has typed one, otherwise omit so it derives from the title.
+    slug: values.slug || undefined,
+    sub_title: values.sub_title || undefined,
+    summary: values.summary || undefined,
+    detail: values.detail || undefined,
+    narrator_type: values.narrator_type,
+    perspective_character_id: values.perspective_character_id ?? undefined,
+    tags: values.tags.length > 0 ? values.tags : undefined,
+  };
+}
+
+export function toUpdateData(values: StoryFormValues): Partial<StoryInput> {
+  return {
+    title: values.title,
+    slug: values.slug,
+    // Text fields are sent as-is (including "") so clearing a field on an
+    // existing record actually persists the clear.
+    sub_title: values.sub_title,
+    summary: values.summary,
+    detail: values.detail,
+    // narrator_type is always included, which keeps updateStory's first-person
+    // guard satisfied: the form guarantees a first_person story has a non-null
+    // perspective, and any non-first-person value authorises clearing it.
+    narrator_type: values.narrator_type,
+    perspective_character_id: values.perspective_character_id,
+    tags: values.tags,
+  };
+}
+
+/**
+ * "Save and add another" carries the narrator voice into the next blank form.
+ * A first-person voice is coerced back to third-person so the fresh form is not
+ * born invalid (it would otherwise demand a perspective character immediately).
+ */
+export function seedForAddAnother(values: StoryFormValues): StoryFormValues {
+  return {
+    ...BLANK_VALUES,
+    narrator_type:
+      values.narrator_type === "first_person"
+        ? "third_person"
+        : values.narrator_type,
+  };
+}

--- a/apps/admin/app/(protected)/stories/_components/story-list-client.tsx
+++ b/apps/admin/app/(protected)/stories/_components/story-list-client.tsx
@@ -5,16 +5,13 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "@repo/ui/components/sonner";
 import { Plus } from "lucide-react";
-import type { TemporalData } from "@repo/services/schemas/temporal";
 import {
-  deleteCharacter,
-  publishCharacter,
-  unpublishCharacter,
-  type CharacterFilters,
-  type CharacterListRow,
-  type CharacterType,
-  type Significance,
-} from "@repo/services/character-service";
+  deleteStory,
+  publishStory,
+  unpublishStory,
+  type StoryFilters,
+  type StoryListRow,
+} from "@repo/services/story-service";
 import { BulkActionBar } from "@repo/ui/components/bulk-action-bar";
 import { Button } from "@repo/ui/components/button";
 import {
@@ -26,18 +23,17 @@ import {
 import { FilterRail, type FilterGroup } from "@repo/ui/components/filter-rail";
 import { Skeleton } from "@repo/ui/components/skeleton";
 import { StatusBadge } from "@repo/ui/components/status-badge";
-import { TemporalDisplay } from "@repo/ui/components/temporal-display";
-import { cn } from "@repo/ui/lib/utils";
-import {
-  characterKeys,
-  useCharactersPage,
-  useCharacterFacetCounts,
-} from "@repo/ui/hooks/use-characters";
-import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
 import {
   CharacterTypeBadge,
-  CHARACTER_TYPE_ICON,
+  type CharacterType,
 } from "@repo/ui/components/character-type-badge";
+import {
+  storyKeys,
+  useStoriesPage,
+  useStoryFacetCounts,
+} from "@repo/ui/hooks/use-stories";
+import { useCharacters } from "@repo/ui/hooks/use-characters";
+import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -45,58 +41,33 @@ import {
 
 const PAGE_SIZE = 20;
 
-// character_type values are the exact schema enum (see characterTypeEnum).
-const CHARACTER_TYPES: { value: CharacterType; label: string }[] = [
-  { value: "human", label: "Human" },
-  { value: "animal", label: "Animal" },
-  { value: "mythological", label: "Mythological" },
-  { value: "fictional", label: "Fictional" },
-  { value: "organization", label: "Organization" },
-  { value: "divine", label: "Divine" },
-  { value: "artifact", label: "Artifact" },
+const NARRATOR_TYPES: { value: string; label: string }[] = [
+  { value: "first_person", label: "First-person" },
+  { value: "third_person", label: "Third-person" },
+  { value: "omniscient", label: "Omniscient" },
 ];
-const VALID_TYPES = new Set<string>(CHARACTER_TYPES.map((t) => t.value));
+const NARRATOR_LABEL: Record<string, string> = Object.fromEntries(
+  NARRATOR_TYPES.map((n) => [n.value, n.label]),
+);
+const VALID_NARRATORS = new Set(NARRATOR_TYPES.map((n) => n.value));
 
-const SIGNIFICANCES: { value: Significance; label: string }[] = [
-  { value: "low", label: "Low" },
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-  { value: "critical", label: "Critical" },
-];
-const VALID_SIGNIFICANCES = new Set<string>(SIGNIFICANCES.map((s) => s.value));
-
-// Published and has-media are each rendered as a 2-option checkbox group
-// (not the shared radio component) specifically so both options can carry a
-// count, matching the wireframe — the filter is applied only when exactly one
-// option is checked, same convention the events list uses for its own
-// Status group.
-const VALID_PUBLICATIONS = new Set<string>(["published", "draft"]);
-const VALID_MEDIA = new Set<string>(["yes", "no"]);
+// Published is a 2-option checkbox group (not the shared radio) so both options
+// can carry a count; the filter is applied only when exactly one is checked —
+// the same "exactly one" convention the characters list uses for its Published
+// and Has-media groups.
+const VALID_PUBLICATIONS = new Set(["published", "draft"]);
 
 const SORT_LABELS: Record<string, string> = {
-  name: "Name",
-  created_at: "Created",
   updated_at: "Last updated",
-  sort_order_years: "Birth date",
+  created_at: "Created",
+  title: "Title",
 };
 const VALID_SORT = new Set(Object.keys(SORT_LABELS));
 
-const SIGNIFICANCE_STARS: Record<Significance, number> = {
-  low: 1,
-  medium: 2,
-  high: 3,
-  critical: 4,
-};
-// Reuses the existing Batch F importance sequential ramp — significance and
-// importance are the same visual language (03-aesthetic-notes.md § Significance
-// scale, finalized). Literal class names (not interpolated) so Tailwind's
-// scanner picks them up.
-const SIGNIFICANCE_CLASS: Record<Significance, string> = {
-  low: "text-importance-low",
-  medium: "text-importance-medium",
-  high: "text-importance-high",
-  critical: "text-importance-critical",
-};
+// Perspective characters populate both the filter combobox and the per-row
+// perspective chip. Capped at the service's max page size — admins rarely
+// exceed this early on, and an unresolved id simply omits the chip.
+const PERSPECTIVE_FETCH_SIZE = 100;
 
 // ---------------------------------------------------------------------------
 // URL state helpers
@@ -112,8 +83,7 @@ function arrayToCsv(values: string[]): string {
 }
 
 /**
- * Returns a windowed list of page numbers and "ellipsis" placeholders.
- * Always shows first, last, current ±2, with "ellipsis" gaps between.
+ * Windowed page numbers with "ellipsis" gaps: always first, last, current ±2.
  */
 function buildPageWindows(
   current: number,
@@ -139,10 +109,10 @@ function buildPageWindows(
 }
 
 interface ParsedFilters {
-  types: string[];
-  significances: string[];
+  narrators: string[];
   publications: string[];
-  media: string[];
+  perspective: string | null;
+  tags: string[];
   search: string;
   sortBy: string;
   sortDir: "asc" | "desc";
@@ -150,59 +120,51 @@ interface ParsedFilters {
 }
 
 function readFiltersFromParams(params: URLSearchParams): ParsedFilters {
-  const rawSort = params.get("sort") ?? "name";
-  const sortBy = VALID_SORT.has(rawSort) ? rawSort : "name";
+  const rawSort = params.get("sort") ?? "updated_at";
+  const sortBy = VALID_SORT.has(rawSort) ? rawSort : "updated_at";
 
   const rawPage = parseInt(params.get("page") ?? "1", 10);
   const page = Number.isFinite(rawPage) ? Math.max(1, rawPage) : 1;
 
   return {
-    types: csvToArray(params.get("type")).filter((t) => VALID_TYPES.has(t)),
-    significances: csvToArray(params.get("sig")).filter((s) =>
-      VALID_SIGNIFICANCES.has(s),
+    narrators: csvToArray(params.get("narrator")).filter((n) =>
+      VALID_NARRATORS.has(n),
     ),
     publications: csvToArray(params.get("pub")).filter((p) =>
       VALID_PUBLICATIONS.has(p),
     ),
-    media: csvToArray(params.get("media")).filter((m) => VALID_MEDIA.has(m)),
+    perspective: params.get("persp"),
+    tags: csvToArray(params.get("tags")),
     search: params.get("q") ?? "",
     sortBy,
-    sortDir: params.get("dir") === "desc" ? "desc" : "asc",
+    // Stories default to newest-first (updated_at desc): they are work surfaces.
+    sortDir: params.get("dir") === "asc" ? "asc" : "desc",
     page,
   };
 }
 
-function buildServiceFilters(parsed: ParsedFilters): CharacterFilters {
-  const filters: CharacterFilters = {
+function buildServiceFilters(parsed: ParsedFilters): StoryFilters {
+  const filters: StoryFilters = {
     page: parsed.page,
     pageSize: PAGE_SIZE,
-    sortBy: parsed.sortBy as CharacterFilters["sortBy"],
+    sortBy: parsed.sortBy as StoryFilters["sortBy"],
     sortDirection: parsed.sortDir,
   };
 
-  const safeTypes = parsed.types.filter((t) =>
-    VALID_TYPES.has(t),
-  ) as CharacterType[];
-  if (safeTypes.length > 0) {
-    filters.characterType = safeTypes;
-  }
-
-  const safeSignificances = parsed.significances.filter((s) =>
-    VALID_SIGNIFICANCES.has(s),
-  ) as Significance[];
-  if (safeSignificances.length > 0) {
-    filters.significance = safeSignificances;
-  }
-
-  // published/hasMedia: exactly one value selected → filter; otherwise omit
+  // narrator/published: exactly one value selected → filter; otherwise omit
   // (both, or neither, checked narrows nothing).
+  if (parsed.narrators.length === 1) {
+    filters.narratorType = parsed.narrators[0] as StoryFilters["narratorType"];
+  }
   if (parsed.publications.length === 1) {
     filters.published = parsed.publications[0] === "published";
   }
-  if (parsed.media.length === 1) {
-    filters.hasMedia = parsed.media[0] === "yes";
+  if (parsed.perspective) {
+    filters.perspectiveCharacterId = parsed.perspective;
   }
-
+  if (parsed.tags.length > 0) {
+    filters.tags = parsed.tags;
+  }
   if (parsed.search.length > 0) {
     filters.search = parsed.search;
   }
@@ -214,55 +176,36 @@ function buildServiceFilters(parsed: ParsedFilters): CharacterFilters {
 // Cells
 // ---------------------------------------------------------------------------
 
-function SignificanceCell({ value }: { value: Significance | null }) {
-  // significance is DEFAULT 'medium' but not NOT NULL (migration 00001), so a
-  // row written outside the app's own create/update path (direct SQL, import)
-  // can carry a null — render the same "—" placeholder as the Temporal cell
-  // rather than indexing the lookup maps with a value they don't cover.
-  if (value === null) {
-    return <span className="text-sm text-foreground-muted">—</span>;
-  }
-  const filled = SIGNIFICANCE_STARS[value];
-  return (
-    <span
-      className={cn("text-sm", SIGNIFICANCE_CLASS[value])}
-      title={`Significance: ${value}`}
-    >
-      <span aria-hidden>{"★".repeat(filled)}</span>
-      <span className="sr-only">{value}</span>
-    </span>
-  );
-}
+type PerspectiveInfo = { name: string; character_type: CharacterType };
 
-function NameCell({
+function TitleCell({
   row,
+  perspectiveMap,
   onRowClick,
 }: {
-  row: CharacterListRow;
-  onRowClick: (row: CharacterListRow) => void;
+  row: StoryListRow;
+  perspectiveMap: Map<string, PerspectiveInfo>;
+  onRowClick: (row: StoryListRow) => void;
 }) {
-  const primaryMedia =
-    row.character_media.find((m) => m.is_primary === true)?.media ??
-    row.character_media[0]?.media ??
-    null;
-  const aliases = row.aliases ?? [];
-  const firstAlias = aliases[0];
-  const extraAliasCount = aliases.length > 1 ? aliases.length - 1 : 0;
-  const eventCount = row.event_characters[0]?.count ?? 0;
-  const line2 = [
-    firstAlias !== undefined
-      ? `${firstAlias}${extraAliasCount > 0 ? ` +${extraAliasCount}` : ""}`
-      : null,
-    eventCount > 0 ? `${eventCount} event${eventCount !== 1 ? "s" : ""}` : null,
-  ].filter(Boolean);
-  const PlaceholderIcon =
-    CHARACTER_TYPE_ICON[row.character_type as CharacterType];
+  const eventCount = row.story_events[0]?.count ?? 0;
+  const characterCount = row.story_characters[0]?.count ?? 0;
+  const tags = row.tags ?? [];
+  const shownTags = tags.slice(0, 2);
+  const extraTags = tags.length - shownTags.length;
+
+  const perspective =
+    row.perspective_character_id !== null
+      ? (perspectiveMap.get(row.perspective_character_id) ?? null)
+      : null;
+  const isFirstPerson = row.narrator_type === "first_person";
+
+  const counts = `${eventCount} ev · ${characterCount} ch`;
 
   return (
-    <div className="group relative">
+    <div className="flex flex-col gap-1">
       <button
         type="button"
-        className="flex w-full flex-col gap-0.5 text-left hover:opacity-80 transition-opacity"
+        className="flex flex-col gap-0.5 text-left hover:opacity-80 transition-opacity"
         onClick={(ev) => {
           ev.stopPropagation();
           onRowClick(row);
@@ -270,32 +213,41 @@ function NameCell({
       >
         <span
           className="line-clamp-1 font-medium text-foreground leading-tight"
-          title={row.name}
+          title={row.title}
         >
-          {row.name}
+          {row.title}
         </span>
-        {line2.length > 0 && (
-          <span className="text-xs text-foreground-muted">
-            {line2.join(" · ")}
+        {row.sub_title && (
+          <span
+            className="line-clamp-1 text-xs text-foreground-muted"
+            title={row.sub_title}
+          >
+            {row.sub_title}
           </span>
         )}
       </button>
-      <div className="pointer-events-none absolute left-0 top-full z-10 mt-1 hidden rounded-md border border-border bg-popover p-1 shadow-md group-hover:block">
-        {primaryMedia ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={primaryMedia.url}
-            alt={primaryMedia.alt_text ?? ""}
-            className="h-24 w-24 rounded object-cover"
-          />
-        ) : (
-          <div className="flex h-24 w-24 items-center justify-center rounded bg-surface-2">
-            <PlaceholderIcon
-              className="h-8 w-8 text-foreground-muted"
-              aria-hidden
+      <div className="flex flex-wrap items-center gap-1.5 text-xs text-foreground-muted">
+        {perspective && (
+          <span className="inline-flex items-center gap-1">
+            <CharacterTypeBadge
+              type={perspective.character_type}
+              label={perspective.name}
             />
-          </div>
+            {isFirstPerson && (
+              <span className="text-foreground-muted">(narrator)</span>
+            )}
+          </span>
         )}
+        <span>{counts}</span>
+        {shownTags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded bg-surface-2 px-1.5 py-0.5 text-foreground-muted"
+          >
+            {tag}
+          </span>
+        ))}
+        {extraTags > 0 && <span>+{extraTags}</span>}
       </div>
     </div>
   );
@@ -306,60 +258,35 @@ function NameCell({
 // ---------------------------------------------------------------------------
 
 function buildColumns(
-  onRowClick: (row: CharacterListRow) => void,
-): DataTableProps<CharacterListRow, unknown>["columns"] {
+  perspectiveMap: Map<string, PerspectiveInfo>,
+  onRowClick: (row: StoryListRow) => void,
+): DataTableProps<StoryListRow, unknown>["columns"] {
   return [
-    createSelectColumn<CharacterListRow>(),
+    createSelectColumn<StoryListRow>(),
     {
-      id: "name",
-      header: "Name",
+      id: "title",
+      header: "Title",
       enableSorting: false,
-      cell: ({ row }: { row: { original: CharacterListRow } }) => (
-        <NameCell row={row.original} onRowClick={onRowClick} />
+      cell: ({ row }: { row: { original: StoryListRow } }) => (
+        <TitleCell
+          row={row.original}
+          perspectiveMap={perspectiveMap}
+          onRowClick={onRowClick}
+        />
       ),
     },
     {
-      accessorKey: "character_type",
-      header: "Type",
+      accessorKey: "narrator_type",
+      header: "Narrator",
       enableSorting: false,
-      cell: ({ getValue }: { getValue: () => unknown }) => (
-        <CharacterTypeBadge type={getValue() as CharacterType} />
-      ),
-    },
-    {
-      id: "temporal",
-      header: "Temporal",
-      enableSorting: false,
-      cell: ({ row }: { row: { original: CharacterListRow } }) => {
-        const c = row.original;
-        const birth = c.birth_temporal as TemporalData | null;
-        if (!birth || Object.keys(birth).length === 0) {
-          return <span className="text-sm text-foreground-muted">—</span>;
-        }
+      cell: ({ getValue }: { getValue: () => unknown }) => {
+        const v = getValue() as string | null;
         return (
           <span className="text-sm text-foreground-muted">
-            <TemporalDisplay
-              value={birth}
-              endValue={(c.death_temporal as TemporalData | null) ?? undefined}
-              format="compact"
-            />
+            {v !== null ? (NARRATOR_LABEL[v] ?? v) : "—"}
           </span>
         );
       },
-    },
-    {
-      accessorKey: "significance",
-      // Star glyph for sighted users; sr-only text so the column is announced.
-      header: () => (
-        <>
-          <span aria-hidden>★</span>
-          <span className="sr-only">Significance</span>
-        </>
-      ),
-      enableSorting: false,
-      cell: ({ getValue }: { getValue: () => unknown }) => (
-        <SignificanceCell value={getValue() as Significance | null} />
-      ),
     },
     {
       accessorKey: "published",
@@ -367,11 +294,6 @@ function buildColumns(
       enableSorting: false,
       cell: ({ getValue }: { getValue: () => unknown }) => {
         const v = getValue() as boolean | null;
-        // DECISION NEEDED: wireframe 03 annotation #7 describes a 3rd "shared"
-        // status (reachable via a timeline_collaborators join two hops away).
-        // No query for that reachability exists yet and the events list (the
-        // reference template) doesn't implement it either — deferring to
-        // 2-state per the wireframe's own filter checkboxes and #55's AC.
         return <StatusBadge status={v === true ? "published" : "draft"} />;
       },
     },
@@ -397,7 +319,7 @@ function TableSkeleton() {
 // Main component
 // ---------------------------------------------------------------------------
 
-export function CharacterListClient() {
+export function StoryListClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -425,21 +347,21 @@ export function CharacterListClient() {
   const client = React.useMemo(() => getBrowserSupabaseClient(), []);
 
   const filters = React.useMemo(() => buildServiceFilters(parsed), [parsed]);
-  // Facet counts key off the filters minus page/sort, so paging or changing
-  // sort doesn't refire all 15 count queries the rail depends on.
-  const facetFilters = React.useMemo<CharacterFilters>(() => {
-    const picked: CharacterFilters = {};
-    if (filters.characterType !== undefined) {
-      picked.characterType = filters.characterType;
-    }
-    if (filters.significance !== undefined) {
-      picked.significance = filters.significance;
+  // Facet counts key off the filters minus page/sort so paging or re-sorting
+  // doesn't refire the count queries the rail depends on.
+  const facetFilters = React.useMemo<StoryFilters>(() => {
+    const picked: StoryFilters = {};
+    if (filters.narratorType !== undefined) {
+      picked.narratorType = filters.narratorType;
     }
     if (filters.published !== undefined) {
       picked.published = filters.published;
     }
-    if (filters.hasMedia !== undefined) {
-      picked.hasMedia = filters.hasMedia;
+    if (filters.perspectiveCharacterId !== undefined) {
+      picked.perspectiveCharacterId = filters.perspectiveCharacterId;
+    }
+    if (filters.tags !== undefined) {
+      picked.tags = filters.tags;
     }
     if (filters.search !== undefined) {
       picked.search = filters.search;
@@ -447,14 +369,11 @@ export function CharacterListClient() {
     return picked;
   }, [filters]);
 
-  const { data, isPending, isError, refetch } = useCharactersPage(
-    client,
-    filters,
-  );
-  const { data: facetCounts } = useCharacterFacetCounts(client, facetFilters);
+  const { data, isPending, isError, refetch } = useStoriesPage(client, filters);
+  const { data: facetCounts } = useStoryFacetCounts(client, facetFilters);
 
-  // Current user — used to gate bulk publish/unpublish/delete to owner-owned
-  // rows (RLS re-checks server-side regardless).
+  // Current user — used to gate bulk publish/unpublish/delete to owned rows
+  // (RLS re-checks server-side regardless) and to scope the perspective query.
   const { data: userId = "" } = useQuery({
     queryKey: ["auth", "user-id"],
     queryFn: async () => {
@@ -466,21 +385,38 @@ export function CharacterListClient() {
     staleTime: 5 * 60_000,
   });
 
+  // The user's characters drive the perspective filter options and the per-row
+  // perspective chip. Only fetched once a user id is known.
+  const { data: characters = [] } = useCharacters(
+    client,
+    { userId, pageSize: PERSPECTIVE_FETCH_SIZE, sortBy: "name" },
+    { enabled: userId !== "" },
+  );
+
+  const perspectiveMap = React.useMemo(() => {
+    const map = new Map<string, PerspectiveInfo>();
+    for (const c of characters) {
+      map.set(c.id, {
+        name: c.name,
+        character_type: c.character_type as CharacterType,
+      });
+    }
+    return map;
+  }, [characters]);
+
   const queryClient = useQueryClient();
 
-  // Row selection for the bulk-action bar, keyed by character id (getRowId).
   const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
   const [bulkBusy, setBulkBusy] = React.useState(false);
 
   const rows = React.useMemo(
-    () => (data?.rows ?? []) as CharacterListRow[],
+    () => (data?.rows ?? []) as StoryListRow[],
     [data],
   );
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
-  // Selection lives on the current page only; reset it whenever the query
-  // (filters/sort/page) changes so stale ids never leak into a bulk action.
+  // Selection lives on the current page only; reset whenever the query changes.
   const filterKey = searchParams.toString();
   const [prevFilterKey, setPrevFilterKey] = React.useState(filterKey);
   if (filterKey !== prevFilterKey) {
@@ -492,8 +428,6 @@ export function CharacterListClient() {
     () => rows.filter((r) => rowSelection[r.id]),
     [rows, rowSelection],
   );
-  // Publishing/deleting is owner-only — exclude shared/other-owned rows from
-  // the action and report them as skipped.
   const ownedSelected = React.useMemo(
     () => selectedRows.filter((r) => r.user_id === userId),
     [selectedRows, userId],
@@ -506,13 +440,13 @@ export function CharacterListClient() {
     setBulkBusy(true);
     const fn =
       action === "publish"
-        ? publishCharacter
+        ? publishStory
         : action === "unpublish"
-          ? unpublishCharacter
-          : deleteCharacter;
+          ? unpublishStory
+          : deleteStory;
     const results = await Promise.allSettled(ids.map((id) => fn(client, id)));
     setBulkBusy(false);
-    await queryClient.invalidateQueries({ queryKey: characterKeys.all });
+    await queryClient.invalidateQueries({ queryKey: storyKeys.all });
     setRowSelection({});
 
     const failed = results.filter((r) => r.status === "rejected").length;
@@ -523,7 +457,7 @@ export function CharacterListClient() {
         : action === "unpublish"
           ? "Unpublished"
           : "Deleted";
-    const noun = (n: number) => `character${n !== 1 ? "s" : ""}`;
+    const noun = (n: number) => `stor${n !== 1 ? "ies" : "y"}`;
     if (failed === 0) {
       toast.success(`${verb} ${ok} ${noun(ok)}.`);
     } else if (ok === 0) {
@@ -534,10 +468,10 @@ export function CharacterListClient() {
   }
 
   const hasFilters =
-    parsed.types.length > 0 ||
-    parsed.significances.length > 0 ||
+    parsed.narrators.length === 1 ||
     parsed.publications.length === 1 ||
-    parsed.media.length === 1 ||
+    parsed.perspective !== null ||
+    parsed.tags.length > 0 ||
     parsed.search.length > 0;
 
   // ---------------------------------------------------------------------------
@@ -545,12 +479,10 @@ export function CharacterListClient() {
   // ---------------------------------------------------------------------------
 
   function updateParams(updates: Record<string, string | null>) {
-    // Build from the live URL, not the closed-over `searchParams` snapshot:
-    // the search box's debounced update fires ~300ms after a keystroke, and
-    // if a filter/sort/page change lands in that window, building from the
-    // stale snapshot would drop it. updateParams only runs from event
-    // handlers / the debounce timeout (never during render), so reading
-    // window.location here is safe. See #329.
+    // Build from the live URL, not the closed-over snapshot: the search box's
+    // debounced update fires ~300ms after a keystroke, and a filter/sort/page
+    // change landing in that window must not be dropped. Only runs from event
+    // handlers / the debounce timeout (never during render). Mirrors #329.
     const next = new URLSearchParams(window.location.search);
     for (const [key, val] of Object.entries(updates)) {
       if (val === null || val === "") {
@@ -562,17 +494,17 @@ export function CharacterListClient() {
     router.replace(`?${next.toString()}`, { scroll: false });
   }
 
-  function handleTypeChange(values: string[]) {
-    updateParams({ type: arrayToCsv(values) || null, page: null });
-  }
-  function handleSignificanceChange(values: string[]) {
-    updateParams({ sig: arrayToCsv(values) || null, page: null });
+  function handleNarratorChange(values: string[]) {
+    updateParams({ narrator: arrayToCsv(values) || null, page: null });
   }
   function handlePublicationChange(values: string[]) {
     updateParams({ pub: arrayToCsv(values) || null, page: null });
   }
-  function handleMediaChange(values: string[]) {
-    updateParams({ media: arrayToCsv(values) || null, page: null });
+  function handlePerspectiveChange(value: string | null) {
+    updateParams({ persp: value, page: null });
+  }
+  function handleTagsChange(values: string[]) {
+    updateParams({ tags: arrayToCsv(values) || null, page: null });
   }
   function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
     const value = e.target.value;
@@ -600,13 +532,13 @@ export function CharacterListClient() {
     router.replace("?", { scroll: false });
   }
 
-  function handleNewCharacter() {
-    router.push("/characters/new");
+  function handleNewStory() {
+    router.push("/stories/new");
   }
 
   const handleRowClick = React.useCallback(
-    (row: CharacterListRow) => {
-      router.push(`/characters/${row.slug}`);
+    (row: StoryListRow) => {
+      router.push(`/stories/${row.slug}`);
     },
     [router],
   );
@@ -645,37 +577,37 @@ export function CharacterListClient() {
   }
 
   // ---------------------------------------------------------------------------
-  // Filter groups. Published and Has-media are checkbox groups (not the
-  // shared radio component) so both options can carry a count.
+  // Filter groups
   // ---------------------------------------------------------------------------
 
   const filterGroups: FilterGroup[] = [
     {
       type: "checkbox",
-      id: "type",
-      label: "Type",
-      options: CHARACTER_TYPES.map((t) => ({
-        ...t,
-        count: facetCounts?.characterType[t.value],
+      id: "narrator",
+      label: "Narrator",
+      options: NARRATOR_TYPES.map((n) => ({
+        ...n,
+        count:
+          facetCounts?.narratorType[
+            n.value as keyof typeof facetCounts.narratorType
+          ],
       })),
-      value: parsed.types,
-      onChange: handleTypeChange,
+      value: parsed.narrators,
+      onChange: handleNarratorChange,
     },
     {
-      type: "checkbox",
-      id: "significance",
-      label: "Significance",
-      options: SIGNIFICANCES.map((s) => ({
-        ...s,
-        count: facetCounts?.significance[s.value],
-      })),
-      value: parsed.significances,
-      onChange: handleSignificanceChange,
+      type: "combobox",
+      id: "perspective",
+      label: "Perspective",
+      placeholder: "Any character",
+      value: parsed.perspective,
+      options: characters.map((c) => ({ value: c.id, label: c.name })),
+      onChange: handlePerspectiveChange,
     },
     {
       type: "checkbox",
       id: "publication",
-      label: "Published",
+      label: "Status",
       options: [
         {
           value: "published",
@@ -688,21 +620,17 @@ export function CharacterListClient() {
       onChange: handlePublicationChange,
     },
     {
-      type: "checkbox",
-      id: "media",
-      label: "Has media",
-      options: [
-        { value: "yes", label: "Yes", count: facetCounts?.hasMedia.yes },
-        { value: "no", label: "No", count: facetCounts?.hasMedia.no },
-      ],
-      value: parsed.media,
-      onChange: handleMediaChange,
+      type: "tags",
+      id: "tags",
+      label: "Tags",
+      value: parsed.tags,
+      onChange: handleTagsChange,
     },
   ];
 
   const columns = React.useMemo(
-    () => buildColumns(handleRowClick),
-    [handleRowClick],
+    () => buildColumns(perspectiveMap, handleRowClick),
+    [perspectiveMap, handleRowClick],
   );
 
   // ---------------------------------------------------------------------------
@@ -715,23 +643,23 @@ export function CharacterListClient() {
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-6 py-4 shrink-0">
           <div>
-            <h1 className="font-display text-xl text-foreground">Characters</h1>
+            <h1 className="font-display text-xl text-foreground">Stories</h1>
             <p className="mt-0.5 text-xs text-foreground-muted">
               {isPending
                 ? "Loading…"
                 : hasFilters
                   ? `${total} result${total !== 1 ? "s" : ""} · filtered`
-                  : `${total} character${total !== 1 ? "s" : ""}`}
+                  : `${total} stor${total !== 1 ? "ies" : "y"}`}
             </p>
           </div>
           <Button
             variant="primary"
             size="sm"
             className="gap-1.5"
-            onClick={handleNewCharacter}
+            onClick={handleNewStory}
           >
             <Plus className="h-3.5 w-3.5" aria-hidden />
-            New character
+            New story
           </Button>
         </div>
 
@@ -739,11 +667,11 @@ export function CharacterListClient() {
         <div className="flex items-center gap-3 border-b border-border px-6 py-3 shrink-0">
           <input
             type="search"
-            placeholder="Search name, biography, aliases…"
+            placeholder="Search title, sub-title, summary, detail…"
             value={searchInput}
             onChange={handleSearchChange}
             className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-foreground-muted focus:outline-none focus:ring-2 focus:ring-ring"
-            aria-label="Search characters"
+            aria-label="Search stories"
           />
         </div>
 
@@ -755,7 +683,7 @@ export function CharacterListClient() {
               className="flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-8 text-center"
             >
               <p className="text-sm text-destructive">
-                Failed to load characters.
+                Failed to load stories.
               </p>
               <Button
                 variant="secondary"
@@ -772,12 +700,12 @@ export function CharacterListClient() {
           {!isError && !isPending && total === 0 && !hasFilters && (
             <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
               <p className="max-w-sm text-sm text-foreground-muted">
-                No characters yet. Characters are the people, beings, and
-                organizations that participate in your events.
+                No stories yet. A story is a telling — your interpretation of
+                events, from a point of view.
               </p>
-              <Button variant="primary" size="sm" onClick={handleNewCharacter}>
+              <Button variant="primary" size="sm" onClick={handleNewStory}>
                 <Plus className="mr-1.5 h-3.5 w-3.5" aria-hidden />
-                New character
+                New story
               </Button>
             </div>
           )}
@@ -785,7 +713,7 @@ export function CharacterListClient() {
           {!isError && !isPending && total === 0 && hasFilters && (
             <div className="flex flex-col items-center justify-center gap-2 py-20 text-center">
               <p className="text-sm text-foreground-muted">
-                No characters match these filters.
+                No stories match these filters.
               </p>
               <button
                 type="button"
@@ -802,7 +730,7 @@ export function CharacterListClient() {
               <BulkActionBar
                 count={ownedSelected.length}
                 skippedCount={skippedCount}
-                entityLabel="character"
+                entityLabel="story"
                 busy={bulkBusy}
                 onPublish={() => void runBulk("publish")}
                 onUnpublish={() => void runBulk("unpublish")}
@@ -848,23 +776,20 @@ export function CharacterListClient() {
 
             <div className="flex items-center gap-2">
               <label
-                htmlFor="character-sort-select"
+                htmlFor="story-sort-select"
                 className="text-xs text-foreground-muted"
               >
                 Sort:
               </label>
               <select
-                id="character-sort-select"
+                id="story-sort-select"
                 value={parsed.sortBy}
                 onChange={handleSortChange}
                 className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
               >
-                <option value="name">{SORT_LABELS["name"]}</option>
-                <option value="created_at">{SORT_LABELS["created_at"]}</option>
                 <option value="updated_at">{SORT_LABELS["updated_at"]}</option>
-                <option value="sort_order_years">
-                  {SORT_LABELS["sort_order_years"]}
-                </option>
+                <option value="created_at">{SORT_LABELS["created_at"]}</option>
+                <option value="title">{SORT_LABELS["title"]}</option>
               </select>
               <button
                 type="button"

--- a/apps/admin/app/(protected)/stories/_components/use-unsaved-changes-guard.ts
+++ b/apps/admin/app/(protected)/stories/_components/use-unsaved-changes-guard.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Guards a dirty form against accidental navigation loss.
+ *
+ * Two surfaces are covered:
+ *  - **Hard navigation** (reload / tab close / external link): a `beforeunload`
+ *    listener triggers the browser's native confirmation while `isDirty`.
+ *  - **In-app navigation** the form controls (Cancel button, breadcrumbs):
+ *    call `requestNavigate(href)` instead of `router.push`. When dirty it
+ *    defers the push and exposes `isConfirmOpen` so the caller can render a
+ *    confirm dialog; on confirm it completes the navigation.
+ *
+ * (Route-local copy of the character/timeline editor guard — kept per-route
+ * rather than promoted to a shared hook to avoid a cross-route import.)
+ */
+export function useUnsavedChangesGuard(isDirty: boolean) {
+  const router = useRouter();
+  const [pendingHref, setPendingHref] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!isDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // Required for Chrome to show the native prompt.
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+
+  const requestNavigate = React.useCallback(
+    (href: string) => {
+      if (isDirty) {
+        setPendingHref(href);
+      } else {
+        router.push(href);
+      }
+    },
+    [isDirty, router],
+  );
+
+  const confirmNavigation = React.useCallback(() => {
+    setPendingHref((href) => {
+      if (href !== null) router.push(href);
+      return null;
+    });
+  }, [router]);
+
+  const cancelNavigation = React.useCallback(() => setPendingHref(null), []);
+
+  return {
+    requestNavigate,
+    isConfirmOpen: pendingHref !== null,
+    confirmNavigation,
+    cancelNavigation,
+  };
+}

--- a/apps/admin/app/(protected)/stories/new/page.tsx
+++ b/apps/admin/app/(protected)/stories/new/page.tsx
@@ -1,0 +1,9 @@
+import { StoryFormClient } from "../_components/story-form-client";
+
+export const metadata = {
+  title: "New story",
+};
+
+export default function NewStoryPage() {
+  return <StoryFormClient mode="create" />;
+}

--- a/apps/admin/app/(protected)/stories/page.tsx
+++ b/apps/admin/app/(protected)/stories/page.tsx
@@ -1,11 +1,27 @@
-import { PlaceholderPage } from "../../../components/placeholder-page";
+import { Suspense } from "react";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { StoryListClient } from "./_components/story-list-client";
+
+export const metadata = {
+  title: "Stories",
+};
+
+const loadingRowIds = ["row-1", "row-2", "row-3", "row-4", "row-5", "row-6"];
 
 export default function StoriesPage() {
   return (
-    <PlaceholderPage
-      title="Stories"
-      description="Curated narratives weaving events into a single arc."
-      trackedIn="Batch F (list primitives)"
-    />
+    // Suspense is required because StoryListClient calls useSearchParams(),
+    // which opts the subtree into client rendering during the initial render.
+    <Suspense
+      fallback={
+        <div className="p-6 space-y-2">
+          {loadingRowIds.map((rowId) => (
+            <Skeleton key={rowId} className="h-16 w-full rounded-md" />
+          ))}
+        </div>
+      }
+    >
+      <StoryListClient />
+    </Suspense>
   );
 }

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
         "app/**/character-detail-helpers.ts",
         "app/**/character-form-mappers.ts",
         "app/**/event-form-mappers.ts",
+        "app/**/story-form-mappers.ts",
         "app/**/timeline-form-mappers.ts",
       ],
       exclude: ["app/**/*.test.{ts,tsx}"],

--- a/packages/services/src/modules/story-service.test.ts
+++ b/packages/services/src/modules/story-service.test.ts
@@ -3,12 +3,16 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "../supabase/types";
 import {
   getStories,
+  getStoriesPage,
+  getStoryFacetCounts,
   getStoryById,
   getStoryBySlug,
   getStoryEvents,
   createStory,
   updateStory,
   deleteStory,
+  publishStory,
+  unpublishStory,
   addCharacterToStory,
   removeCharacterFromStory,
   updateStoryCharacterRole,
@@ -23,7 +27,11 @@ import {
 // Mock builder helpers
 // ---------------------------------------------------------------------------
 
-function makeBuilder(result: { data: unknown; error: unknown }) {
+function makeBuilder(result: {
+  data: unknown;
+  error: unknown;
+  count?: unknown;
+}) {
   const terminal = vi.fn().mockResolvedValue(result);
   const builder = {
     select: vi.fn().mockReturnThis(),
@@ -32,6 +40,9 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
     upsert: vi.fn().mockReturnThis(),
     delete: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    overlaps: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
     textSearch: vi.fn().mockReturnThis(),
     range: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
@@ -43,7 +54,7 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
 }
 
 function makeClient(overrides: {
-  fromResult?: { data: unknown; error: unknown };
+  fromResult?: { data: unknown; error: unknown; count?: unknown };
   authUser?: { data: { user: unknown }; error: unknown };
 }) {
   const { fromResult = { data: null, error: null }, authUser } = overrides;
@@ -160,12 +171,144 @@ describe("getStories", () => {
     expect(builder.textSearch).not.toHaveBeenCalled();
   });
 
+  it("applies perspectiveCharacterId filter", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getStories(client, { perspectiveCharacterId: "char-9" });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith(
+      "perspective_character_id",
+      "char-9",
+    );
+  });
+
+  it("applies tags filter via array overlap", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getStories(client, { tags: ["war", "myth"] });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.overlaps).toHaveBeenCalledWith("tags", ["war", "myth"]);
+  });
+
+  it("does not apply tags filter when the array is empty", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getStories(client, { tags: [] });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.overlaps).not.toHaveBeenCalled();
+  });
+
+  it("applies published=true as an equality filter", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getStories(client, { published: true });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.eq).toHaveBeenCalledWith("published", true);
+  });
+
+  it("applies published=false as `not published is true` (matches NULL drafts)", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getStories(client, { published: false });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.not).toHaveBeenCalledWith("published", "is", true);
+  });
+
+  it("defaults to sorting by updated_at descending", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getStories(client);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.order).toHaveBeenCalledWith("updated_at", {
+      ascending: false,
+      nullsFirst: false,
+    });
+  });
+
+  it("honours an explicit sortBy/sortDirection", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getStories(client, { sortBy: "title", sortDirection: "asc" });
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.order).toHaveBeenCalledWith("title", {
+      ascending: true,
+      nullsFirst: false,
+    });
+  });
+
   it("throws on query error", async () => {
     const client = makeClient({
       fromResult: { data: null, error: { message: "db error" } },
     });
     await expect(getStories(client)).rejects.toThrow(
       "StoryService.getStories: db error",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStoriesPage
+// ---------------------------------------------------------------------------
+
+describe("getStoriesPage", () => {
+  const listRow = {
+    ...sampleStory,
+    story_events: [{ count: 3 }],
+    story_characters: [{ count: 2 }],
+  };
+
+  it("returns rows and the total filtered count", async () => {
+    const client = makeClient({
+      fromResult: { data: [listRow], count: 7, error: null },
+    });
+    const result = await getStoriesPage(client, { userId: "user-123" });
+    expect(result.rows).toEqual([listRow]);
+    expect(result.total).toBe(7);
+  });
+
+  it("defaults total to 0 when count is null", async () => {
+    const client = makeClient({
+      fromResult: { data: [], count: null, error: null },
+    });
+    const result = await getStoriesPage(client);
+    expect(result.total).toBe(0);
+    expect(result.rows).toEqual([]);
+  });
+
+  it("throws on query error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, count: null, error: { message: "boom" } },
+    });
+    await expect(getStoriesPage(client)).rejects.toThrow(
+      "StoryService.getStoriesPage: boom",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStoryFacetCounts
+// ---------------------------------------------------------------------------
+
+describe("getStoryFacetCounts", () => {
+  it("returns per-narrator and published/draft counts", async () => {
+    // makeClient returns the same builder for every `from()` call, so all five
+    // head-count round-trips resolve to the same count — enough to assert shape.
+    const client = makeClient({
+      fromResult: { data: null, count: 4, error: null },
+    });
+    const result = await getStoryFacetCounts(client, { userId: "user-123" });
+    expect(result).toEqual({
+      narratorType: { first_person: 4, third_person: 4, omniscient: 4 },
+      published: { published: 4, draft: 4 },
+    });
+  });
+
+  it("throws on a count query error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, count: null, error: { message: "nope" } },
+    });
+    await expect(getStoryFacetCounts(client)).rejects.toThrow(
+      "StoryService.getStoryFacetCounts",
     );
   });
 });
@@ -537,6 +680,62 @@ describe("deleteStory", () => {
     });
     await expect(deleteStory(client, "story-1")).rejects.toThrow(
       "StoryService.deleteStory: delete failed",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// publishStory / unpublishStory
+// ---------------------------------------------------------------------------
+
+describe("publishStory", () => {
+  it("sets published true and stamps published_at", async () => {
+    const published = { ...sampleStory, published: true };
+    const client = makeClient({
+      fromResult: { data: published, error: null },
+    });
+    const result = await publishStory(client, "story-1");
+    expect(result).toEqual(published);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ published: true }),
+    );
+    const updateArg = (builder.update as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as { published_at: string };
+    expect(typeof updateArg.published_at).toBe("string");
+  });
+
+  it("throws on DB error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "failed" } },
+    });
+    await expect(publishStory(client, "story-1")).rejects.toThrow(
+      "StoryService.publishStory: failed",
+    );
+  });
+});
+
+describe("unpublishStory", () => {
+  it("sets published false and clears published_at", async () => {
+    const draft = { ...sampleStory, published: false, published_at: null };
+    const client = makeClient({ fromResult: { data: draft, error: null } });
+    const result = await unpublishStory(client, "story-1");
+    expect(result).toEqual(draft);
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(builder.update).toHaveBeenCalledWith({
+      published: false,
+      published_at: null,
+    });
+  });
+
+  it("throws on DB error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "failed" } },
+    });
+    await expect(unpublishStory(client, "story-1")).rejects.toThrow(
+      "StoryService.unpublishStory: failed",
     );
   });
 });

--- a/packages/services/src/modules/story-service.ts
+++ b/packages/services/src/modules/story-service.ts
@@ -30,7 +30,17 @@ export interface StoryEventWithOrder extends EventRow {
 export interface StoryFilters {
   userId?: string;
   narratorType?: z.infer<typeof narratorTypeEnum>;
+  /** Filter to stories told through a specific perspective character. */
+  perspectiveCharacterId?: string;
+  /** Match stories carrying ANY of these tags (SQL array overlap). */
+  tags?: string[];
+  /** When true → only published rows; false → only draft rows; omit → no filter. */
+  published?: boolean;
   search?: string;
+  /** Sort column. Defaults to "updated_at" (stories are work surfaces). */
+  sortBy?: "title" | "created_at" | "updated_at";
+  /** Sort direction. Defaults to "desc". */
+  sortDirection?: "asc" | "desc";
   page?: number;
   pageSize?: number;
 }
@@ -39,6 +49,27 @@ export interface StoryWithRelations extends StoryRow {
   story_periods?: StoryPeriodRow[];
   story_characters?: StoryCharacterRow[];
   story_events?: StoryEventRow[];
+}
+
+/**
+ * A story row as returned by getStoriesPage — carries the event and character
+ * link counts the list renders on each row (`N ev · M ch`).
+ */
+export interface StoryListRow extends StoryRow {
+  story_events: { count: number }[];
+  story_characters: { count: number }[];
+}
+
+/** Paginated result from getStoriesPage — includes the total filtered count. */
+export interface StoriesPage {
+  rows: StoryListRow[];
+  total: number;
+}
+
+/** Per-option counts for the stories list filter rail (see getStoryFacetCounts). */
+export interface StoryFacetCounts {
+  narratorType: Record<z.infer<typeof narratorTypeEnum>, number>;
+  published: { published: number; draft: number };
 }
 
 export type CreateStoryInput = Omit<StoryInput, "slug"> & { slug?: string };
@@ -52,51 +83,151 @@ function assertNoError(
   }
 }
 
+/** Builder surface needed by applyStoryFilters. */
+interface StoryFilterBuilder<T> {
+  eq(column: string, value: string | boolean): T;
+  overlaps(column: string, value: readonly string[]): T;
+  not(column: string, op: string, value: boolean | null): T;
+  textSearch(column: string, query: string, opts: { type: "websearch" }): T;
+}
+
+/**
+ * Applies the owner, narrator-type, perspective-character, tag, published, and
+ * full-text-search predicates shared by getStories, getStoriesPage, and every
+ * getStoryFacetCounts per-option count query. Skip flags omit a group's own
+ * predicate so counting that group's options isn't constrained by the group's
+ * own current selection — the standard faceted-filter convention (mirrors
+ * CharacterService.applyCharacterListFilters).
+ */
+function applyStoryFilters<T extends StoryFilterBuilder<T>>(
+  builder: T,
+  filters: StoryFilters,
+  opts: { skipNarratorType?: boolean; skipPublished?: boolean } = {},
+): T {
+  let q = builder;
+  const {
+    userId,
+    narratorType,
+    perspectiveCharacterId,
+    tags,
+    published,
+    search,
+  } = filters;
+
+  if (userId !== undefined) {
+    q = q.eq("user_id", userId);
+  }
+  if (!opts.skipNarratorType && narratorType !== undefined) {
+    q = q.eq("narrator_type", narratorType);
+  }
+  if (perspectiveCharacterId !== undefined) {
+    q = q.eq("perspective_character_id", perspectiveCharacterId);
+  }
+  if (tags !== undefined && tags.length > 0) {
+    q = q.overlaps("tags", tags);
+  }
+  if (!opts.skipPublished && published !== undefined) {
+    // "draft" (published === false) must also match NULL rows — `published` is
+    // nullable, and the list badge renders NULL as "Draft", so the filter must
+    // too. `not.is.true` = published IS NOT TRUE. Mirrors CharacterService (#331).
+    q = published ? q.eq("published", true) : q.not("published", "is", true);
+  }
+  if (search !== undefined && search.trim().length > 0) {
+    q = q.textSearch("search_vector", search, { type: "websearch" });
+  }
+  return q;
+}
+
 /**
  * Return a paginated list of stories, optionally filtered.
  *
- * Implemented filters: `userId`, `narratorType`, full-text `search` (over the
- * generated `search_vector`), and pagination (`page`/`pageSize`). Results are
- * ordered by `created_at` descending.
+ * Filters: `userId`, `narratorType`, `perspectiveCharacterId`, `tags` (array
+ * overlap — matches ANY), `published`, and full-text `search` (over the
+ * generated `search_vector`). Sorts by `sortBy`/`sortDirection` (default
+ * `updated_at` desc — stories are work surfaces, per wireframe 18) with an `id`
+ * tie-break for deterministic paging.
  *
- * Deferred to the list-UI ticket (#62), per wireframe 18-stories-list.md:
- * published-state filter, tag filter, perspective-character filter, and
- * caller-selectable sort (`title` / `updated_at` / `created_at`).
+ * `page` is clamped to ≥ 1; `pageSize` is clamped to [1, 100].
  *
  * @param client - Supabase client instance
- * @param filters - Optional filters: userId, narratorType, search, page, pageSize
- * @returns Array of story rows ordered by created_at descending
+ * @param filters - Optional filters + sort + pagination
+ * @returns Array of story rows in the requested order
  */
 export async function getStories(
   client: SupabaseClient<Database>,
   filters: StoryFilters = {},
 ): Promise<StoryRow[]> {
-  const { userId, narratorType, search, page, pageSize } = filters;
+  const { sortBy = "updated_at", sortDirection = "desc" } = filters;
 
-  const safePage = Math.max(1, Math.floor(page ?? 1));
-  const safePageSize = Math.min(100, Math.max(1, Math.floor(pageSize ?? 20)));
+  const safePage = Math.max(1, Math.floor(filters.page ?? 1));
+  const safePageSize = Math.min(
+    100,
+    Math.max(1, Math.floor(filters.pageSize ?? 20)),
+  );
   const from = (safePage - 1) * safePageSize;
   const to = from + safePageSize - 1;
 
-  let query = client
-    .from("stories")
-    .select("*")
-    .order("created_at", { ascending: false })
-    .range(from, to);
+  const base = client.from("stories").select("*");
+  let query = applyStoryFilters(
+    base as unknown as StoryFilterBuilder<typeof base>,
+    filters,
+  ) as unknown as typeof base;
 
-  if (userId !== undefined) {
-    query = query.eq("user_id", userId);
-  }
-  if (narratorType !== undefined) {
-    query = query.eq("narrator_type", narratorType);
-  }
-  if (search !== undefined && search.trim().length > 0) {
-    query = query.textSearch("search_vector", search, { type: "websearch" });
-  }
+  const ascending = sortDirection === "asc";
+  query = query
+    .order(sortBy, { ascending, nullsFirst: false })
+    .order("id", { ascending: true })
+    .range(from, to);
 
   const { data, error } = await query;
   assertNoError(error, "getStories");
   return data ?? [];
+}
+
+/**
+ * Returns a page of stories together with the total filtered count and the
+ * event/character link counts the stories list renders on each row.
+ *
+ * Supports the same filter + sort set as getStories. `page` is clamped to ≥ 1;
+ * `pageSize` is clamped to [1, 100].
+ */
+export async function getStoriesPage(
+  client: SupabaseClient<Database>,
+  filters: StoryFilters = {},
+): Promise<StoriesPage> {
+  const { sortBy = "updated_at", sortDirection = "desc" } = filters;
+
+  const safePage = Math.max(1, Math.floor(filters.page ?? 1));
+  const safePageSize = Math.min(
+    100,
+    Math.max(1, Math.floor(filters.pageSize ?? 20)),
+  );
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+
+  const base = client
+    .from("stories")
+    .select("*, story_events(count), story_characters(count)", {
+      count: "exact",
+    });
+  let query = applyStoryFilters(
+    base as unknown as StoryFilterBuilder<typeof base>,
+    filters,
+  ) as unknown as typeof base;
+
+  const ascending = sortDirection === "asc";
+  query = query
+    .order(sortBy, { ascending, nullsFirst: false })
+    .order("id", { ascending: true })
+    .range(from, to);
+
+  const { data, count, error } = await query;
+  assertNoError(error, "getStoriesPage");
+
+  return {
+    rows: (data ?? []) as unknown as StoryListRow[],
+    total: count ?? 0,
+  };
 }
 
 /**
@@ -276,6 +407,140 @@ export async function deleteStory(
 ): Promise<void> {
   const { error } = await client.from("stories").delete().eq("id", id);
   assertNoError(error, "deleteStory");
+}
+
+/**
+ * Marks a story as published and records `published_at`.
+ *
+ * Stories carry no publish precondition (unlike timelines, which gate on event
+ * count) — the story wireframes specify none. Publishing is owner-gated in the
+ * UI and re-checked by RLS on the write path (defense in depth).
+ */
+export async function publishStory(
+  client: SupabaseClient<Database>,
+  id: string,
+): Promise<StoryRow> {
+  const { data, error } = await client
+    .from("stories")
+    .update({ published: true, published_at: new Date().toISOString() })
+    .eq("id", id)
+    .select()
+    .single();
+
+  assertNoError(error, "publishStory");
+  return data;
+}
+
+/**
+ * Reverts a story to unpublished state and clears `published_at`.
+ */
+export async function unpublishStory(
+  client: SupabaseClient<Database>,
+  id: string,
+): Promise<StoryRow> {
+  const { data, error } = await client
+    .from("stories")
+    .update({ published: false, published_at: null })
+    .eq("id", id)
+    .select()
+    .single();
+
+  assertNoError(error, "unpublishStory");
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Facet counts
+// ---------------------------------------------------------------------------
+
+/** Builder surface for the per-option count predicates (`.eq`, `.not`). */
+interface StoryCountPredicateBuilder {
+  eq(column: string, value: string | boolean): StoryCountPredicateBuilder;
+  not(
+    column: string,
+    op: string,
+    value: boolean | null,
+  ): StoryCountPredicateBuilder;
+}
+
+/** One head-count round-trip: count stories matching the base filters plus `apply`. */
+async function countStoriesWith(
+  client: SupabaseClient<Database>,
+  filters: StoryFilters,
+  skip: { skipNarratorType?: boolean; skipPublished?: boolean },
+  apply: (q: StoryCountPredicateBuilder) => StoryCountPredicateBuilder,
+  context: string,
+): Promise<number> {
+  const base = client
+    .from("stories")
+    .select("*", { count: "exact", head: true });
+  const filtered = applyStoryFilters(
+    base as unknown as StoryFilterBuilder<typeof base>,
+    filters,
+    skip,
+  ) as unknown as typeof base;
+  apply(filtered as unknown as StoryCountPredicateBuilder);
+  const { count, error } = await filtered;
+  assertNoError(error, context);
+  return count ?? 0;
+}
+
+/**
+ * Returns per-option counts for the stories list filter rail. The narrator-type
+ * and published groups are each counted with their OWN selection removed (so
+ * toggling an option within a group does not zero out its siblings) but with
+ * the other groups + owner + perspective + tags + search applied — OR within a
+ * group, AND across groups. Mirrors CharacterService.getCharacterFacetCounts.
+ *
+ * Perspective (a combobox) and tags (a free-form chip input) are not enumerable
+ * facets, so they contribute no per-option counts.
+ */
+export async function getStoryFacetCounts(
+  client: SupabaseClient<Database>,
+  filters: StoryFilters = {},
+): Promise<StoryFacetCounts> {
+  const narratorOptions = narratorTypeEnum.options;
+
+  const [narratorCounts, publishedCount, draftCount] = await Promise.all([
+    Promise.all(
+      narratorOptions.map((n) =>
+        countStoriesWith(
+          client,
+          filters,
+          { skipNarratorType: true },
+          (q) => q.eq("narrator_type", n),
+          "getStoryFacetCounts.narratorType",
+        ),
+      ),
+    ),
+    countStoriesWith(
+      client,
+      filters,
+      { skipPublished: true },
+      (q) => q.eq("published", true),
+      "getStoryFacetCounts.published.published",
+    ),
+    countStoriesWith(
+      client,
+      filters,
+      { skipPublished: true },
+      // Draft = published IS NOT TRUE (false OR null), matching the list badge
+      // and the getStories draft filter.
+      (q) => q.not("published", "is", true),
+      "getStoryFacetCounts.published.draft",
+    ),
+  ]);
+
+  return {
+    narratorType: {
+      first_person:
+        narratorCounts[narratorOptions.indexOf("first_person")] ?? 0,
+      third_person:
+        narratorCounts[narratorOptions.indexOf("third_person")] ?? 0,
+      omniscient: narratorCounts[narratorOptions.indexOf("omniscient")] ?? 0,
+    },
+    published: { published: publishedCount, draft: draftCount },
+  };
 }
 
 /**

--- a/packages/ui/src/components/character-type-badge.tsx
+++ b/packages/ui/src/components/character-type-badge.tsx
@@ -1,12 +1,11 @@
-// TODO: replace with @repo/ui/components/character-type-badge once #284 ships.
-// Local scaffold per #55's fallback instructions — #284 ("Build
-// CharacterTypeBadge primitive") was still open when this list was built, so
-// the shared `--color-type-*` tokens (Batch J) don't exist yet; this uses
-// inline low-chroma Tailwind classes instead, matching the icon/color mapping
-// from docs/design/admin/03-aesthetic-notes.md § Character-type identity.
-// No `cva` here (unlike the eventual shared primitive) — `class-variance-
-// authority` is a @repo/ui dependency, not an apps/admin one, and pulling it
-// in for a component this scaffold will delete isn't worth the new edge.
+// Shared CharacterTypeBadge primitive. Promoted from apps/admin (#55 scaffold)
+// to @repo/ui in #62 so the stories pages can render the perspective-character
+// identity without a cross-route import.
+//
+// This still uses inline low-chroma Tailwind classes (not `cva` + the
+// `--color-type-*` tokens) — building the fully token-driven primitive remains
+// #284's job. The icon/color mapping matches
+// docs/design/admin/03-aesthetic-notes.md § Character-type identity.
 import * as React from "react";
 import {
   User,
@@ -22,8 +21,8 @@ import { characterTypeEnum } from "@repo/services/schemas/character";
 
 export type CharacterType = (typeof characterTypeEnum.options)[number];
 
-/** Exported for reuse as the type-icon placeholder in the list's name-cell
- * hover thumbnail (no media → show the type icon instead). */
+/** Exported for reuse as the type-icon placeholder in list name-cell hover
+ * thumbnails (no media → show the type icon instead). */
 export const CHARACTER_TYPE_ICON: Record<
   CharacterType,
   React.ComponentType<{ className?: string }>

--- a/packages/ui/src/components/filter-rail.test.tsx
+++ b/packages/ui/src/components/filter-rail.test.tsx
@@ -192,6 +192,104 @@ describe("FilterRail", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("selects a combobox option and reveals clear-all", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const groups: FilterGroup[] = [
+      {
+        type: "combobox",
+        id: "perspective",
+        label: "Perspective",
+        value: null,
+        placeholder: "Any character",
+        options: [
+          { value: "char-1", label: "Frodo" },
+          { value: "char-2", label: "Sam" },
+        ],
+        onChange,
+      },
+    ];
+
+    render(<FilterRail groups={groups} onClearAll={vi.fn()} />);
+
+    // Null value → "any" option shown, no active filter yet.
+    expect(
+      screen.queryByRole("button", { name: /clear all/i }),
+    ).not.toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Perspective" }),
+      "char-2",
+    );
+    expect(onChange).toHaveBeenCalledWith("char-2");
+  });
+
+  it("clears the combobox selection back to null when 'any' is chosen", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const groups: FilterGroup[] = [
+      {
+        type: "combobox",
+        id: "perspective",
+        label: "Perspective",
+        value: "char-1",
+        placeholder: "Any character",
+        options: [{ value: "char-1", label: "Frodo" }],
+        onChange,
+      },
+    ];
+
+    render(<FilterRail groups={groups} onClearAll={vi.fn()} />);
+
+    // A non-null value counts as active.
+    expect(
+      screen.getByRole("button", { name: /clear all/i }),
+    ).toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Perspective" }),
+      "Any character",
+    );
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("adds a tag via the tags group and marks the rail active", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const groups: FilterGroup[] = [
+      {
+        type: "tags",
+        id: "tags",
+        label: "Tags",
+        value: [],
+        onChange,
+      },
+    ];
+
+    render(<FilterRail groups={groups} onClearAll={vi.fn()} />);
+
+    const input = screen.getByLabelText("Tags");
+    await user.type(input, "war{Enter}");
+    expect(onChange).toHaveBeenCalledWith(["war"]);
+  });
+
+  it("counts a tags group with values as an active filter", () => {
+    const groups: FilterGroup[] = [
+      {
+        type: "tags",
+        id: "tags",
+        label: "Tags",
+        value: ["myth"],
+        onChange: vi.fn(),
+      },
+    ];
+
+    render(<FilterRail groups={groups} onClearAll={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /clear all/i }),
+    ).toBeInTheDocument();
+  });
+
   it("handles unknown group types without crashing", () => {
     const groups = [
       {

--- a/packages/ui/src/components/filter-rail.test.tsx
+++ b/packages/ui/src/components/filter-rail.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -246,9 +246,12 @@ describe("FilterRail", () => {
       screen.getByRole("button", { name: /clear all/i }),
     ).toBeInTheDocument();
 
+    // Select the "any" option by its node (its value is "", not the label), so
+    // the match doesn't depend on selectOptions' label/value fallback.
+    const select = screen.getByRole("combobox", { name: "Perspective" });
     await user.selectOptions(
-      screen.getByRole("combobox", { name: "Perspective" }),
-      "Any character",
+      select,
+      within(select).getByRole("option", { name: "Any character" }),
     );
     expect(onChange).toHaveBeenCalledWith(null);
   });

--- a/packages/ui/src/components/filter-rail.tsx
+++ b/packages/ui/src/components/filter-rail.tsx
@@ -7,6 +7,7 @@ import { cn } from "@repo/ui/lib/utils";
 import { Checkbox } from "@repo/ui/components/checkbox";
 import { Slider } from "@repo/ui/components/slider";
 import { Label } from "@repo/ui/components/label";
+import { ChipInput } from "@repo/ui/components/chip-input";
 
 // ---- Filter group type definitions ----------------------------------------
 
@@ -48,8 +49,46 @@ export interface FilterRadioGroup {
   noLabel?: string;
 }
 
+export interface FilterComboboxOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Single-select dropdown group (e.g. the stories list's perspective-character
+ * filter). `value` of null means "no selection" — the group renders an "any"
+ * option (labelled by `placeholder`) at the top.
+ */
+export interface FilterComboboxGroup {
+  type: "combobox";
+  id: string;
+  label: string;
+  value: string | null;
+  options: FilterComboboxOption[];
+  onChange: (value: string | null) => void;
+  /** Label for the null/"any" option. Defaults to "Any". */
+  placeholder?: string;
+}
+
+/**
+ * Free-form tag entry group (e.g. the stories list's tag filter). Matching is
+ * ANY-of the entered tags; the group is active whenever at least one tag is set.
+ */
+export interface FilterTagsGroup {
+  type: "tags";
+  id: string;
+  label: string;
+  value: string[];
+  onChange: (value: string[]) => void;
+  placeholder?: string;
+}
+
 export type FilterGroup =
-  FilterCheckboxGroup | FilterRangeGroup | FilterRadioGroup;
+  | FilterCheckboxGroup
+  | FilterRangeGroup
+  | FilterRadioGroup
+  | FilterComboboxGroup
+  | FilterTagsGroup;
 
 // ---- FilterRail component --------------------------------------------------
 
@@ -142,6 +181,38 @@ function RadioGroupSection({ group }: { group: FilterRadioGroup }) {
   );
 }
 
+function ComboboxGroupSection({ group }: { group: FilterComboboxGroup }) {
+  return (
+    <select
+      id={`${group.id}-select`}
+      value={group.value ?? ""}
+      onChange={(e) =>
+        group.onChange(e.target.value === "" ? null : e.target.value)
+      }
+      aria-label={group.label}
+      className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+    >
+      <option value="">{group.placeholder ?? "Any"}</option>
+      {group.options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function TagsGroupSection({ group }: { group: FilterTagsGroup }) {
+  return (
+    <ChipInput
+      value={group.value}
+      onChange={group.onChange}
+      placeholder={group.placeholder ?? "Add tag"}
+      aria-label={group.label}
+    />
+  );
+}
+
 // ---- Main export -----------------------------------------------------------
 
 export function FilterRail({ groups, onClearAll, className }: FilterRailProps) {
@@ -149,6 +220,8 @@ export function FilterRail({ groups, onClearAll, className }: FilterRailProps) {
     if (g.type === "checkbox") return g.value.length > 0;
     if (g.type === "range") return g.value[0] !== g.min || g.value[1] !== g.max;
     if (g.type === "radio") return g.value !== "any";
+    if (g.type === "combobox") return g.value !== null && g.value !== "";
+    if (g.type === "tags") return g.value.length > 0;
     return false;
   });
 
@@ -186,6 +259,10 @@ export function FilterRail({ groups, onClearAll, className }: FilterRailProps) {
             )}
             {group.type === "range" && <RangeGroupSection group={group} />}
             {group.type === "radio" && <RadioGroupSection group={group} />}
+            {group.type === "combobox" && (
+              <ComboboxGroupSection group={group} />
+            )}
+            {group.type === "tags" && <TagsGroupSection group={group} />}
           </div>
         ))}
       </div>

--- a/packages/ui/src/hooks/use-stories.test.tsx
+++ b/packages/ui/src/hooks/use-stories.test.tsx
@@ -4,11 +4,15 @@ import { type ReactNode, createElement } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   useStories,
+  useStoriesPage,
+  useStoryFacetCounts,
   useStory,
   useStoryEvents,
   useCreateStory,
   useUpdateStory,
   useDeleteStory,
+  usePublishStory,
+  useUnpublishStory,
   useAddCharacterToStory,
   useRemoveCharacterFromStory,
   useUpdateStoryCharacterRole,
@@ -22,12 +26,16 @@ import {
 
 vi.mock("@repo/services/story-service", () => ({
   getStories: vi.fn(),
+  getStoriesPage: vi.fn(),
+  getStoryFacetCounts: vi.fn(),
   getStoryById: vi.fn(),
   getStoryBySlug: vi.fn(),
   getStoryEvents: vi.fn(),
   createStory: vi.fn(),
   updateStory: vi.fn(),
   deleteStory: vi.fn(),
+  publishStory: vi.fn(),
+  unpublishStory: vi.fn(),
   addCharacterToStory: vi.fn(),
   removeCharacterFromStory: vi.fn(),
   updateStoryCharacterRole: vi.fn(),
@@ -40,11 +48,15 @@ vi.mock("@repo/services/story-service", () => ({
 
 import {
   getStories,
+  getStoriesPage,
+  getStoryFacetCounts,
   getStoryById,
   getStoryEvents,
   createStory,
   updateStory,
   deleteStory,
+  publishStory,
+  unpublishStory,
   addCharacterToStory,
   removeCharacterFromStory,
   updateStoryCharacterRole,
@@ -85,6 +97,42 @@ describe("useStories", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(getStories).toHaveBeenCalledWith(mockClient, {});
+  });
+});
+
+describe("useStoriesPage", () => {
+  it("calls getStoriesPage with client and filters", async () => {
+    vi.mocked(getStoriesPage).mockResolvedValue({
+      rows: [],
+      total: 0,
+    } as never);
+    const { wrapper } = createWrapper();
+    const filters = { userId: "user-1", published: true };
+    const { result } = renderHook(() => useStoriesPage(mockClient, filters), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getStoriesPage).toHaveBeenCalledWith(mockClient, filters);
+  });
+});
+
+describe("useStoryFacetCounts", () => {
+  it("calls getStoryFacetCounts with client and filters", async () => {
+    vi.mocked(getStoryFacetCounts).mockResolvedValue({
+      narratorType: { first_person: 0, third_person: 0, omniscient: 0 },
+      published: { published: 0, draft: 0 },
+    } as never);
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useStoryFacetCounts(mockClient, { userId: "user-1" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getStoryFacetCounts).toHaveBeenCalledWith(mockClient, {
+      userId: "user-1",
+    });
   });
 });
 
@@ -182,6 +230,46 @@ describe("useDeleteStory", () => {
     expect(deleteStory).toHaveBeenCalledWith(mockClient, "story-1");
     expect(removeSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: storyKeys.detail("story-1") }),
+    );
+  });
+});
+
+describe("usePublishStory", () => {
+  it("calls publishStory and invalidates the stories prefix", async () => {
+    vi.mocked(publishStory).mockResolvedValue(mockStory as never);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => usePublishStory(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate("story-1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(publishStory).toHaveBeenCalledWith(mockClient, "story-1");
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: storyKeys.all }),
+    );
+  });
+});
+
+describe("useUnpublishStory", () => {
+  it("calls unpublishStory and invalidates the stories prefix", async () => {
+    vi.mocked(unpublishStory).mockResolvedValue(mockStory as never);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnpublishStory(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate("story-1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(unpublishStory).toHaveBeenCalledWith(mockClient, "story-1");
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: storyKeys.all }),
     );
   });
 });
@@ -422,6 +510,16 @@ describe("storyKeys", () => {
   it("produces stable, unique keys", () => {
     expect(storyKeys.all).toEqual(["stories"]);
     expect(storyKeys.lists()).toEqual(["stories", "list"]);
+    expect(storyKeys.page({ userId: "u" })).toEqual([
+      "stories",
+      "page",
+      { userId: "u" },
+    ]);
+    expect(storyKeys.facetCounts({ userId: "u" })).toEqual([
+      "stories",
+      "facetCounts",
+      { userId: "u" },
+    ]);
     expect(storyKeys.detail("story-1")).toEqual([
       "stories",
       "detail",

--- a/packages/ui/src/hooks/use-stories.tsx
+++ b/packages/ui/src/hooks/use-stories.tsx
@@ -11,12 +11,16 @@ import {
 } from "@tanstack/react-query";
 import {
   getStories,
+  getStoriesPage,
+  getStoryFacetCounts,
   getStoryById,
   getStoryBySlug,
   getStoryEvents,
   createStory,
   updateStory,
   deleteStory,
+  publishStory,
+  unpublishStory,
   addCharacterToStory,
   removeCharacterFromStory,
   updateStoryCharacterRole,
@@ -45,6 +49,9 @@ export const storyKeys = {
   all: ["stories"] as const,
   lists: () => [...storyKeys.all, "list"] as const,
   list: (filters: StoryFilters) => [...storyKeys.lists(), filters] as const,
+  page: (filters: StoryFilters) => [...storyKeys.all, "page", filters] as const,
+  facetCounts: (filters: StoryFilters) =>
+    [...storyKeys.all, "facetCounts", filters] as const,
   details: () => [...storyKeys.all, "detail"] as const,
   detail: (id: string) => [...storyKeys.details(), id] as const,
   bySlug: (userId: string, slug: string) =>
@@ -69,6 +76,43 @@ export function useStories(
   return useQuery({
     queryKey: storyKeys.list(filters),
     queryFn: () => getStories(client, filters),
+    staleTime: 30_000,
+    ...options,
+  });
+}
+
+/**
+ * Fetch a page of stories together with the total filtered count and the
+ * event/character link counts the stories list renders on each row.
+ */
+export function useStoriesPage(
+  client: ServiceClient,
+  filters: StoryFilters = {},
+  options?: Omit<
+    UseQueryOptions<Awaited<ReturnType<typeof getStoriesPage>>>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery({
+    queryKey: storyKeys.page(filters),
+    queryFn: () => getStoriesPage(client, filters),
+    staleTime: 30_000,
+    ...options,
+  });
+}
+
+/** Fetch per-option facet counts for the stories list filter rail. */
+export function useStoryFacetCounts(
+  client: ServiceClient,
+  filters: StoryFilters = {},
+  options?: Omit<
+    UseQueryOptions<Awaited<ReturnType<typeof getStoryFacetCounts>>>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery({
+    queryKey: storyKeys.facetCounts(filters),
+    queryFn: () => getStoryFacetCounts(client, filters),
     staleTime: 30_000,
     ...options,
   });
@@ -166,6 +210,32 @@ export function useDeleteStory(client: ServiceClient) {
     onSuccess: (_data, id) => {
       queryClient.removeQueries({ queryKey: storyKeys.detail(id) });
       void queryClient.invalidateQueries({ queryKey: storyKeys.lists() });
+    },
+  });
+}
+
+/** Publish a story (set published=true and record published_at). */
+export function usePublishStory(client: ServiceClient) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => publishStory(client, id),
+    onSuccess: () => {
+      // Invalidate by prefix so lists, page, bySlug, and detail queries stay
+      // consistent with the RLS visibility change — mirrors usePublishCharacter.
+      void queryClient.invalidateQueries({ queryKey: storyKeys.all });
+    },
+  });
+}
+
+/** Unpublish a story (set published=false and clear published_at). */
+export function useUnpublishStory(client: ServiceClient) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => unpublishStory(client, id),
+    onSuccess: () => {
+      // Invalidate by prefix so lists, page, bySlug, and detail queries stay
+      // consistent with the RLS visibility change — mirrors useUnpublishCharacter.
+      void queryClient.invalidateQueries({ queryKey: storyKeys.all });
     },
   });
 }


### PR DESCRIPTION
Closes #62.

Replaces the `stories` placeholder with the full Story authoring surface: list, create/edit editor, and a detail page with **narrative event ordering**.

## What's included

### Routes (`apps/admin/app/(protected)/stories/`)
- **List** — right-rail filters (narrator / perspective / status / tags) with facet counts, debounced search, sort, pagination-with-total, owner-gated bulk publish/unpublish/delete, and distinct loading/empty/error states.
- **Editor** (new + edit) — RHF + Zod, two-column shell with a "Narrative voice" block (narrator select + searchable perspective-character picker), first-person-requires-perspective validation surfaced inline, draft-only save, 30s autosave, and an unsaved-changes guard. Pure mapping logic extracted to `story-form-mappers.ts` (100% test coverage).
- **Detail** — owner-only `PublishControl`, prose body, and Events / Characters / Periods tabs. Events reorder with **up/down buttons** backed by `useReorderStoryEvent`, showing the narrative index alongside the chronological date; character-role management; period associations; danger-zone delete.

### Service (`@repo/services`)
- Extended `StoryFilters` + `getStories` with published / tags (array overlap) / perspective filters and caller-selectable sort (default `updated_at` desc).
- Added `getStoriesPage` (rows + total + per-row event/character counts), `getStoryFacetCounts`, `publishStory`, `unpublishStory`. Tests extended.

### Hooks (`@repo/ui`)
- Added `useStoriesPage`, `useStoryFacetCounts`, `usePublishStory`, `useUnpublishStory`, and `storyKeys.page` / `.facetCounts`. Tests extended.

### Shared
- Promoted `CharacterTypeBadge` from `apps/admin` into `@repo/ui/components/character-type-badge` for cross-feature reuse (character routes repointed; scaffold deleted). The token/cva upgrade remains #284's job.
- Extended `FilterRail` additively with `combobox` and `tags` group types (+ tests) — no impact to existing checkbox/range/radio consumers.

## Decisions (confirmed during planning)
- **Reorder = up/down buttons**, not drag-and-drop — matches the existing timeline/media convention, so no new dependency and no ADR. Diverges from the wireframe's `⠿` handle (flagged in a code comment).
- **List = full characters parity** — facet counts, bulk actions, pagination-with-total.
- **Prose** renders as plain `whitespace-pre-wrap` (no markdown lib in the repo; rich rendering is an admin non-goal).

## Verification
`pnpm verify` is green — format, lint, check-types, test:coverage (80% threshold met), and build (all four `/stories` routes compile).

Manual browser verification (create → validate first-person → add/reorder events → publish/unpublish) is the remaining step; it needs a running local Supabase stack + auth session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)