### PR TITLE
feat(admin): Category management UI (tree + inspector) — #63

### DIFF
--- a/apps/admin/app/(protected)/categories/_components/category-color-field.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-color-field.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+
+import { Input } from "@repo/ui/components/input";
+import { cn } from "@repo/ui/lib/utils";
+
+const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Category color input: a native color-picker swatch paired with a hex text
+ * field, kept in sync. `value` is `""` when unset (rendered as a neutral,
+ * checkered swatch) or a 6-digit hex like `#8b5cf6`. Final validity is enforced
+ * by the form schema; this component allows partial typing so a hex can be
+ * edited character by character.
+ */
+export function CategoryColorField({
+  id,
+  value,
+  onChange,
+  onBlur,
+}: {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+}) {
+  const isValid = HEX_COLOR.test(value);
+  // The native <input type="color"> can't hold "", so give it a concrete value
+  // while the swatch overlay shows the true (possibly unset) state.
+  const nativeValue = isValid ? value : "#000000";
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="relative inline-flex h-9 w-9 shrink-0">
+        {/* Neutral checkered backdrop shows through when unset. */}
+        <span
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-0 rounded-md border border-border",
+            !isValid &&
+              "bg-[repeating-conic-gradient(theme(colors.muted)_0_25%,transparent_0_50%)] bg-[length:10px_10px]",
+          )}
+          style={isValid ? { backgroundColor: value } : undefined}
+        />
+        <input
+          type="color"
+          aria-label="Pick a color"
+          value={nativeValue}
+          onChange={(e) => onChange(e.target.value.toLowerCase())}
+          onBlur={onBlur}
+          className="h-full w-full cursor-pointer opacity-0"
+        />
+      </span>
+      <Input
+        id={id}
+        value={value}
+        placeholder="#8b5cf6"
+        spellCheck={false}
+        autoComplete="off"
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={onBlur}
+        className="font-mono"
+        aria-invalid={value !== "" && !isValid}
+      />
+      {value !== "" && (
+        <button
+          type="button"
+          aria-label="Clear color"
+          onClick={() => onChange("")}
+          className="grid h-9 w-9 shrink-0 place-content-center rounded-md text-foreground-subtle hover:bg-surface-2 hover:text-foreground"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/categories/_components/category-form-mappers.test.ts
+++ b/apps/admin/app/(protected)/categories/_components/category-form-mappers.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+
+import type { CategoryNode } from "@repo/services/category-service";
+
+import {
+  categoryFormSchema,
+  BLANK_VALUES,
+  mapNodeToFormValues,
+  blankForParent,
+  toCreateInput,
+  toUpdateData,
+  type CategoryFormValues,
+} from "./category-form-mappers";
+
+function makeValues(
+  overrides: Partial<CategoryFormValues> = {},
+): CategoryFormValues {
+  return {
+    ...BLANK_VALUES,
+    title: "Physics",
+    slug: "physics",
+    ...overrides,
+  };
+}
+
+function makeNode(overrides: Partial<CategoryNode> = {}): CategoryNode {
+  return {
+    id: "cat-1",
+    user_id: "user-1",
+    slug: "physics",
+    title: "Physics",
+    description: null,
+    color: null,
+    icon: null,
+    parent_category_id: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    children: [],
+    ...overrides,
+  };
+}
+
+describe("categoryFormSchema", () => {
+  it("accepts a valid root category with unset color/icon", () => {
+    const result = categoryFormSchema.safeParse(makeValues());
+    expect(result.success).toBe(true);
+  });
+
+  it("requires a title", () => {
+    const result = categoryFormSchema.safeParse(makeValues({ title: "" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an empty color (the 'unset' sentinel)", () => {
+    const result = categoryFormSchema.safeParse(makeValues({ color: "" }));
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a valid 6-digit hex color", () => {
+    const result = categoryFormSchema.safeParse(
+      makeValues({ color: "#8b5cf6" }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a malformed color", () => {
+    const result = categoryFormSchema.safeParse(
+      makeValues({ color: "purple" }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(["color"]);
+    }
+  });
+
+  it("rejects a 3-digit hex color", () => {
+    const result = categoryFormSchema.safeParse(makeValues({ color: "#abc" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a null parent (root) and a uuid parent", () => {
+    expect(
+      categoryFormSchema.safeParse(makeValues({ parent_category_id: null }))
+        .success,
+    ).toBe(true);
+    expect(
+      categoryFormSchema.safeParse(
+        makeValues({
+          parent_category_id: "11111111-1111-4111-8111-111111111111",
+        }),
+      ).success,
+    ).toBe(true);
+  });
+});
+
+describe("mapNodeToFormValues", () => {
+  it("maps nullable columns to editor defaults", () => {
+    expect(mapNodeToFormValues(makeNode())).toEqual({
+      title: "Physics",
+      slug: "physics",
+      description: "",
+      color: "",
+      icon: "",
+      parent_category_id: null,
+    });
+  });
+
+  it("preserves populated fields", () => {
+    const values = mapNodeToFormValues(
+      makeNode({
+        description: "Sub-atomic behavior",
+        color: "#8b5cf6",
+        icon: "atom",
+        parent_category_id: "cat-parent",
+      }),
+    );
+    expect(values.description).toBe("Sub-atomic behavior");
+    expect(values.color).toBe("#8b5cf6");
+    expect(values.icon).toBe("atom");
+    expect(values.parent_category_id).toBe("cat-parent");
+  });
+});
+
+describe("blankForParent", () => {
+  it("defaults to a root category", () => {
+    expect(blankForParent()).toEqual(BLANK_VALUES);
+    expect(blankForParent().parent_category_id).toBeNull();
+  });
+
+  it("pre-parents the blank form when given an id", () => {
+    const values = blankForParent("cat-parent");
+    expect(values.parent_category_id).toBe("cat-parent");
+    expect(values.title).toBe("");
+  });
+});
+
+describe("toCreateInput", () => {
+  it("omits blank optional fields and an empty slug", () => {
+    const input = toCreateInput(makeValues({ slug: "" }));
+    expect(input.slug).toBeUndefined();
+    expect(input.description).toBeUndefined();
+    expect(input.color).toBeUndefined();
+    expect(input.icon).toBeUndefined();
+    expect(input.title).toBe("Physics");
+  });
+
+  it("passes through populated fields and the parent id", () => {
+    const input = toCreateInput(
+      makeValues({
+        slug: "quantum",
+        description: "d",
+        color: "#8b5cf6",
+        icon: "atom",
+        parent_category_id: "cat-parent",
+      }),
+    );
+    expect(input.slug).toBe("quantum");
+    expect(input.description).toBe("d");
+    expect(input.color).toBe("#8b5cf6");
+    expect(input.icon).toBe("atom");
+    expect(input.parent_category_id).toBe("cat-parent");
+  });
+
+  it("keeps a null parent (root) rather than dropping it", () => {
+    expect(toCreateInput(makeValues()).parent_category_id).toBeNull();
+  });
+});
+
+describe("toUpdateData", () => {
+  it("sends description as-is (including empty) so a clear persists", () => {
+    expect(toUpdateData(makeValues({ description: "" })).description).toBe("");
+  });
+
+  it("omits empty color/icon (schema can't express clear-to-null)", () => {
+    const data = toUpdateData(makeValues({ color: "", icon: "" }));
+    expect(data.color).toBeUndefined();
+    expect(data.icon).toBeUndefined();
+  });
+
+  it("sends a null parent to reparent to root", () => {
+    expect(
+      toUpdateData(makeValues({ parent_category_id: null })).parent_category_id,
+    ).toBeNull();
+  });
+
+  it("sends a uuid parent to reparent under a node", () => {
+    expect(
+      toUpdateData(makeValues({ parent_category_id: "cat-parent" }))
+        .parent_category_id,
+    ).toBe("cat-parent");
+  });
+});

--- a/apps/admin/app/(protected)/categories/_components/category-form-mappers.ts
+++ b/apps/admin/app/(protected)/categories/_components/category-form-mappers.ts
@@ -1,0 +1,133 @@
+import { z } from "zod";
+
+import { slugSchema } from "@repo/services/schemas/slug";
+import type { CategoryInput } from "@repo/services/schemas/category";
+import type {
+  CategoryNode,
+  CreateCategoryInput,
+} from "@repo/services/category-service";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The category inspector's working value type. Field names mirror the persisted
+ * `categories` row (snake_case) so `zodResolver` validates a shape close to what
+ * is stored.
+ *
+ * Every field is concrete (never `undefined`) so the same object drives both the
+ * create and edit forms. `color` / `icon` / `description` hold `""` when unset;
+ * `parent_category_id` is `null` for a root category. There is no `published`
+ * field — categories are taxonomy, always live for their owner (wireframe 24).
+ */
+export interface CategoryFormValues {
+  title: string;
+  slug: string;
+  description: string;
+  /** `""` when unset, otherwise a 6-digit hex like `#8b5cf6`. */
+  color: string;
+  /** `""` when unset, otherwise a lucide icon name or an emoji. */
+  icon: string;
+  /** `null` = root category. */
+  parent_category_id: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Validation — form-only schema (the canonical categorySchema runs server-side)
+// ---------------------------------------------------------------------------
+
+const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Form-only schema. The canonical `categorySchema` still runs server-side in
+ * `createCategory`/`updateCategory`; this validates the inspector's own value
+ * shape and surfaces errors inline before the round-trip.
+ *
+ * `color` accepts either `""` (unset) or a 6-digit hex — the persisted schema's
+ * regex rejects `""`, so the form models "cleared" as the empty string and the
+ * mappers translate that to an omitted field on the way out.
+ */
+export const categoryFormSchema = z.object({
+  title: z.string().min(1, "Title is required.").max(2000),
+  slug: slugSchema,
+  description: z.string(),
+  color: z
+    .string()
+    .refine(
+      (v) => v === "" || HEX_COLOR.test(v),
+      "Color must be a 6-digit hex like #8b5cf6.",
+    ),
+  icon: z.string().max(100),
+  parent_category_id: z.string().uuid().nullable(),
+});
+
+// ---------------------------------------------------------------------------
+// Pure mappers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+export const BLANK_VALUES: CategoryFormValues = {
+  title: "",
+  slug: "",
+  description: "",
+  color: "",
+  icon: "",
+  parent_category_id: null,
+};
+
+/** Hydrate the inspector from a selected tree node (edit mode). */
+export function mapNodeToFormValues(node: CategoryNode): CategoryFormValues {
+  return {
+    title: node.title,
+    slug: node.slug,
+    description: node.description ?? "",
+    color: node.color ?? "",
+    icon: node.icon ?? "",
+    parent_category_id: node.parent_category_id,
+  };
+}
+
+/**
+ * A fresh create form, optionally pre-parented (e.g. "add child of X"). Passing
+ * `null` yields a root category.
+ */
+export function blankForParent(
+  parentId: string | null = null,
+): CategoryFormValues {
+  return { ...BLANK_VALUES, parent_category_id: parentId };
+}
+
+export function toCreateInput(values: CategoryFormValues): CreateCategoryInput {
+  return {
+    title: values.title,
+    // The service generates + collision-resolves the slug; only pass a base
+    // when the user has typed one, otherwise omit so it derives from the title.
+    slug: values.slug || undefined,
+    description: values.description || undefined,
+    color: values.color || undefined,
+    icon: values.icon || undefined,
+    // null = root (the column default); passed through explicitly.
+    parent_category_id: values.parent_category_id,
+  };
+}
+
+export function toUpdateData(
+  values: CategoryFormValues,
+): Partial<CategoryInput> {
+  return {
+    title: values.title,
+    slug: values.slug,
+    // description is sent as-is (including "") so clearing it persists the clear.
+    description: values.description,
+    // color / icon: the persisted schema is optional-but-not-nullable and its
+    // hex regex rejects "", so an empty value is sent as `undefined` (no-op).
+    // A set value is persisted; clearing back to null is not expressible through
+    // updateCategory today — a known limitation of the categories schema tracked
+    // in #347.
+    color: values.color || undefined,
+    icon: values.icon || undefined,
+    // null reparents to root; a uuid reparents under that node (cycle-guarded
+    // server-side by assertNoCategoryCycle).
+    parent_category_id: values.parent_category_id,
+  };
+}

--- a/apps/admin/app/(protected)/categories/_components/category-icon-field.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-icon-field.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import * as React from "react";
+import { ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import { Input } from "@repo/ui/components/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import { cn } from "@repo/ui/lib/utils";
+
+import { CATEGORY_ICONS, CategoryIcon } from "./category-icon";
+
+/**
+ * Category icon picker: a searchable grid of the curated lucide subset plus an
+ * emoji / free-text fallback. `value` is the persisted icon identifier (`""`
+ * when unset, otherwise a curated lucide name or an emoji). Anything not in the
+ * curated map is treated as free text so emoji "just work".
+ */
+export function CategoryIconField({
+  id,
+  value,
+  onChange,
+  onBlur,
+}: {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const entries = React.useMemo(() => Object.entries(CATEGORY_ICONS), []);
+
+  return (
+    <div className="flex items-center gap-2">
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) onBlur?.();
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            id={id}
+            type="button"
+            variant="secondary"
+            role="combobox"
+            aria-expanded={open}
+            className={cn(
+              "w-full justify-between font-normal",
+              value === "" && "text-foreground-muted",
+            )}
+          >
+            <span className="flex items-center gap-2 truncate">
+              <CategoryIcon name={value} className="h-4 w-4" />
+              <span className="truncate">
+                {value === "" ? "Choose an icon" : value}
+              </span>
+            </span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+          <Command>
+            <CommandInput placeholder="Search icons…" />
+            <CommandList>
+              <CommandEmpty>No icons found.</CommandEmpty>
+              <CommandGroup>
+                <div className="grid grid-cols-8 gap-1 p-1">
+                  {entries.map(([name]) => (
+                    <CommandItem
+                      key={name}
+                      value={name}
+                      title={name}
+                      onSelect={() => {
+                        onChange(name === value ? "" : name);
+                        setOpen(false);
+                      }}
+                      className={cn(
+                        "flex items-center justify-center rounded-md p-0 aspect-square",
+                        value === name && "bg-surface-2 ring-1 ring-ring",
+                      )}
+                    >
+                      <CategoryIcon name={name} className="h-4 w-4" />
+                    </CommandItem>
+                  ))}
+                </div>
+              </CommandGroup>
+            </CommandList>
+          </Command>
+          <div className="border-t border-border p-2">
+            <Input
+              value={value}
+              placeholder="…or paste an emoji"
+              spellCheck={false}
+              autoComplete="off"
+              onChange={(e) => onChange(e.target.value)}
+              aria-label="Custom icon or emoji"
+            />
+          </div>
+        </PopoverContent>
+      </Popover>
+      {value !== "" && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onChange("")}
+        >
+          Clear
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/categories/_components/category-icon.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-icon.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import * as React from "react";
+import {
+  Anchor,
+  Atom,
+  Bird,
+  BookOpen,
+  Brain,
+  Bug,
+  Building2,
+  Castle,
+  Church,
+  Cog,
+  Coins,
+  Compass,
+  Crown,
+  Dna,
+  Feather,
+  FlaskConical,
+  Flame,
+  Gavel,
+  Gem,
+  Globe,
+  Hammer,
+  Heart,
+  Landmark,
+  Leaf,
+  MapPin,
+  Microscope,
+  Mountain,
+  Music,
+  Palette,
+  Rocket,
+  Scroll,
+  Ship,
+  Shield,
+  Skull,
+  Sparkles,
+  Star,
+  Swords,
+  Tag,
+  Telescope,
+  TreePine,
+  Trophy,
+  Users,
+  Wheat,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+/**
+ * Curated lucide subset offered by the category icon picker. Keys are the
+ * canonical kebab-case lucide names (lucide.dev) and are what gets persisted in
+ * `categories.icon`. Chosen to cover common taxonomy domains (science, war,
+ * art, nature, myth, religion, tech…) without shipping the whole icon set.
+ */
+export const CATEGORY_ICONS: Record<string, LucideIcon> = {
+  atom: Atom,
+  landmark: Landmark,
+  swords: Swords,
+  palette: Palette,
+  "flask-conical": FlaskConical,
+  globe: Globe,
+  "book-open": BookOpen,
+  users: Users,
+  crown: Crown,
+  sparkles: Sparkles,
+  rocket: Rocket,
+  microscope: Microscope,
+  music: Music,
+  scroll: Scroll,
+  "building-2": Building2,
+  church: Church,
+  skull: Skull,
+  leaf: Leaf,
+  mountain: Mountain,
+  ship: Ship,
+  cog: Cog,
+  coins: Coins,
+  gavel: Gavel,
+  heart: Heart,
+  flame: Flame,
+  star: Star,
+  "map-pin": MapPin,
+  zap: Zap,
+  brain: Brain,
+  dna: Dna,
+  telescope: Telescope,
+  feather: Feather,
+  hammer: Hammer,
+  shield: Shield,
+  trophy: Trophy,
+  wheat: Wheat,
+  "tree-pine": TreePine,
+  bird: Bird,
+  bug: Bug,
+  gem: Gem,
+  anchor: Anchor,
+  compass: Compass,
+  castle: Castle,
+};
+
+export const CATEGORY_ICON_NAMES = Object.keys(CATEGORY_ICONS);
+
+/** The neutral fallback icon for categories with no chosen icon. */
+export const DefaultCategoryIcon = Tag;
+
+/**
+ * Render a category's icon. Resolution order (wireframe 24 #3):
+ * 1. a curated lucide name → that icon;
+ * 2. any other non-empty string → rendered verbatim as text (covers emoji and
+ *    free-text identifiers);
+ * 3. empty/undefined → the neutral {@link DefaultCategoryIcon} (`Tag`).
+ */
+export function CategoryIcon({
+  name,
+  className = "h-3.5 w-3.5",
+}: {
+  name?: string | null;
+  className?: string;
+}) {
+  const trimmed = name?.trim() ?? "";
+  if (trimmed === "") {
+    return <DefaultCategoryIcon className={className} aria-hidden />;
+  }
+  const Icon = CATEGORY_ICONS[trimmed];
+  if (Icon) {
+    return <Icon className={className} aria-hidden />;
+  }
+  // Emoji / unknown identifier: render the raw glyph in the icon's sizing box so
+  // tree rows stay aligned. `leading-none` keeps a single emoji centered.
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center leading-none",
+        className,
+      )}
+      aria-hidden
+    >
+      {trimmed}
+    </span>
+  );
+}

--- a/apps/admin/app/(protected)/categories/_components/category-inspector.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-inspector.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import * as React from "react";
+import { useForm, Controller, useWatch, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { Trash2 } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@repo/ui/components/alert";
+import { Button } from "@repo/ui/components/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/form";
+import { Input } from "@repo/ui/components/input";
+import { Label } from "@repo/ui/components/label";
+import { SlugField } from "@repo/ui/components/slug-field";
+import { Textarea } from "@repo/ui/components/textarea";
+import { useUiStore } from "@repo/ui/stores";
+import { generateSlug } from "@repo/services/utils/slug";
+import {
+  useCreateCategory,
+  useUpdateCategory,
+} from "@repo/ui/hooks/use-categories";
+import type { CategoryNode } from "@repo/services/category-service";
+
+import {
+  categoryFormSchema,
+  mapNodeToFormValues,
+  blankForParent,
+  toCreateInput,
+  toUpdateData,
+  type CategoryFormValues,
+} from "./category-form-mappers";
+import { CategoryColorField } from "./category-color-field";
+import { CategoryIconField } from "./category-icon-field";
+import { CategoryParentPicker } from "./category-parent-picker";
+import { DeleteCategoryDialog } from "./delete-category-dialog";
+
+export type InspectorSelection =
+  | { mode: "create"; parentId: string | null }
+  | { mode: "edit"; node: CategoryNode };
+
+/**
+ * The category inspector — a create/edit form for the selected (or new) node.
+ * The manager remounts it (via a `key` on the selection) so form state resets
+ * cleanly between selections rather than hand-managing hydration.
+ */
+export function CategoryInspector({
+  client,
+  tree,
+  usage,
+  selection,
+  onSaved,
+  onDeleted,
+  onCancel,
+}: {
+  client: SupabaseClient;
+  tree: CategoryNode[];
+  usage: Record<string, number> | undefined;
+  selection: InspectorSelection;
+  onSaved: (node: CategoryNode) => void;
+  onDeleted: () => void;
+  onCancel: () => void;
+}) {
+  const isEdit = selection.mode === "edit";
+  const addToast = useUiStore((s) => s.addToast);
+  const createMut = useCreateCategory(client);
+  const updateMut = useUpdateCategory(client);
+  const [formError, setFormError] = React.useState<string | null>(null);
+  const [showDelete, setShowDelete] = React.useState(false);
+
+  const form = useForm<CategoryFormValues>({
+    resolver: zodResolver(categoryFormSchema) as Resolver<CategoryFormValues>,
+    mode: "onTouched",
+    defaultValues: isEdit
+      ? mapNodeToFormValues(selection.node)
+      : blankForParent(selection.parentId),
+  });
+
+  const watchedTitle = useWatch({ control: form.control, name: "title" });
+
+  const onSubmit = React.useCallback(
+    async (values: CategoryFormValues) => {
+      setFormError(null);
+      try {
+        if (selection.mode === "edit") {
+          const row = await updateMut.mutateAsync({
+            id: selection.node.id,
+            data: toUpdateData(values),
+          });
+          addToast({
+            id: `category-saved-${Date.now()}`,
+            message: `Saved “${row.title}”.`,
+            variant: "success",
+          });
+          form.reset(mapNodeToFormValues(row));
+          onSaved(row);
+        } else {
+          const row = await createMut.mutateAsync(toCreateInput(values));
+          addToast({
+            id: `category-created-${Date.now()}`,
+            message: `Created “${row.title}”.`,
+            variant: "success",
+          });
+          onSaved(row);
+        }
+      } catch (err) {
+        setFormError(
+          err instanceof Error ? err.message : "Failed to save the category.",
+        );
+      }
+    },
+    [selection, updateMut, createMut, addToast, form, onSaved],
+  );
+
+  // Flush the slug synchronously before validating: SlugField debounces
+  // generation, so a fast title→Save can fire before it lands and trip the
+  // schema's required-slug rule.
+  const submit = React.useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const { slug, title } = form.getValues();
+      if (slug.trim().length === 0 && title.trim().length > 0) {
+        try {
+          form.setValue("slug", generateSlug(title), { shouldValidate: false });
+        } catch {
+          // Non-sluggable title — let validation surface it.
+        }
+      }
+      void form.handleSubmit(onSubmit)();
+    },
+    [form, onSubmit],
+  );
+
+  const pending = createMut.isPending || updateMut.isPending;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-border px-4 py-3">
+        <h2 className="font-display text-sm font-medium text-foreground">
+          {isEdit ? "Edit category" : "New category"}
+        </h2>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={submit} className="flex flex-1 flex-col overflow-auto">
+          <div className="flex-1 space-y-4 p-4">
+            {formError && (
+              <Alert variant="destructive">
+                <AlertTitle>Couldn’t save</AlertTitle>
+                <AlertDescription>{formError}</AlertDescription>
+              </Alert>
+            )}
+
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g. Quantum Mechanics" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={3}
+                      placeholder="What does this category group?"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="color"
+              render={({ field, fieldState }) => (
+                <div className="space-y-2">
+                  <Label htmlFor="category-color">Color</Label>
+                  <CategoryColorField
+                    id="category-color"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                  />
+                  {fieldState.error && (
+                    <p className="text-sm text-destructive">
+                      {fieldState.error.message}
+                    </p>
+                  )}
+                </div>
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="icon"
+              render={({ field, fieldState }) => (
+                <div className="space-y-2">
+                  <Label htmlFor="category-icon">Icon</Label>
+                  <CategoryIconField
+                    id="category-icon"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                  />
+                  {fieldState.error && (
+                    <p className="text-sm text-destructive">
+                      {fieldState.error.message}
+                    </p>
+                  )}
+                </div>
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="parent_category_id"
+              render={({ field }) => (
+                <div className="space-y-2">
+                  <Label htmlFor="category-parent">Parent</Label>
+                  <CategoryParentPicker
+                    id="category-parent"
+                    tree={tree}
+                    currentId={isEdit ? selection.node.id : undefined}
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                  />
+                </div>
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="slug"
+              render={({ field }) => (
+                <SlugField
+                  label="Slug"
+                  value={field.value}
+                  onChange={field.onChange}
+                  sourceValue={watchedTitle}
+                  mode={isEdit ? "edit" : "create"}
+                  warning={
+                    isEdit
+                      ? "Changing the slug will break existing links to this category."
+                      : undefined
+                  }
+                  description="Auto-generated from the title."
+                />
+              )}
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-2 border-t border-border p-4">
+            {isEdit ? (
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                disabled={pending}
+                onClick={() => setShowDelete(true)}
+              >
+                <Trash2 className="mr-1.5 h-4 w-4" aria-hidden />
+                Delete
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={pending}
+                onClick={onCancel}
+              >
+                Cancel
+              </Button>
+            )}
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+
+      {isEdit && (
+        <DeleteCategoryDialog
+          client={client}
+          node={selection.node}
+          tree={tree}
+          usage={usage}
+          open={showDelete}
+          onOpenChange={setShowDelete}
+          onDeleted={onDeleted}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/categories/_components/category-manager-client.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-manager-client.tsx
@@ -33,11 +33,19 @@ export function CategoryManagerClient({ userId }: { userId: string }) {
   const usageQuery = useCategoryUsageCounts(client, userId);
 
   // Deep-link: /categories?new=1 (topbar quick-create) opens the create form.
+  const newParam = searchParams.get("new");
   const [selection, setSelection] = React.useState<Selection>(() =>
-    searchParams.get("new") !== null
-      ? { mode: "create", parentId: null }
-      : null,
+    newParam !== null ? { mode: "create", parentId: null } : null,
   );
+  // Open create when ?new=1 arrives while already on this page (the component
+  // stays mounted, so only the search param changes). Adjust-state-during-render
+  // on param change — React's alternative to an effect — fires once per change,
+  // so it won't clobber a selection the user makes after the form first opens.
+  const [prevNewParam, setPrevNewParam] = React.useState(newParam);
+  if (newParam !== prevNewParam) {
+    setPrevNewParam(newParam);
+    if (newParam !== null) setSelection({ mode: "create", parentId: null });
+  }
 
   const tree = React.useMemo(() => treeQuery.data ?? [], [treeQuery.data]);
   const total = React.useMemo(() => flattenTree(tree).length, [tree]);

--- a/apps/admin/app/(protected)/categories/_components/category-manager-client.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-manager-client.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import * as React from "react";
+import { useSearchParams } from "next/navigation";
+import { FolderTree, Plus } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@repo/ui/components/alert";
+import { Button } from "@repo/ui/components/button";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import {
+  useCategoryTree,
+  useCategoryUsageCounts,
+} from "@repo/ui/hooks/use-categories";
+import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+
+import { CategoryTree } from "./category-tree";
+import {
+  CategoryInspector,
+  type InspectorSelection,
+} from "./category-inspector";
+import { flattenTree, findNode } from "./category-tree-utils";
+
+type Selection =
+  | { mode: "edit"; id: string }
+  | { mode: "create"; parentId: string | null }
+  | null;
+
+export function CategoryManagerClient({ userId }: { userId: string }) {
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+  const searchParams = useSearchParams();
+
+  const treeQuery = useCategoryTree(client, userId);
+  const usageQuery = useCategoryUsageCounts(client, userId);
+
+  // Deep-link: /categories?new=1 (topbar quick-create) opens the create form.
+  const [selection, setSelection] = React.useState<Selection>(() =>
+    searchParams.get("new") !== null
+      ? { mode: "create", parentId: null }
+      : null,
+  );
+
+  const tree = React.useMemo(() => treeQuery.data ?? [], [treeQuery.data]);
+  const total = React.useMemo(() => flattenTree(tree).length, [tree]);
+  const rootCount = tree.length;
+
+  // Resolve the edit selection against the live tree; a deleted node clears it.
+  const inspectorSelection: InspectorSelection | null = React.useMemo(() => {
+    if (selection === null) return null;
+    if (selection.mode === "create") return selection;
+    const node = findNode(tree, selection.id);
+    return node ? { mode: "edit", node } : null;
+  }, [selection, tree]);
+
+  const selectionKey =
+    selection === null
+      ? "none"
+      : selection.mode === "edit"
+        ? `edit:${selection.id}`
+        : `create:${selection.parentId ?? "root"}`;
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex items-center justify-between gap-4 border-b border-border px-6 py-4">
+        <div>
+          <h1 className="font-display text-xl text-foreground">Categories</h1>
+          {!treeQuery.isPending && !treeQuery.isError && total > 0 && (
+            <p className="text-sm text-foreground-muted">
+              {total} categor{total === 1 ? "y" : "ies"} · {rootCount} root
+              {rootCount === 1 ? "" : "s"}
+            </p>
+          )}
+        </div>
+        <Button
+          onClick={() => setSelection({ mode: "create", parentId: null })}
+        >
+          <Plus className="mr-1.5 h-4 w-4" aria-hidden />
+          New category
+        </Button>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          {treeQuery.isError ? (
+            <div className="p-6">
+              <Alert variant="destructive">
+                <AlertTitle>Couldn’t load categories</AlertTitle>
+                <AlertDescription className="flex items-center gap-3">
+                  {treeQuery.error instanceof Error
+                    ? treeQuery.error.message
+                    : "Something went wrong."}
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => void treeQuery.refetch()}
+                  >
+                    Retry
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            </div>
+          ) : treeQuery.isPending ? (
+            <div className="space-y-2 p-4">
+              {["s1", "s2", "s3", "s4", "s5"].map((id) => (
+                <Skeleton key={id} className="h-8 w-full rounded-md" />
+              ))}
+            </div>
+          ) : total === 0 ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+              <FolderTree
+                className="h-10 w-10 text-foreground-subtle"
+                aria-hidden
+              />
+              <div className="max-w-md space-y-1">
+                <p className="font-medium text-foreground">No categories yet</p>
+                <p className="text-sm text-foreground-muted">
+                  Categories are the tags that organize your events — nest them
+                  into a tree (Science → Physics → Quantum Mechanics).
+                </p>
+              </div>
+              <Button
+                onClick={() => setSelection({ mode: "create", parentId: null })}
+              >
+                <Plus className="mr-1.5 h-4 w-4" aria-hidden />
+                New category
+              </Button>
+            </div>
+          ) : (
+            <CategoryTree
+              tree={tree}
+              usage={usageQuery.data}
+              onSelect={(id) => setSelection({ mode: "edit", id })}
+            />
+          )}
+        </main>
+
+        <aside className="flex w-80 shrink-0 flex-col border-l border-border">
+          {inspectorSelection === null ? (
+            <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-foreground-muted">
+              Select a category to edit, or create a new one.
+            </div>
+          ) : (
+            <CategoryInspector
+              key={selectionKey}
+              client={client}
+              tree={tree}
+              usage={usageQuery.data}
+              selection={inspectorSelection}
+              onSaved={(node) => setSelection({ mode: "edit", id: node.id })}
+              onDeleted={() => setSelection(null)}
+              onCancel={() => setSelection(null)}
+            />
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/categories/_components/category-parent-picker.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-parent-picker.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import { cn } from "@repo/ui/lib/utils";
+import type { CategoryNode } from "@repo/services/category-service";
+
+import {
+  flattenTree,
+  findNode,
+  collectSelfAndDescendantIds,
+} from "./category-tree-utils";
+
+/**
+ * Searchable parent selector for the category inspector. Options are the whole
+ * forest flattened (indented by depth), plus a "— none (root) —" choice.
+ *
+ * Cycle prevention (wireframe 24 #7): when editing an existing node, that node
+ * and all its descendants are excluded — a category can't be parented under
+ * itself or its own child. The service `assertNoCategoryCycle` remains the
+ * backstop for any raced write. In create mode (`currentId` undefined) the full
+ * forest is selectable.
+ */
+export function CategoryParentPicker({
+  id,
+  tree,
+  currentId,
+  value,
+  onChange,
+  onBlur,
+}: {
+  id?: string;
+  tree: CategoryNode[];
+  currentId?: string;
+  value: string | null;
+  onChange: (parentId: string | null) => void;
+  onBlur?: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+
+  const excluded = React.useMemo(() => {
+    if (currentId === undefined) return new Set<string>();
+    const current = findNode(tree, currentId);
+    return current ? collectSelfAndDescendantIds(current) : new Set<string>();
+  }, [tree, currentId]);
+
+  const options = React.useMemo(
+    () => flattenTree(tree).filter(({ node }) => !excluded.has(node.id)),
+    [tree, excluded],
+  );
+
+  const selectedLabel =
+    value === null
+      ? "— none (root) —"
+      : (options.find(({ node }) => node.id === value)?.node.title ??
+        "— none (root) —");
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) onBlur?.();
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="secondary"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "w-full justify-between font-normal",
+            value === null && "text-foreground-muted",
+          )}
+        >
+          <span className="truncate">{selectedLabel}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput placeholder="Search categories…" />
+          <CommandList>
+            <CommandEmpty>No categories found.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="__root__"
+                onSelect={() => {
+                  onChange(null);
+                  setOpen(false);
+                }}
+              >
+                <Check
+                  className={cn(
+                    "mr-2 h-4 w-4",
+                    value === null ? "opacity-100" : "opacity-0",
+                  )}
+                />
+                — none (root) —
+              </CommandItem>
+              {options.map(({ node, depth }) => (
+                <CommandItem
+                  key={node.id}
+                  value={`${node.title} ${node.id}`}
+                  onSelect={() => {
+                    onChange(node.id === value ? null : node.id);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === node.id ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span
+                    className="truncate"
+                    style={{ paddingLeft: `${depth * 12}px` }}
+                  >
+                    {node.title}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/admin/app/(protected)/categories/_components/category-tree-utils.test.ts
+++ b/apps/admin/app/(protected)/categories/_components/category-tree-utils.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+
+import type { CategoryNode } from "@repo/services/category-service";
+
+import {
+  flattenTree,
+  findNode,
+  collectSelfAndDescendantIds,
+  countDescendants,
+  sumSubtreeUsage,
+} from "./category-tree-utils";
+
+function node(
+  id: string,
+  children: CategoryNode[] = [],
+  overrides: Partial<CategoryNode> = {},
+): CategoryNode {
+  return {
+    id,
+    user_id: "user-1",
+    slug: id,
+    title: id.toUpperCase(),
+    description: null,
+    color: null,
+    icon: null,
+    parent_category_id: null,
+    created_at: null,
+    updated_at: null,
+    children,
+    ...overrides,
+  };
+}
+
+// science → (physics → (quantum, relativity)), chemistry
+// war
+const tree: CategoryNode[] = [
+  node("science", [
+    node("physics", [node("quantum"), node("relativity")]),
+    node("chemistry"),
+  ]),
+  node("war"),
+];
+
+describe("flattenTree", () => {
+  it("pre-orders parents before children with depth", () => {
+    const flat = flattenTree(tree);
+    expect(flat.map((f) => `${f.node.id}@${f.depth}`)).toEqual([
+      "science@0",
+      "physics@1",
+      "quantum@2",
+      "relativity@2",
+      "chemistry@1",
+      "war@0",
+    ]);
+  });
+
+  it("returns an empty array for an empty forest", () => {
+    expect(flattenTree([])).toEqual([]);
+  });
+});
+
+describe("findNode", () => {
+  it("finds a deeply nested node", () => {
+    expect(findNode(tree, "quantum")?.id).toBe("quantum");
+  });
+
+  it("finds a root node", () => {
+    expect(findNode(tree, "war")?.id).toBe("war");
+  });
+
+  it("returns null when absent", () => {
+    expect(findNode(tree, "missing")).toBeNull();
+  });
+});
+
+describe("collectSelfAndDescendantIds", () => {
+  it("includes the node and every descendant", () => {
+    const physics = findNode(tree, "physics")!;
+    expect([...collectSelfAndDescendantIds(physics)].sort()).toEqual([
+      "physics",
+      "quantum",
+      "relativity",
+    ]);
+  });
+
+  it("is just the node itself for a leaf", () => {
+    const leaf = findNode(tree, "war")!;
+    expect([...collectSelfAndDescendantIds(leaf)]).toEqual(["war"]);
+  });
+});
+
+describe("countDescendants", () => {
+  it("counts the whole subtree below a node", () => {
+    expect(countDescendants(findNode(tree, "science")!)).toBe(4);
+    expect(countDescendants(findNode(tree, "physics")!)).toBe(2);
+  });
+
+  it("is zero for a leaf", () => {
+    expect(countDescendants(findNode(tree, "war")!)).toBe(0);
+  });
+});
+
+describe("sumSubtreeUsage", () => {
+  const usage = { science: 1, physics: 5, quantum: 9, relativity: 6, war: 3 };
+
+  it("sums the node plus all descendants", () => {
+    // science(1) + physics(5) + quantum(9) + relativity(6) + chemistry(0) = 21
+    expect(sumSubtreeUsage(findNode(tree, "science")!, usage)).toBe(21);
+    // physics(5) + quantum(9) + relativity(6) = 20
+    expect(sumSubtreeUsage(findNode(tree, "physics")!, usage)).toBe(20);
+  });
+
+  it("treats a missing usage entry as zero", () => {
+    expect(sumSubtreeUsage(findNode(tree, "chemistry")!, usage)).toBe(0);
+    expect(sumSubtreeUsage(findNode(tree, "war")!, {})).toBe(0);
+  });
+});

--- a/apps/admin/app/(protected)/categories/_components/category-tree-utils.ts
+++ b/apps/admin/app/(protected)/categories/_components/category-tree-utils.ts
@@ -1,0 +1,86 @@
+import type { CategoryNode } from "@repo/services/category-service";
+
+/** A tree node flattened to a render/pick row, carrying its depth (root = 0). */
+export interface FlatCategory {
+  node: CategoryNode;
+  depth: number;
+}
+
+/**
+ * Pre-order flatten of the category forest — parents immediately before their
+ * children — with each node's depth. The service already orders every level
+ * deterministically (title, id), so this preserves that order.
+ */
+export function flattenTree(
+  nodes: CategoryNode[],
+  depth = 0,
+  out: FlatCategory[] = [],
+): FlatCategory[] {
+  for (const node of nodes) {
+    out.push({ node, depth });
+    if (node.children && node.children.length > 0) {
+      flattenTree(node.children, depth + 1, out);
+    }
+  }
+  return out;
+}
+
+/** Find a node anywhere in the forest by id, or `null`. */
+export function findNode(
+  nodes: CategoryNode[],
+  id: string,
+): CategoryNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    if (node.children) {
+      const found = findNode(node.children, id);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * The id set that a reparent must exclude as candidate parents: the node itself
+ * and every descendant. Assigning any of these as the node's parent would form
+ * a cycle (mirrors the service-layer `assertNoCategoryCycle` guard).
+ */
+export function collectSelfAndDescendantIds(node: CategoryNode): Set<string> {
+  const ids = new Set<string>();
+  const walk = (n: CategoryNode) => {
+    ids.add(n.id);
+    n.children?.forEach(walk);
+  };
+  walk(node);
+  return ids;
+}
+
+/** Number of descendant categories below a node (excludes the node itself). */
+export function countDescendants(node: CategoryNode): number {
+  let count = 0;
+  const walk = (children: CategoryNode[] | undefined) => {
+    for (const child of children ?? []) {
+      count += 1;
+      walk(child.children);
+    }
+  };
+  walk(node.children);
+  return count;
+}
+
+/**
+ * Sum of a usage-count map over a node's whole subtree (the node plus every
+ * descendant). Powers the delete blast radius ("removes the tag from N events");
+ * a tag on multiple categories in the subtree is counted once per category, so
+ * this is the number of category→event links removed, not distinct events.
+ */
+export function sumSubtreeUsage(
+  node: CategoryNode,
+  usage: Record<string, number>,
+): number {
+  let total = usage[node.id] ?? 0;
+  for (const child of node.children ?? []) {
+    total += sumSubtreeUsage(child, usage);
+  }
+  return total;
+}

--- a/apps/admin/app/(protected)/categories/_components/category-tree.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-tree.tsx
@@ -128,9 +128,12 @@ export function CategoryTree({
             No categories match “{filter}”.
           </p>
         ) : (
-          // Remount on filter changes so default-expansion recomputes.
+          // Remount on every filter change (not just empty↔non-empty) so the
+          // Tree recomputes default-expansion and newly-matched nodes aren't
+          // hidden by stale internal expand state. The filter input lives
+          // outside this subtree, so it keeps focus across remounts.
           <Tree
-            key={expandAll ? "filtered" : "all"}
+            key={expandAll ? `filtered:${filter.trim()}` : "all"}
             nodes={nodes}
             aria-label="Category hierarchy"
           />

--- a/apps/admin/app/(protected)/categories/_components/category-tree.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-tree.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import * as React from "react";
+import { Search } from "lucide-react";
+
+import { Input } from "@repo/ui/components/input";
+import { Tree, type TreeNode } from "@repo/ui/components/tree";
+import type { CategoryNode } from "@repo/services/category-service";
+
+import { CategoryIcon } from "./category-icon";
+
+/** Leading glyph for a tree row: the icon tinted by the node color, or a color dot. */
+function NodeGlyph({ node }: { node: CategoryNode }) {
+  const color = node.color ?? undefined;
+  if (node.icon && node.icon.trim() !== "") {
+    return (
+      <span className="inline-flex" style={color ? { color } : undefined}>
+        <CategoryIcon name={node.icon} className="h-3.5 w-3.5" />
+      </span>
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      className="inline-block h-2.5 w-2.5 rounded-full border border-border"
+      style={color ? { backgroundColor: color } : undefined}
+    />
+  );
+}
+
+/**
+ * Keep only nodes whose title matches `query`, plus their ancestors (so a deep
+ * match stays reachable). Returns a new pruned forest; the original is untouched.
+ */
+function filterForest(nodes: CategoryNode[], query: string): CategoryNode[] {
+  const q = query.trim().toLowerCase();
+  if (q === "") return nodes;
+  const prune = (list: CategoryNode[]): CategoryNode[] => {
+    const kept: CategoryNode[] = [];
+    for (const node of list) {
+      const children = node.children ? prune(node.children) : [];
+      const selfMatches = node.title.toLowerCase().includes(q);
+      if (selfMatches || children.length > 0) {
+        kept.push({ ...node, children });
+      }
+    }
+    return kept;
+  };
+  return prune(nodes);
+}
+
+function toTreeNodes(
+  nodes: CategoryNode[],
+  usage: Record<string, number> | undefined,
+  onSelect: (id: string) => void,
+  expandAll: boolean,
+  depth = 0,
+): TreeNode[] {
+  return nodes.map((node) => {
+    // Once the usage map has loaded, show a count for every node (including 0).
+    // While it's still loading (`usage` undefined) render no meta rather than
+    // a misleading "0 events".
+    const count = usage === undefined ? undefined : (usage[node.id] ?? 0);
+    return {
+      id: node.id,
+      label: (
+        <span className="flex items-center gap-1.5">
+          <NodeGlyph node={node} />
+          <span className="truncate">{node.title}</span>
+        </span>
+      ),
+      meta: count === undefined ? undefined : `${count} events`,
+      // Expand roots by default; expand everything while a filter is active so
+      // matches deep in the tree are visible.
+      defaultExpanded: expandAll || depth === 0,
+      onActivate: () => onSelect(node.id),
+      children:
+        node.children && node.children.length > 0
+          ? toTreeNodes(node.children, usage, onSelect, expandAll, depth + 1)
+          : undefined,
+    };
+  });
+}
+
+/**
+ * The category hierarchy pane: a filterable, keyboard-navigable disclosure tree.
+ * Selecting a row (click / Enter) calls `onSelect` with its id, which the
+ * manager routes to the inspector.
+ */
+export function CategoryTree({
+  tree,
+  usage,
+  onSelect,
+}: {
+  tree: CategoryNode[];
+  usage: Record<string, number> | undefined;
+  onSelect: (id: string) => void;
+}) {
+  const [filter, setFilter] = React.useState("");
+  const filtered = React.useMemo(
+    () => filterForest(tree, filter),
+    [tree, filter],
+  );
+  const expandAll = filter.trim() !== "";
+  const nodes = React.useMemo(
+    () => toTreeNodes(filtered, usage, onSelect, expandAll),
+    [filtered, usage, onSelect, expandAll],
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="relative border-b border-border p-2">
+        <Search
+          className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-foreground-subtle"
+          aria-hidden
+        />
+        <Input
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter categories…"
+          aria-label="Filter categories"
+          className="pl-8"
+        />
+      </div>
+      <div className="flex-1 overflow-auto p-2">
+        {nodes.length === 0 ? (
+          <p className="px-2 py-6 text-sm text-foreground-muted">
+            No categories match “{filter}”.
+          </p>
+        ) : (
+          // Remount on filter changes so default-expansion recomputes.
+          <Tree
+            key={expandAll ? "filtered" : "all"}
+            nodes={nodes}
+            aria-label="Category hierarchy"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/categories/_components/delete-category-dialog.tsx
+++ b/apps/admin/app/(protected)/categories/_components/delete-category-dialog.tsx
@@ -65,6 +65,13 @@ export function DeleteCategoryDialog({
   const ownUsage = counts[node.id] ?? 0;
   const subtreeUsage = sumSubtreeUsage(node, counts);
 
+  // Until the usage map has loaded, the counts above are all 0 from the `{}`
+  // fallback — don't present that as fact ("0 events") since it understates the
+  // blast radius; show an explicit unknown placeholder instead.
+  const usageLoaded = usage !== undefined;
+  const eventsText = (n: number) =>
+    usageLoaded ? pluralize(n, "event") : "an unknown number of events";
+
   const parentName =
     node.parent_category_id === null
       ? "root"
@@ -113,21 +120,20 @@ export function DeleteCategoryDialog({
                     <li>
                       <strong>Reparent children first</strong> — move its direct
                       children up to <em>{parentName}</em>, then delete only
-                      this category (removes its tag from{" "}
-                      {pluralize(ownUsage, "event")}
+                      this category (removes its tag from {eventsText(ownUsage)}
                       ). The subtree is preserved.
                     </li>
                     <li>
                       <strong>Delete subtree</strong> — delete this category and
                       all {pluralize(descendants, "descendant")}, removing tags
-                      from {pluralize(subtreeUsage, "event")}.
+                      from {eventsText(subtreeUsage)}.
                     </li>
                   </ul>
                 </>
               ) : (
                 <p>
-                  This removes its tag from {pluralize(ownUsage, "event")}. This
-                  cannot be undone.
+                  This removes its tag from {eventsText(ownUsage)}. This cannot
+                  be undone.
                 </p>
               )}
             </div>

--- a/apps/admin/app/(protected)/categories/_components/delete-category-dialog.tsx
+++ b/apps/admin/app/(protected)/categories/_components/delete-category-dialog.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import * as React from "react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel,
+} from "@repo/ui/components/alert-dialog";
+import { Button } from "@repo/ui/components/button";
+import { toast } from "@repo/ui/components/sonner";
+import {
+  useDeleteCategory,
+  useDeleteCategoryReparentingChildren,
+} from "@repo/ui/hooks/use-categories";
+import type { CategoryNode } from "@repo/services/category-service";
+
+import {
+  findNode,
+  countDescendants,
+  sumSubtreeUsage,
+} from "./category-tree-utils";
+
+function pluralize(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * Delete-a-category confirmation with an explicit child + usage policy
+ * (wireframe 24 #6). Shows the blast radius, then:
+ * - a node with children offers **Reparent children first** (recommended —
+ *   preserves the subtree, deletes only this node) vs **Delete subtree** (raw
+ *   cascade);
+ * - a leaf offers a single Delete.
+ */
+export function DeleteCategoryDialog({
+  client,
+  node,
+  tree,
+  usage,
+  open,
+  onOpenChange,
+  onDeleted,
+}: {
+  client: SupabaseClient;
+  node: CategoryNode;
+  tree: CategoryNode[];
+  usage: Record<string, number> | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDeleted: () => void;
+}) {
+  const cascade = useDeleteCategory(client);
+  const reparent = useDeleteCategoryReparentingChildren(client);
+  const pending = cascade.isPending || reparent.isPending;
+
+  const counts = usage ?? {};
+  const descendants = countDescendants(node);
+  const hasChildren = descendants > 0;
+  const ownUsage = counts[node.id] ?? 0;
+  const subtreeUsage = sumSubtreeUsage(node, counts);
+
+  const parentName =
+    node.parent_category_id === null
+      ? "root"
+      : (findNode(tree, node.parent_category_id)?.title ?? "root");
+
+  const childPreview = (node.children ?? [])
+    .slice(0, 3)
+    .map((c) => c.title)
+    .join(", ");
+
+  async function run(
+    kind: "cascade" | "reparent",
+    mutate: (id: string) => Promise<void>,
+  ) {
+    try {
+      await mutate(node.id);
+      toast.success(
+        kind === "reparent"
+          ? `Deleted “${node.title}”; its children were reparented.`
+          : `Deleted “${node.title}”.`,
+      );
+      onOpenChange(false);
+      onDeleted();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to delete category.",
+      );
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete “{node.title}”?</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              {hasChildren ? (
+                <>
+                  <p>
+                    This category has {pluralize(descendants, "descendant")}
+                    {childPreview && ` (${childPreview}…)`}. Choose how to
+                    handle them:
+                  </p>
+                  <ul className="list-disc space-y-1 pl-5">
+                    <li>
+                      <strong>Reparent children first</strong> — move its direct
+                      children up to <em>{parentName}</em>, then delete only
+                      this category (removes its tag from{" "}
+                      {pluralize(ownUsage, "event")}
+                      ). The subtree is preserved.
+                    </li>
+                    <li>
+                      <strong>Delete subtree</strong> — delete this category and
+                      all {pluralize(descendants, "descendant")}, removing tags
+                      from {pluralize(subtreeUsage, "event")}.
+                    </li>
+                  </ul>
+                </>
+              ) : (
+                <p>
+                  This removes its tag from {pluralize(ownUsage, "event")}. This
+                  cannot be undone.
+                </p>
+              )}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+          {hasChildren ? (
+            <>
+              <Button
+                variant="destructive"
+                disabled={pending}
+                onClick={() => void run("cascade", cascade.mutateAsync)}
+              >
+                Delete subtree
+              </Button>
+              <Button
+                variant="primary"
+                disabled={pending}
+                onClick={() => void run("reparent", reparent.mutateAsync)}
+              >
+                Reparent children first
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="destructive"
+              disabled={pending}
+              onClick={() => void run("cascade", cascade.mutateAsync)}
+            >
+              Delete
+            </Button>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/admin/app/(protected)/categories/page.tsx
+++ b/apps/admin/app/(protected)/categories/page.tsx
@@ -1,11 +1,35 @@
-import { PlaceholderPage } from "../../../components/placeholder-page";
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { getUser } from "../../../lib/auth";
+import { getServerSupabaseClient } from "../../auth/_lib/server-supabase";
+import { CategoryManagerClient } from "./_components/category-manager-client";
 
-export default function CategoriesPage() {
+export const metadata = {
+  title: "Categories",
+};
+
+export default async function CategoriesPage() {
+  // Resolve the owner id server-side (session already validated by the
+  // protected layout) so the tree/usage hooks can build their (userId) query
+  // keys on first render without an auth round-trip / loading flash.
+  const client = await getServerSupabaseClient();
+  const user = await getUser(client);
+  if (!user) redirect("/auth/login");
+
   return (
-    <PlaceholderPage
-      title="Categories"
-      description="Hierarchical tags applied to events, characters, and media."
-      trackedIn="Batch F (list primitives)"
-    />
+    // Suspense: CategoryManagerClient calls useSearchParams() (the ?new=1
+    // quick-create deep link), which opts the subtree into client rendering.
+    <Suspense
+      fallback={
+        <div className="space-y-2 p-6">
+          {["s1", "s2", "s3", "s4", "s5"].map((id) => (
+            <Skeleton key={id} className="h-8 w-full rounded-md" />
+          ))}
+        </div>
+      }
+    >
+      <CategoryManagerClient userId={user.id} />
+    </Suspense>
   );
 }

--- a/apps/admin/lib/nav.ts
+++ b/apps/admin/lib/nav.ts
@@ -51,7 +51,9 @@ export const QUICK_CREATE_ITEMS: ShellQuickCreateItem[] = [
   { label: "Period", href: "/periods/new" },
   { label: "Story", href: "/stories/new" },
   { label: "Timeline", href: "/timelines/new" },
-  { label: "Category", href: "/categories/new" },
+  // Categories are a single tree+inspector surface (no per-node route); the
+  // ?new=1 deep link opens the create form (issue #63).
+  { label: "Category", href: "/categories?new=1" },
   { label: "Media", href: "/media/new" },
   { label: "Relationship", href: "/relationships/new" },
 ];

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
         "app/**/_components/media/attach-media-dialog.tsx",
         "app/**/_components/media/media-library.tsx",
         "app/**/_components/media/media-section.tsx",
+        "app/**/category-form-mappers.ts",
+        "app/**/category-tree-utils.ts",
         "app/**/character-detail-helpers.ts",
         "app/**/character-form-mappers.ts",
         "app/**/event-form-mappers.ts",

--- a/packages/services/src/modules/category-service.test.ts
+++ b/packages/services/src/modules/category-service.test.ts
@@ -11,6 +11,7 @@ import {
   deleteCategoryReparentingChildren,
   assertNoCategoryCycle,
   getCategoryTree,
+  getCategoryUsageCounts,
 } from "./category-service";
 
 // ---------------------------------------------------------------------------
@@ -602,6 +603,56 @@ describe("getCategoryTree", () => {
     });
     await expect(getCategoryTree(client, "user-123")).rejects.toThrow(
       "CategoryService.getCategoryTree: db error",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCategoryUsageCounts
+// ---------------------------------------------------------------------------
+
+describe("getCategoryUsageCounts", () => {
+  it("aggregates junction rows into a per-category count map", async () => {
+    const client = makeClient({
+      fromResult: {
+        data: [
+          { category_id: "cat-1" },
+          { category_id: "cat-1" },
+          { category_id: "cat-2" },
+          { category_id: "cat-1" },
+        ],
+        error: null,
+      },
+    });
+    const counts = await getCategoryUsageCounts(client, "user-123");
+    expect(counts).toEqual({ "cat-1": 3, "cat-2": 1 });
+  });
+
+  it("scopes the query to the owner's categories via the inner embed", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    await getCategoryUsageCounts(client, "user-123");
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as ReturnType<typeof makeBuilder>;
+    expect(client.from).toHaveBeenCalledWith("event_categories");
+    expect(builder.eq).toHaveBeenCalledWith("categories.user_id", "user-123");
+  });
+
+  it("returns an empty map when no events are tagged", async () => {
+    const client = makeClient({ fromResult: { data: [], error: null } });
+    expect(await getCategoryUsageCounts(client, "user-123")).toEqual({});
+  });
+
+  it("tolerates a null data payload", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    expect(await getCategoryUsageCounts(client, "user-123")).toEqual({});
+  });
+
+  it("throws on DB error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "db error" } },
+    });
+    await expect(getCategoryUsageCounts(client, "user-123")).rejects.toThrow(
+      "CategoryService.getCategoryUsageCounts: db error",
     );
   });
 });

--- a/packages/services/src/modules/category-service.ts
+++ b/packages/services/src/modules/category-service.ts
@@ -409,3 +409,40 @@ export async function getCategoryTree(
 
   return roots;
 }
+
+/**
+ * Count how many events are tagged with each of a user's categories via the
+ * `event_categories` junction. Powers the per-node usage indicator and the
+ * delete-dialog blast radius in the category management UI (wireframe 24 #4/#6).
+ *
+ * The junction has no `user_id`; ownership is scoped two ways that agree — the
+ * `categories!inner(user_id)` embed filters to rows whose category belongs to
+ * the user, and RLS restricts visible junction rows to the caller's own data.
+ * Counts are aggregated in memory: the result set is bounded by how many
+ * event/category tags a single owner has, so a client-side reduce is adequate
+ * (promote to a `SECURITY INVOKER` aggregate RPC — per the `00026` precedent —
+ * only if that volume ever grows).
+ *
+ * Categories with zero tagged events are simply absent from the map; callers
+ * should treat a missing key as `0`.
+ *
+ * @param client - Supabase client instance
+ * @param userId - Owner's user UUID
+ * @returns A map of category UUID → number of events tagged with it
+ */
+export async function getCategoryUsageCounts(
+  client: SupabaseClient<Database>,
+  userId: string,
+): Promise<Record<string, number>> {
+  const { data, error } = await client
+    .from("event_categories")
+    .select("category_id, categories!inner(user_id)")
+    .eq("categories.user_id", userId);
+  assertNoError(error, "getCategoryUsageCounts");
+
+  const counts: Record<string, number> = {};
+  for (const row of (data ?? []) as { category_id: string }[]) {
+    counts[row.category_id] = (counts[row.category_id] ?? 0) + 1;
+  }
+  return counts;
+}

--- a/packages/ui/src/hooks/use-categories.test.tsx
+++ b/packages/ui/src/hooks/use-categories.test.tsx
@@ -7,9 +7,11 @@ import {
   useCategory,
   useCategoryBySlug,
   useCategoryTree,
+  useCategoryUsageCounts,
   useCreateCategory,
   useUpdateCategory,
   useDeleteCategory,
+  useDeleteCategoryReparentingChildren,
   categoryKeys,
 } from "./use-categories";
 
@@ -20,7 +22,9 @@ vi.mock("@repo/services/category-service", () => ({
   createCategory: vi.fn(),
   updateCategory: vi.fn(),
   deleteCategory: vi.fn(),
+  deleteCategoryReparentingChildren: vi.fn(),
   getCategoryTree: vi.fn(),
+  getCategoryUsageCounts: vi.fn(),
 }));
 
 import {
@@ -30,7 +34,9 @@ import {
   createCategory,
   updateCategory,
   deleteCategory,
+  deleteCategoryReparentingChildren,
   getCategoryTree,
+  getCategoryUsageCounts,
 } from "@repo/services/category-service";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -237,6 +243,64 @@ describe("useDeleteCategory", () => {
   });
 });
 
+describe("useCategoryUsageCounts", () => {
+  it("returns the usage-count map keyed by category id", async () => {
+    vi.mocked(getCategoryUsageCounts).mockResolvedValue({
+      "cat-1": 3,
+    } as never);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useCategoryUsageCounts(mockClient, "user-1"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getCategoryUsageCounts).toHaveBeenCalledWith(mockClient, "user-1");
+    expect(result.current.data).toEqual({ "cat-1": 3 });
+  });
+
+  it("uses the usage query key", async () => {
+    vi.mocked(getCategoryUsageCounts).mockResolvedValue({} as never);
+    const { wrapper, queryClient } = createWrapper();
+
+    renderHook(() => useCategoryUsageCounts(mockClient, "user-9"), { wrapper });
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData(categoryKeys.usage("user-9")),
+      ).toBeDefined(),
+    );
+  });
+});
+
+describe("useDeleteCategoryReparentingChildren", () => {
+  it("calls the reparent-delete service fn and removes from cache", async () => {
+    vi.mocked(deleteCategoryReparentingChildren).mockResolvedValue(
+      undefined as never,
+    );
+
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(categoryKeys.detail("cat-1"), mockCategory);
+    const removeSpy = vi.spyOn(queryClient, "removeQueries");
+
+    const { result } = renderHook(
+      () => useDeleteCategoryReparentingChildren(mockClient),
+      { wrapper },
+    );
+    result.current.mutate("cat-1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(deleteCategoryReparentingChildren).toHaveBeenCalledWith(
+      mockClient,
+      "cat-1",
+    );
+    expect(removeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: categoryKeys.detail("cat-1") }),
+    );
+  });
+});
+
 describe("categoryKeys", () => {
   it("produces stable, unique keys", () => {
     expect(categoryKeys.all).toEqual(["categories"]);
@@ -244,6 +308,11 @@ describe("categoryKeys", () => {
     expect(categoryKeys.tree("user-1")).toEqual([
       "categories",
       "tree",
+      "user-1",
+    ]);
+    expect(categoryKeys.usage("user-1")).toEqual([
+      "categories",
+      "usage",
       "user-1",
     ]);
     expect(categoryKeys.bySlug("user-1", "battles")).toEqual([

--- a/packages/ui/src/hooks/use-categories.tsx
+++ b/packages/ui/src/hooks/use-categories.tsx
@@ -16,7 +16,9 @@ import {
   createCategory,
   updateCategory,
   deleteCategory,
+  deleteCategoryReparentingChildren,
   getCategoryTree,
+  getCategoryUsageCounts,
 } from "@repo/services/category-service";
 import type {
   CategoryFilters,
@@ -41,6 +43,7 @@ export const categoryKeys = {
   bySlug: (userId: string, slug: string) =>
     [...categoryKeys.all, "slug", userId, slug] as const,
   tree: (userId: string) => [...categoryKeys.all, "tree", userId] as const,
+  usage: (userId: string) => [...categoryKeys.all, "usage", userId] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -113,6 +116,26 @@ export function useCategoryTree(
   });
 }
 
+/**
+ * Fetch a map of category UUID → number of events tagged with it. Categories
+ * with no tagged events are absent from the map; treat a missing key as `0`.
+ */
+export function useCategoryUsageCounts(
+  client: ServiceClient,
+  userId: string,
+  options?: Omit<
+    UseQueryOptions<Awaited<ReturnType<typeof getCategoryUsageCounts>>>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery({
+    queryKey: categoryKeys.usage(userId),
+    queryFn: () => getCategoryUsageCounts(client, userId),
+    staleTime: 30_000,
+    ...options,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Mutation hooks
 // ---------------------------------------------------------------------------
@@ -126,6 +149,9 @@ export function useCreateCategory(client: ServiceClient) {
       void queryClient.invalidateQueries({ queryKey: categoryKeys.lists() });
       void queryClient.invalidateQueries({
         queryKey: [...categoryKeys.all, "tree"],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [...categoryKeys.all, "usage"],
       });
     },
   });
@@ -153,6 +179,9 @@ export function useUpdateCategory(client: ServiceClient) {
       void queryClient.invalidateQueries({
         queryKey: [...categoryKeys.all, "tree"],
       });
+      void queryClient.invalidateQueries({
+        queryKey: [...categoryKeys.all, "usage"],
+      });
     },
   });
 }
@@ -167,6 +196,31 @@ export function useDeleteCategory(client: ServiceClient) {
       void queryClient.invalidateQueries({ queryKey: categoryKeys.lists() });
       void queryClient.invalidateQueries({
         queryKey: [...categoryKeys.all, "tree"],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [...categoryKeys.all, "usage"],
+      });
+    },
+  });
+}
+
+/**
+ * Delete a category while preserving its subtree — its direct children are
+ * reparented to the target's own parent (wireframe 24 "Option A"). Mirrors
+ * {@link useDeleteCategory} but calls the atomic reparent-then-delete RPC.
+ */
+export function useDeleteCategoryReparentingChildren(client: ServiceClient) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteCategoryReparentingChildren(client, id),
+    onSuccess: (_data, id) => {
+      queryClient.removeQueries({ queryKey: categoryKeys.detail(id) });
+      void queryClient.invalidateQueries({ queryKey: categoryKeys.lists() });
+      void queryClient.invalidateQueries({
+        queryKey: [...categoryKeys.all, "tree"],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [...categoryKeys.all, "usage"],
       });
     },
   });


### PR DESCRIPTION
Closes #63.

Replaces the categories placeholder with a single **tree + inspector** management surface (wireframe 24) — a filterable, keyboard-navigable hierarchy on the left and a create/edit inspector on the right. Categories are lightweight taxonomy, so there are no per-node routes.

## What's included

**UI (`apps/admin/app/(protected)/categories/`)**
- Tree from `getCategoryTree` with a per-node color/icon glyph and event **usage counts**; expand/collapse; client-side filter.
- Inspector (react-hook-form + zod): title, description, color (hex + native swatch), icon (curated lucide grid + emoji fallback), parent picker, slug.
- **Parent picker** excludes the edited node + its descendants (client-side cycle guard mirroring the service `assertNoCategoryCycle`).
- **Delete dialog** with explicit child policy + blast radius: _reparent children first_ (recommended) vs _delete subtree_, or a single delete for leaves.
- Empty / loading / error states; `?new=1` deep link powers the topbar quick-create.

**Backing additions**
- `services`: `getCategoryUsageCounts` (events tagged per category via `event_categories`, owner-scoped) + tests.
- `ui` hooks: `useCategoryUsageCounts`, `useDeleteCategoryReparentingChildren`, a `usage` query key, and usage invalidation on create/update/delete + tests.
- `nav`: Category quick-create → `/categories?new=1` (single-surface model).

## Verification

- `pnpm verify` green (format, lint, check-types, test:coverage, build).
- **Live smoke test** (Playwright against local Supabase) covered: create root + nested child, edit color/icon (tree re-tints), parent-picker cycle exclusion, delete-parent with both policies (reparent promotes the child), delete-leaf (selection clears). No console/network errors on load.
- Two real issues found & fixed during smoke testing: zero-usage nodes now show "0 events" once the map loads; a synchronous slug flush on submit prevents the `SlugField` debounce race from silently failing fast creates.

## Acceptance criteria

- [x] Route exits placeholder state
- [x] Tree reflects the real `parent_category_id` hierarchy (deterministic alpha ordering)
- [x] Create/edit/delete persist; color + icon editable
- [x] Delete child-handling explicit in UI + implementation (reparent vs. cascade, with blast radius incl. event untagging)
- [x] Reparent respects cycle prevention
- [x] Empty/loading/error states implemented

## Known limitation

`categorySchema` can't clear `color`/`icon` back to `null` on update (sent as `undefined` no-op) — tracked in #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)