### PR TITLE
feat(admin): Period management UI with hierarchical nesting and temporal ranges — #64

### DIFF
--- a/apps/admin/app/(protected)/periods/[slug]/_components/period-detail-client.tsx
+++ b/apps/admin/app/(protected)/periods/[slug]/_components/period-detail-client.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronUp, MoreHorizontal } from "lucide-react";
+import { toast } from "@repo/ui/components/sonner";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+
+import {
+  periodKeys,
+  usePeriod,
+  usePeriodBySlug,
+  usePublishPeriod,
+  useUnpublishPeriod,
+  useDeletePeriod,
+} from "@repo/ui/hooks/use-periods";
+import { getBrowserSupabaseClient } from "../../../../../lib/auth/browser-client";
+
+import { Button, buttonVariants } from "@repo/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@repo/ui/components/dropdown-menu";
+import { PublishControl } from "@repo/ui/components/publish-control";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@repo/ui/components/tabs";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+
+import {
+  SignificanceRamp,
+  type Significance,
+} from "../../_components/significance-ramp";
+import { PeriodTimelinesTab } from "./period-timelines-tab";
+import { PeriodEventsTab } from "./period-events-tab";
+
+export function PeriodDetailClient({
+  userId,
+  slug,
+}: {
+  userId: string;
+  slug: string;
+}) {
+  const router = useRouter();
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+  const queryClient = useQueryClient();
+
+  const {
+    data: period,
+    isPending,
+    isError,
+  } = usePeriodBySlug(client, userId, slug);
+
+  const [tab, setTab] = React.useState("timelines");
+  const [showDelete, setShowDelete] = React.useState(false);
+  const [showDangerZone, setShowDangerZone] = React.useState(false);
+
+  const publish = usePublishPeriod(client);
+  const unpublish = useUnpublishPeriod(client);
+  const deletePeriod = useDeletePeriod(client);
+
+  // Junction mutations invalidate periodKeys.detail(id), but this page reads via
+  // bySlug — refresh that query after a tab mutation.
+  const refreshPeriod = React.useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: periodKeys.bySlug(userId, slug),
+    });
+  }, [queryClient, userId, slug]);
+
+  if (isPending) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-8 w-64 rounded-md" />
+        <Skeleton className="h-4 w-96 rounded-md" />
+        <Skeleton className="h-4 w-48 rounded-md" />
+        <div className="mt-6 space-y-2">
+          {[1, 2, 3, 4].map((step) => (
+            <Skeleton key={step} className="h-14 w-full rounded-md" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !period) {
+    return (
+      <div className="p-6 text-center space-y-4">
+        <p className="text-muted-foreground">Period not found.</p>
+        <Link
+          href="/periods"
+          className={buttonVariants({ variant: "secondary", size: "sm" })}
+        >
+          Back to periods
+        </Link>
+      </div>
+    );
+  }
+
+  const isOwner = period.user_id === userId;
+  const canEdit = isOwner;
+  const editHref = `/periods/${slug}/edit`;
+
+  const significance = (period.significance as Significance | null) ?? "medium";
+  const characteristics = period.characteristics ?? [];
+  const children = period.child_periods ?? [];
+  const overlaidTimelineIds = (period.period_timelines ?? []).map(
+    (r) => r.timeline_id,
+  );
+  const parentId = period.parent_period_id;
+
+  const hasProse =
+    (period.summary && period.summary.length > 0) ||
+    (period.detail && period.detail.length > 0);
+
+  return (
+    <div className="p-6 space-y-6 max-w-4xl">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 space-y-1">
+          <nav className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Link href="/periods" className="hover:text-foreground">
+              Periods
+            </Link>
+            <span aria-hidden>▸</span>
+            {parentId && <ParentCrumb client={client} parentId={parentId} />}
+          </nav>
+          <h1 className="truncate text-2xl font-bold tracking-tight">
+            {period.title}
+          </h1>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            {period.temporal_data && (
+              <span className="text-foreground">
+                <TemporalDisplay
+                  value={period.temporal_data as TemporalData}
+                  endValue={
+                    (period.end_temporal_data as TemporalData | null) ??
+                    undefined
+                  }
+                  format="compact"
+                />
+              </span>
+            )}
+            <span aria-hidden>·</span>
+            <SignificanceRamp value={significance} />
+            <span className="font-mono">· {period.slug}</span>
+          </div>
+          {characteristics.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 pt-1">
+              {characteristics.map((c) => (
+                <span
+                  key={c}
+                  className="rounded bg-surface-2 px-1.5 py-0.5 text-xs text-foreground-muted"
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <PublishControl
+            published={period.published ?? false}
+            entityLabel="period"
+            canPublish={isOwner}
+            onPublish={() =>
+              publish.mutate(period.id, {
+                onSuccess: () => toast.success("Period published."),
+                onError: (err) =>
+                  toast.error(
+                    err instanceof Error ? err.message : "Publish failed",
+                  ),
+              })
+            }
+            onUnpublish={() =>
+              unpublish.mutate(period.id, {
+                onSuccess: () => toast.success("Period unpublished."),
+                onError: (err) =>
+                  toast.error(
+                    err instanceof Error ? err.message : "Unpublish failed",
+                  ),
+              })
+            }
+          />
+          {canEdit && (
+            <Link
+              href={editHref}
+              className={buttonVariants({ variant: "secondary", size: "sm" })}
+            >
+              Edit
+            </Link>
+          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+                aria-label="More actions"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => void navigator.clipboard.writeText(period.id)}
+              >
+                Copy ID
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Overview: narrative + hierarchy */}
+      <div className="grid gap-6 md:grid-cols-[1fr_16rem]">
+        <div className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-foreground-muted">
+            Description
+          </h2>
+          {hasProse ? (
+            <div className="space-y-3">
+              {period.summary && (
+                <p className="whitespace-pre-wrap text-sm text-foreground">
+                  {period.summary}
+                </p>
+              )}
+              {period.detail && (
+                <p className="whitespace-pre-wrap text-sm text-muted-foreground">
+                  {period.detail}
+                </p>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No description written yet.
+            </p>
+          )}
+        </div>
+
+        <aside className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-foreground-muted">
+              Parent
+            </h2>
+            {parentId ? (
+              <ParentLink client={client} parentId={parentId} />
+            ) : (
+              <p className="text-sm text-muted-foreground">— top-level —</p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-foreground-muted">
+              Child periods
+            </h2>
+            {children.length === 0 ? (
+              <p className="text-sm text-muted-foreground">— none —</p>
+            ) : (
+              <ul className="space-y-1">
+                {children.map((child) => (
+                  <li key={child.id}>
+                    <Link
+                      href={`/periods/${child.slug}`}
+                      className="text-sm text-primary hover:underline"
+                    >
+                      {child.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </aside>
+      </div>
+
+      {/* Tabs */}
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList>
+          <TabsTrigger value="timelines">
+            Overlaid timelines ({overlaidTimelineIds.length})
+          </TabsTrigger>
+          <TabsTrigger value="events">Events in range</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="timelines" className="pt-4">
+          <PeriodTimelinesTab
+            client={client}
+            periodId={period.id}
+            userId={userId}
+            canEdit={canEdit}
+            overlaidTimelineIds={overlaidTimelineIds}
+            onMutated={refreshPeriod}
+          />
+        </TabsContent>
+
+        <TabsContent value="events" className="pt-4">
+          {/* Lazy: only mount (and run the in-range query) when the tab opens. */}
+          {tab === "events" && (
+            <PeriodEventsTab
+              client={client}
+              periodId={period.id}
+              hasOverlays={overlaidTimelineIds.length > 0}
+            />
+          )}
+        </TabsContent>
+      </Tabs>
+
+      {/* Danger zone */}
+      {isOwner && (
+        <div className="rounded-md border border-destructive/30">
+          <button
+            type="button"
+            aria-expanded={showDangerZone}
+            className="flex w-full items-center gap-2 px-4 py-3 text-sm text-destructive transition-colors hover:bg-destructive/5"
+            onClick={() => setShowDangerZone((v) => !v)}
+          >
+            {showDangerZone ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+            Danger zone
+          </button>
+          {showDangerZone && (
+            <div className="border-t border-destructive/20 px-4 pb-4 pt-1">
+              <p className="mb-3 text-xs text-muted-foreground">
+                Deleting a period is permanent.{" "}
+                {children.length > 0 ? (
+                  <>
+                    It{" "}
+                    <strong>
+                      also deletes its {children.length} child period
+                      {children.length === 1 ? "" : "s"}
+                    </strong>{" "}
+                    (cascade).
+                  </>
+                ) : (
+                  "It has no child periods."
+                )}{" "}
+                Events and timelines are unaffected — the period only overlaid
+                them.
+              </p>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setShowDelete(true)}
+              >
+                Delete period
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Delete confirmation — states the cascade blast radius */}
+      <Dialog
+        open={showDelete}
+        onOpenChange={(o) => {
+          if (!o) setShowDelete(false);
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete “{period.title}”?</DialogTitle>
+            <DialogDescription>
+              {children.length > 0 ? (
+                <>
+                  This also deletes {children.length} child period
+                  {children.length === 1 ? "" : "s"} (
+                  {children
+                    .slice(0, 3)
+                    .map((c) => c.title)
+                    .join(", ")}
+                  {children.length > 3 ? "…" : ""}). Events and timelines are
+                  unaffected. This cannot be undone.
+                </>
+              ) : (
+                <>Events and timelines are unaffected. This cannot be undone.</>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowDelete(false)}
+              disabled={deletePeriod.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={deletePeriod.isPending}
+              onClick={() =>
+                deletePeriod.mutate(period.id, {
+                  onSuccess: () => {
+                    toast.success("Period deleted.");
+                    router.push("/periods");
+                  },
+                  onError: (err) =>
+                    toast.error(
+                      err instanceof Error ? err.message : "Delete failed",
+                    ),
+                })
+              }
+            >
+              {deletePeriod.isPending ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Parent helpers — resolve the parent period for the breadcrumb + hierarchy
+// panel. Fetched by id via its own cached query so it survives navigation.
+// ---------------------------------------------------------------------------
+
+function ParentCrumb({
+  client,
+  parentId,
+}: {
+  client: ReturnType<typeof getBrowserSupabaseClient>;
+  parentId: string;
+}) {
+  const parent = useParentPeriod(client, parentId);
+  if (!parent) return null;
+  return (
+    <>
+      <Link href={`/periods/${parent.slug}`} className="hover:text-foreground">
+        {parent.title}
+      </Link>
+      <span aria-hidden>▸</span>
+    </>
+  );
+}
+
+function ParentLink({
+  client,
+  parentId,
+}: {
+  client: ReturnType<typeof getBrowserSupabaseClient>;
+  parentId: string;
+}) {
+  const parent = useParentPeriod(client, parentId);
+  if (!parent) {
+    return <p className="text-sm text-muted-foreground">…</p>;
+  }
+  return (
+    <Link
+      href={`/periods/${parent.slug}`}
+      className="text-sm text-primary hover:underline"
+    >
+      {parent.title}
+    </Link>
+  );
+}
+
+function useParentPeriod(
+  client: ReturnType<typeof getBrowserSupabaseClient>,
+  parentId: string,
+) {
+  const { data } = usePeriod(client, parentId);
+  return data ?? null;
+}

--- a/apps/admin/app/(protected)/periods/[slug]/_components/period-detail-client.tsx
+++ b/apps/admin/app/(protected)/periods/[slug]/_components/period-detail-client.tsx
@@ -128,6 +128,19 @@ export function PeriodDetailClient({
     (period.summary && period.summary.length > 0) ||
     (period.detail && period.detail.length > 0);
 
+  // clipboard.writeText can reject (non-secure context, denied permission);
+  // surface the outcome rather than dropping the promise. The id is captured in
+  // a const so the narrowing survives into this closure.
+  const periodId = period.id;
+  async function copyId() {
+    try {
+      await navigator.clipboard.writeText(periodId);
+      toast.success("Period ID copied.");
+    } catch {
+      toast.error("Couldn’t copy the ID to the clipboard.");
+    }
+  }
+
   return (
     <div className="p-6 space-y-6 max-w-4xl">
       {/* Header */}
@@ -218,9 +231,7 @@ export function PeriodDetailClient({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onClick={() => void navigator.clipboard.writeText(period.id)}
-              >
+              <DropdownMenuItem onClick={() => void copyId()}>
                 Copy ID
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/apps/admin/app/(protected)/periods/[slug]/_components/period-events-tab.tsx
+++ b/apps/admin/app/(protected)/periods/[slug]/_components/period-events-tab.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { ArrowUpRight } from "lucide-react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@repo/services/supabase/types";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+
+import { useEventsInPeriod } from "@repo/ui/hooks/use-periods";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+
+type ServiceClient = SupabaseClient<Database>;
+
+const PAGE_SIZE = 25;
+
+/**
+ * Events-in-range: the events whose date falls within this period's span
+ * (span-overlay model — computed by date, not linked). Read-only. A scope
+ * toggle limits results to the overlaid timelines vs. all events in range
+ * (wireframe 23 #4). The list is paginated because a wide (e.g. BYA) span can
+ * return many rows.
+ */
+export function PeriodEventsTab({
+  client,
+  periodId,
+  hasOverlays,
+}: {
+  client: ServiceClient;
+  periodId: string;
+  hasOverlays: boolean;
+}) {
+  const router = useRouter();
+  // Default to timeline-scoped when the period overlays something (it is
+  // contextualising those canvases); otherwise all-in-range.
+  const [scoped, setScoped] = React.useState(hasOverlays);
+  const [page, setPage] = React.useState(0);
+
+  // Reset paging whenever the scope changes.
+  const [prevScoped, setPrevScoped] = React.useState(scoped);
+  if (scoped !== prevScoped) {
+    setPrevScoped(scoped);
+    setPage(0);
+  }
+
+  const { data: events = [], isPending } = useEventsInPeriod(client, periodId, {
+    timelineScoped: scoped,
+  });
+
+  const total = events.length;
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const pageEvents = events.slice(
+    page * PAGE_SIZE,
+    page * PAGE_SIZE + PAGE_SIZE,
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs text-foreground-muted">
+          Computed by date — events are not linked to periods (span-overlay
+          model).
+        </p>
+        <div
+          role="radiogroup"
+          aria-label="Event scope"
+          className="flex items-center gap-1 rounded-md border border-border p-0.5 text-xs"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={scoped}
+            disabled={!hasOverlays}
+            onClick={() => setScoped(true)}
+            className={
+              scoped
+                ? "rounded bg-surface-2 px-2 py-1 text-foreground"
+                : "rounded px-2 py-1 text-foreground-muted hover:text-foreground disabled:opacity-40"
+            }
+          >
+            On overlaid timelines
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={!scoped}
+            onClick={() => setScoped(false)}
+            className={
+              !scoped
+                ? "rounded bg-surface-2 px-2 py-1 text-foreground"
+                : "rounded px-2 py-1 text-foreground-muted hover:text-foreground"
+            }
+          >
+            All in range
+          </button>
+        </div>
+      </div>
+
+      {isPending ? (
+        <div className="space-y-2">
+          {["a", "b", "c"].map((k) => (
+            <Skeleton key={k} className="h-10 w-full rounded-md" />
+          ))}
+        </div>
+      ) : total === 0 ? (
+        <p className="py-6 text-center text-sm text-foreground-muted">
+          {scoped && hasOverlays
+            ? "No events on the overlaid timelines fall within this span."
+            : "No events fall within this span yet."}
+        </p>
+      ) : (
+        <>
+          <ul className="divide-y divide-border rounded-md border border-border">
+            {pageEvents.map((ev) => (
+              <li key={ev.id}>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-surface-2/50"
+                  onClick={() => router.push(`/events/${ev.slug}`)}
+                >
+                  <span className="w-28 shrink-0 text-xs text-foreground-muted">
+                    {ev.temporal_data && (
+                      <TemporalDisplay
+                        value={ev.temporal_data as TemporalData}
+                        format="compact"
+                      />
+                    )}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                    {ev.title}
+                  </span>
+                  {ev.event_type && (
+                    <span className="shrink-0 text-xs text-foreground-muted">
+                      {ev.event_type}
+                    </span>
+                  )}
+                  {ev.importance !== null && (
+                    <span
+                      className="shrink-0 text-xs tabular-nums text-foreground-muted"
+                      title={`Importance ${ev.importance}`}
+                    >
+                      ★{ev.importance}
+                    </span>
+                  )}
+                  <ArrowUpRight
+                    className="h-3.5 w-3.5 shrink-0 text-foreground-muted"
+                    aria-hidden
+                  />
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          {pageCount > 1 && (
+            <div className="flex items-center justify-between text-xs text-foreground-muted">
+              <span>
+                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)}{" "}
+                of {total}
+              </span>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  className="rounded px-2 py-1 hover:text-foreground disabled:opacity-40"
+                  aria-label="Previous page"
+                >
+                  ‹
+                </button>
+                <span>
+                  {page + 1} / {pageCount}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+                  disabled={page >= pageCount - 1}
+                  className="rounded px-2 py-1 hover:text-foreground disabled:opacity-40"
+                  aria-label="Next page"
+                >
+                  ›
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/periods/[slug]/_components/period-events-tab.tsx
+++ b/apps/admin/app/(protected)/periods/[slug]/_components/period-events-tab.tsx
@@ -19,8 +19,8 @@ const PAGE_SIZE = 25;
  * Events-in-range: the events whose date falls within this period's span
  * (span-overlay model — computed by date, not linked). Read-only. A scope
  * toggle limits results to the overlaid timelines vs. all events in range
- * (wireframe 23 #4). The list is paginated because a wide (e.g. BYA) span can
- * return many rows.
+ * (wireframe 23 #4). Pagination is server-side (the hook fetches one page +
+ * the total), because a wide (e.g. BYA) span can match many events.
  */
 export function PeriodEventsTab({
   client,
@@ -35,25 +35,24 @@ export function PeriodEventsTab({
   // Default to timeline-scoped when the period overlays something (it is
   // contextualising those canvases); otherwise all-in-range.
   const [scoped, setScoped] = React.useState(hasOverlays);
-  const [page, setPage] = React.useState(0);
+  const [page, setPage] = React.useState(1);
 
-  // Reset paging whenever the scope changes.
-  const [prevScoped, setPrevScoped] = React.useState(scoped);
-  if (scoped !== prevScoped) {
-    setPrevScoped(scoped);
-    setPage(0);
-  }
+  // Changing scope resets to the first page (done in the handler so no state is
+  // written during render).
+  const changeScope = React.useCallback((next: boolean) => {
+    setScoped(next);
+    setPage(1);
+  }, []);
 
-  const { data: events = [], isPending } = useEventsInPeriod(client, periodId, {
+  const { data, isPending } = useEventsInPeriod(client, periodId, {
     timelineScoped: scoped,
+    page,
+    pageSize: PAGE_SIZE,
   });
 
-  const total = events.length;
+  const events = data?.rows ?? [];
+  const total = data?.total ?? 0;
   const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
-  const pageEvents = events.slice(
-    page * PAGE_SIZE,
-    page * PAGE_SIZE + PAGE_SIZE,
-  );
 
   return (
     <div className="space-y-3">
@@ -72,7 +71,7 @@ export function PeriodEventsTab({
             role="radio"
             aria-checked={scoped}
             disabled={!hasOverlays}
-            onClick={() => setScoped(true)}
+            onClick={() => changeScope(true)}
             className={
               scoped
                 ? "rounded bg-surface-2 px-2 py-1 text-foreground"
@@ -85,7 +84,7 @@ export function PeriodEventsTab({
             type="button"
             role="radio"
             aria-checked={!scoped}
-            onClick={() => setScoped(false)}
+            onClick={() => changeScope(false)}
             className={
               !scoped
                 ? "rounded bg-surface-2 px-2 py-1 text-foreground"
@@ -112,7 +111,7 @@ export function PeriodEventsTab({
       ) : (
         <>
           <ul className="divide-y divide-border rounded-md border border-border">
-            {pageEvents.map((ev) => (
+            {events.map((ev) => (
               <li key={ev.id}>
                 <button
                   type="button"
@@ -155,26 +154,26 @@ export function PeriodEventsTab({
           {pageCount > 1 && (
             <div className="flex items-center justify-between text-xs text-foreground-muted">
               <span>
-                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)}{" "}
+                {(page - 1) * PAGE_SIZE + 1}–{Math.min(page * PAGE_SIZE, total)}{" "}
                 of {total}
               </span>
               <div className="flex items-center gap-1">
                 <button
                   type="button"
-                  onClick={() => setPage((p) => Math.max(0, p - 1))}
-                  disabled={page === 0}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1}
                   className="rounded px-2 py-1 hover:text-foreground disabled:opacity-40"
                   aria-label="Previous page"
                 >
                   ‹
                 </button>
                 <span>
-                  {page + 1} / {pageCount}
+                  {page} / {pageCount}
                 </span>
                 <button
                   type="button"
-                  onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
-                  disabled={page >= pageCount - 1}
+                  onClick={() => setPage((p) => Math.min(pageCount, p + 1))}
+                  disabled={page >= pageCount}
                   className="rounded px-2 py-1 hover:text-foreground disabled:opacity-40"
                   aria-label="Next page"
                 >

--- a/apps/admin/app/(protected)/periods/[slug]/_components/period-timelines-tab.tsx
+++ b/apps/admin/app/(protected)/periods/[slug]/_components/period-timelines-tab.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Plus, X } from "lucide-react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@repo/services/supabase/types";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+
+import { useTimelines } from "@repo/ui/hooks/use-timelines";
+import {
+  useAddPeriodToTimeline,
+  useRemovePeriodFromTimeline,
+} from "@repo/ui/hooks/use-periods";
+import { toast } from "@repo/ui/components/sonner";
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+
+type ServiceClient = SupabaseClient<Database>;
+
+/**
+ * The `period_timelines` junction surface — the timelines a period overlays
+ * (wireframe 23 #3). Titles/spans are resolved against the user's timelines
+ * list; add/remove write the junction directly.
+ */
+export function PeriodTimelinesTab({
+  client,
+  periodId,
+  userId,
+  canEdit,
+  overlaidTimelineIds,
+  onMutated,
+}: {
+  client: ServiceClient;
+  periodId: string;
+  userId: string;
+  canEdit: boolean;
+  overlaidTimelineIds: string[];
+  onMutated: () => void;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+
+  const { data: timelines = [], isPending } = useTimelines(
+    client,
+    { userId, pageSize: 100 },
+    { enabled: userId !== "" },
+  );
+
+  const addTimeline = useAddPeriodToTimeline(client);
+  const removeTimeline = useRemovePeriodFromTimeline(client);
+
+  const overlaidSet = React.useMemo(
+    () => new Set(overlaidTimelineIds),
+    [overlaidTimelineIds],
+  );
+  const overlaid = React.useMemo(
+    () => timelines.filter((t) => overlaidSet.has(t.id)),
+    [timelines, overlaidSet],
+  );
+  const addable = React.useMemo(
+    () => timelines.filter((t) => !overlaidSet.has(t.id)),
+    [timelines, overlaidSet],
+  );
+
+  function handleAdd(timelineId: string) {
+    setOpen(false);
+    addTimeline.mutate(
+      { periodId, timelineId },
+      {
+        onSuccess: () => {
+          toast.success("Timeline overlaid.");
+          onMutated();
+        },
+        onError: (err) =>
+          toast.error(err instanceof Error ? err.message : "Failed to add."),
+      },
+    );
+  }
+
+  function handleRemove(timelineId: string) {
+    removeTimeline.mutate(
+      { periodId, timelineId },
+      {
+        onSuccess: () => {
+          toast.success("Timeline removed.");
+          onMutated();
+        },
+        onError: (err) =>
+          toast.error(err instanceof Error ? err.message : "Failed to remove."),
+      },
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {canEdit && (
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button variant="secondary" size="sm" className="gap-1.5">
+              <Plus className="h-3.5 w-3.5" aria-hidden />
+              Overlay a timeline
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80 p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Search timelines…" />
+              <CommandList>
+                <CommandEmpty>
+                  {isPending ? "Loading…" : "No timelines available."}
+                </CommandEmpty>
+                <CommandGroup>
+                  {addable.map((t) => (
+                    <CommandItem
+                      key={t.id}
+                      value={`${t.title} ${t.id}`}
+                      onSelect={() => handleAdd(t.id)}
+                    >
+                      {t.title}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      )}
+
+      {overlaid.length === 0 ? (
+        <p className="py-6 text-center text-sm text-foreground-muted">
+          This period overlays no timelines yet. Overlay one to place this span
+          onto its canvas.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border rounded-md border border-border">
+          {overlaid.map((t) => (
+            <li
+              key={t.id}
+              className="flex items-center justify-between gap-3 px-3 py-2"
+            >
+              <button
+                type="button"
+                className="min-w-0 flex-1 text-left hover:opacity-80"
+                onClick={() => router.push(`/timelines/${t.slug}`)}
+              >
+                <span className="block truncate text-sm text-foreground">
+                  {t.title}
+                </span>
+                {t.temporal_data && (
+                  <span className="text-xs text-foreground-muted">
+                    <TemporalDisplay
+                      value={t.temporal_data as TemporalData}
+                      endValue={
+                        (t.end_temporal_data as TemporalData | null) ??
+                        undefined
+                      }
+                      format="compact"
+                    />
+                  </span>
+                )}
+              </button>
+              {canEdit && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 shrink-0 p-0"
+                  aria-label={`Remove ${t.title}`}
+                  onClick={() => handleRemove(t.id)}
+                >
+                  <X className="h-4 w-4" aria-hidden />
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/periods/[slug]/edit/page.tsx
+++ b/apps/admin/app/(protected)/periods/[slug]/edit/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { getUser } from "../../../../../lib/auth";
+import { getServerSupabaseClient } from "../../../../auth/_lib/server-supabase";
+import { PeriodFormClient } from "../../_components/period-form-client";
+
+interface EditPeriodPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function EditPeriodPage({ params }: EditPeriodPageProps) {
+  const { slug } = await params;
+
+  // Resolve the owner id server-side (session already validated by the
+  // protected layout) so the client hook can build its (userId, slug) query
+  // key on first render without an auth round-trip / loading flash.
+  const client = await getServerSupabaseClient();
+  const user = await getUser(client);
+  if (!user) redirect("/auth/login");
+
+  return <PeriodFormClient mode="edit" userId={user.id} slug={slug} />;
+}

--- a/apps/admin/app/(protected)/periods/[slug]/page.tsx
+++ b/apps/admin/app/(protected)/periods/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { getUser } from "../../../../lib/auth";
+import { getServerSupabaseClient } from "../../../auth/_lib/server-supabase";
+import { PeriodDetailClient } from "./_components/period-detail-client";
+
+export const metadata = {
+  title: "Period",
+};
+
+export default async function PeriodDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  // Resolve the owner id server-side (session already validated by the
+  // protected layout) so the client hook can build its (userId, slug) query
+  // key on first render without an auth round-trip / loading flash.
+  const client = await getServerSupabaseClient();
+  const user = await getUser(client);
+  if (!user) redirect("/auth/login");
+
+  return (
+    <Suspense
+      fallback={
+        <div className="p-6 space-y-4">
+          <Skeleton className="h-8 w-64 rounded-md" />
+          <Skeleton className="h-4 w-96 rounded-md" />
+          <Skeleton className="h-4 w-32 rounded-md" />
+          <div className="mt-6 space-y-2">
+            {[1, 2, 3, 4].map((step) => (
+              <Skeleton key={step} className="h-14 w-full rounded-md" />
+            ))}
+          </div>
+        </div>
+      }
+    >
+      <PeriodDetailClient userId={user.id} slug={slug} />
+    </Suspense>
+  );
+}

--- a/apps/admin/app/(protected)/periods/_components/period-form-client.tsx
+++ b/apps/admin/app/(protected)/periods/_components/period-form-client.tsx
@@ -1,0 +1,655 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { useForm, useWatch, Controller, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { generateSlug } from "@repo/services/utils/slug";
+import { compareTemporal } from "@repo/services/schemas/temporal";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+
+import {
+  usePeriodBySlug,
+  usePeriods,
+  useCreatePeriod,
+  useUpdatePeriod,
+} from "@repo/ui/hooks/use-periods";
+import { useUiStore } from "@repo/ui/stores";
+
+import { Alert, AlertDescription, AlertTitle } from "@repo/ui/components/alert";
+import { AutosaveIndicator } from "@repo/ui/components/autosave-indicator";
+import { Button } from "@repo/ui/components/button";
+import { ChipInput } from "@repo/ui/components/chip-input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/form";
+import { Input } from "@repo/ui/components/input";
+import { SaveDropdown } from "@repo/ui/components/save-dropdown";
+import { SlugField } from "@repo/ui/components/slug-field";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { Textarea } from "@repo/ui/components/textarea";
+import { TemporalInput } from "@repo/ui/components/temporal-input";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+import { cn } from "@repo/ui/lib/utils";
+
+import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import { useUnsavedChangesGuard } from "./use-unsaved-changes-guard";
+import { SignificanceRamp, type Significance } from "./significance-ramp";
+import { PeriodParentPicker } from "./period-parent-picker";
+import {
+  periodFormSchema,
+  BLANK_VALUES,
+  mapRowToFormValues,
+  toCreateInput,
+  toUpdateData,
+  seedForAddAnother,
+  type PeriodFormValues,
+} from "./period-form-mappers";
+
+const SIG_OPTIONS: Significance[] = ["low", "medium", "high", "critical"];
+const SIG_LABEL: Record<Significance, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  critical: "Critical",
+};
+
+const SECTION_HEADING =
+  "text-xs font-semibold uppercase tracking-wider text-foreground-muted";
+
+/** Segmented four-way significance control (wireframe 22 #3). */
+function SignificanceControl({
+  value,
+  onChange,
+}: {
+  value: Significance;
+  onChange: (value: Significance) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <div
+        role="radiogroup"
+        aria-label="Significance"
+        className="flex gap-1 rounded-md border border-border p-1"
+      >
+        {SIG_OPTIONS.map((option) => (
+          <button
+            key={option}
+            type="button"
+            role="radio"
+            aria-checked={value === option}
+            onClick={() => onChange(option)}
+            className={cn(
+              "flex-1 rounded px-2 py-1 text-xs transition-colors",
+              value === option
+                ? "bg-surface-2 text-foreground"
+                : "text-foreground-muted hover:text-foreground",
+            )}
+          >
+            {SIG_LABEL[option]}
+          </button>
+        ))}
+      </div>
+      <SignificanceRamp value={value} />
+    </div>
+  );
+}
+
+/**
+ * Returns a soft, non-blocking message when the child's span falls outside the
+ * chosen parent's span. Returns null when either span is incomplete or the
+ * child sits inside the parent (wireframe 22 edge case).
+ */
+function outOfParentRangeWarning(
+  childStart: TemporalData | null,
+  childEnd: TemporalData | null,
+  parentStart: TemporalData | null,
+  parentEnd: TemporalData | null,
+  parentTitle: string,
+): string | null {
+  if (childStart === null || parentStart === null) return null;
+  const startsBefore = compareTemporal(childStart, parentStart) < 0;
+  const endsAfter =
+    childEnd !== null &&
+    parentEnd !== null &&
+    compareTemporal(childEnd, parentEnd) > 0;
+  if (!startsBefore && !endsAfter) return null;
+  return `This period's span extends outside ${parentTitle}. Period boundaries can overlap — this is allowed, just double-check.`;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+type Props =
+  { mode: "create" } | { mode: "edit"; userId: string; slug: string };
+
+export function PeriodFormClient(props: Props) {
+  const router = useRouter();
+  const addToast = useUiStore((s) => s.addToast);
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+
+  const createPeriod = useCreatePeriod(client);
+  const updatePeriod = useUpdatePeriod(client);
+  // A separate observer for the 30s auto-save so its pending state doesn't
+  // flicker the deliberate Save button.
+  const autosave = useUpdatePeriod(client);
+
+  const isEdit = props.mode === "edit";
+  const editQuery = usePeriodBySlug(
+    client,
+    isEdit ? props.userId : "",
+    isEdit ? props.slug : "",
+    { enabled: isEdit },
+  );
+  const editRow = editQuery.data;
+
+  const cancelHref = isEdit ? `/periods/${props.slug}` : "/periods";
+
+  const form = useForm<PeriodFormValues>({
+    resolver: zodResolver(periodFormSchema) as Resolver<PeriodFormValues>,
+    defaultValues: BLANK_VALUES,
+    mode: "onTouched",
+  });
+
+  // Hydrate once from the fetched row; a background refetch must not clobber
+  // in-progress edits.
+  const hydratedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!isEdit || hydratedRef.current || editRow === undefined) return;
+    form.reset(mapRowToFormValues(editRow));
+    hydratedRef.current = true;
+  }, [isEdit, editRow, form]);
+
+  const isDirty = form.formState.isDirty;
+  const guard = useUnsavedChangesGuard(isDirty);
+
+  const [autosaveAt, setAutosaveAt] = React.useState<Date | null>(null);
+  const [addAnotherNote, setAddAnotherNote] = React.useState(false);
+  const addAnotherRef = React.useRef(false);
+
+  // Current user id — scopes the parent-period options query.
+  const { data: userId = "" } = useQuery({
+    queryKey: ["auth", "user-id"],
+    queryFn: async () => {
+      const {
+        data: { user },
+      } = await client.auth.getUser();
+      return user?.id ?? "";
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  const { data: periods = [] } = usePeriods(
+    client,
+    { userId, pageSize: 100 },
+    { enabled: userId !== "" },
+  );
+
+  // -------------------------------------------------------------------------
+  // Save flow (draft-only — publish lives on the detail page)
+  // -------------------------------------------------------------------------
+
+  const onValid = React.useCallback(
+    async (values: PeriodFormValues) => {
+      const addAnother = addAnotherRef.current;
+      addAnotherRef.current = false;
+
+      try {
+        let savedSlug: string;
+        if (isEdit && editRow) {
+          const row = await updatePeriod.mutateAsync({
+            id: editRow.id,
+            data: toUpdateData(values),
+          });
+          savedSlug = row.slug;
+        } else {
+          const row = await createPeriod.mutateAsync(toCreateInput(values));
+          savedSlug = row.slug;
+        }
+
+        addToast({
+          id: `period-saved-${Date.now()}`,
+          message: isEdit ? "Period updated." : "Period created.",
+          variant: "success",
+        });
+
+        if (addAnother && !isEdit) {
+          form.reset(seedForAddAnother(values));
+          setAutosaveAt(null);
+          setAddAnotherNote(true);
+          return;
+        }
+
+        // Reset to the saved state so isDirty clears before redirect.
+        form.reset({ ...values, slug: savedSlug });
+        router.push(`/periods/${savedSlug}`);
+      } catch {
+        // Surfaced via the form-level Alert below.
+      }
+    },
+    [isEdit, editRow, updatePeriod, createPeriod, form, addToast, router],
+  );
+
+  const submit = React.useCallback(
+    (opts?: { addAnother?: boolean }) => {
+      // Flush the slug synchronously: SlugField debounces generation, so a fast
+      // title→Save can fire before it lands and trip the schema's slug rule.
+      const { slug, title } = form.getValues();
+      if (slug.trim().length === 0 && title.trim().length > 0) {
+        try {
+          form.setValue("slug", generateSlug(title), { shouldValidate: false });
+        } catch {
+          // Non-sluggable title — let validation surface it.
+        }
+      }
+      addAnotherRef.current = opts?.addAnother ?? false;
+      setAddAnotherNote(false);
+      void form.handleSubmit(onValid)();
+    },
+    [form, onValid],
+  );
+
+  // -------------------------------------------------------------------------
+  // Auto-save (edit only): every 30s while dirty. Never publishes.
+  // -------------------------------------------------------------------------
+
+  React.useEffect(() => {
+    if (!isEdit || editRow === undefined) return;
+    const id = editRow.id;
+    const interval = window.setInterval(() => {
+      if (!form.formState.isDirty) return;
+      const values = form.getValues();
+      autosave.mutate(
+        { id, data: toUpdateData(values) },
+        { onSuccess: () => setAutosaveAt(new Date()) },
+      );
+    }, 30_000);
+    return () => window.clearInterval(interval);
+  }, [isEdit, editRow, form, autosave]);
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  const watchedTitle = useWatch({ control: form.control, name: "title" });
+  const watchedParentId = useWatch({
+    control: form.control,
+    name: "parent_period_id",
+  });
+  const watchedStart = useWatch({
+    control: form.control,
+    name: "temporal_data",
+  });
+  const watchedEnd = useWatch({
+    control: form.control,
+    name: "end_temporal_data",
+  });
+
+  const parentPeriod = React.useMemo(
+    () => periods.find((p) => p.id === watchedParentId) ?? null,
+    [periods, watchedParentId],
+  );
+
+  const rangeWarning = React.useMemo(
+    () =>
+      parentPeriod
+        ? outOfParentRangeWarning(
+            watchedStart,
+            watchedEnd,
+            (parentPeriod.temporal_data as TemporalData | null) ?? null,
+            (parentPeriod.end_temporal_data as TemporalData | null) ?? null,
+            parentPeriod.title,
+          )
+        : null,
+    [parentPeriod, watchedStart, watchedEnd],
+  );
+
+  const isSaving = createPeriod.isPending || updatePeriod.isPending;
+  const mutationError = createPeriod.error ?? updatePeriod.error;
+  const hasFieldErrors = Object.keys(form.formState.errors).length > 0;
+
+  if (isEdit && editQuery.isPending) {
+    return (
+      <div className="p-6 space-y-4">
+        <Skeleton className="h-8 w-64 rounded-md" />
+        <Skeleton className="h-4 w-96 rounded-md" />
+        <div className="mt-6 space-y-2">
+          {[1, 2, 3, 4].map((step) => (
+            <Skeleton key={step} className="h-14 w-full rounded-md" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isEdit && editQuery.isError) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
+        <p className="text-sm text-foreground-muted">
+          This period could not be found.
+        </p>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => router.push("/periods")}
+        >
+          Back to periods
+        </Button>
+      </div>
+    );
+  }
+
+  const crumbLabel = isEdit ? (editRow?.title ?? "Period") : "New period";
+
+  return (
+    <Form {...form}>
+      <form
+        className="flex h-full flex-col"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+      >
+        {/* ── Header ──────────────────────────────────────────────────── */}
+        <div className="flex items-center justify-between border-b border-border px-6 py-4 shrink-0">
+          <nav className="flex items-center gap-2 text-sm text-foreground-muted">
+            <button
+              type="button"
+              className="hover:text-foreground"
+              onClick={() => guard.requestNavigate("/periods")}
+            >
+              Periods
+            </button>
+            <span aria-hidden>▸</span>
+            <span className="text-foreground">{crumbLabel}</span>
+          </nav>
+
+          <div className="flex items-center gap-3">
+            {isEdit && (
+              <AutosaveIndicator
+                isSaving={autosave.isPending}
+                savedAt={autosaveAt}
+              />
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => guard.requestNavigate(cancelHref)}
+            >
+              Cancel
+            </Button>
+            <SaveDropdown
+              onSave={() => submit()}
+              disabled={isSaving}
+              onSaveAndAddAnother={
+                isEdit ? undefined : () => submit({ addAnother: true })
+              }
+            />
+          </div>
+        </div>
+
+        {/* ── Body ────────────────────────────────────────────────────── */}
+        <div className="flex flex-1 overflow-auto">
+          {/* Left column — identity, span, hierarchy, characteristics */}
+          <div className="flex-1 space-y-6 overflow-auto px-6 py-6">
+            {(hasFieldErrors || mutationError) && (
+              <Alert variant="destructive" role="alert">
+                <AlertTitle>
+                  {mutationError
+                    ? "Couldn’t save this period"
+                    : "Please fix the highlighted fields"}
+                </AlertTitle>
+                <AlertDescription>
+                  {mutationError instanceof Error
+                    ? mutationError.message
+                    : "Some fields need your attention before saving."}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {addAnotherNote && (
+              <Alert role="status">
+                <AlertDescription>
+                  Saved. The parent and significance carried into this new
+                  period; everything else was cleared.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g. Jurassic" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="summary"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Summary</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={3}
+                      placeholder="A brief description of the span"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="detail"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Detail</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      rows={12}
+                      placeholder="Full description, Markdown…"
+                      className="font-mono text-sm"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Span */}
+            <section className="space-y-4">
+              <h2 className={SECTION_HEADING}>Span</h2>
+              <Controller
+                control={form.control}
+                name="temporal_data"
+                render={({ field, fieldState }) => (
+                  <TemporalInput
+                    label="Start"
+                    required
+                    value={field.value}
+                    onChange={field.onChange}
+                    error={fieldState.error?.message}
+                  />
+                )}
+              />
+              <Controller
+                control={form.control}
+                name="end_temporal_data"
+                render={({ field, fieldState }) => (
+                  <TemporalInput
+                    label="End"
+                    value={field.value}
+                    onChange={field.onChange}
+                    error={fieldState.error?.message}
+                  />
+                )}
+              />
+            </section>
+
+            {/* Hierarchy */}
+            <section className="space-y-2">
+              <h2 className={SECTION_HEADING}>Hierarchy</h2>
+              <Controller
+                control={form.control}
+                name="parent_period_id"
+                render={({ field }) => (
+                  <div className="space-y-1.5">
+                    <label
+                      htmlFor="period-parent"
+                      className="text-sm font-medium text-foreground"
+                    >
+                      Parent period
+                    </label>
+                    <PeriodParentPicker
+                      id="period-parent"
+                      periods={periods}
+                      currentId={isEdit ? editRow?.id : undefined}
+                      value={field.value}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                    />
+                    {parentPeriod && parentPeriod.temporal_data && (
+                      <p className="text-xs text-foreground-muted">
+                        Range:{" "}
+                        <TemporalDisplay
+                          value={parentPeriod.temporal_data as TemporalData}
+                          endValue={
+                            (parentPeriod.end_temporal_data as TemporalData | null) ??
+                            undefined
+                          }
+                          format="compact"
+                        />
+                      </p>
+                    )}
+                    {rangeWarning && (
+                      <p className="text-xs text-amber-600 dark:text-amber-500">
+                        {rangeWarning}
+                      </p>
+                    )}
+                  </div>
+                )}
+              />
+            </section>
+
+            {/* Characteristics */}
+            <FormField
+              control={form.control}
+              name="characteristics"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Characteristics</FormLabel>
+                  <FormControl>
+                    <ChipInput
+                      value={field.value}
+                      onChange={field.onChange}
+                      placeholder="e.g. reptiles, warm climate"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* Right column — significance, publish, slug */}
+          <div className="w-80 shrink-0 space-y-6 overflow-auto border-l border-border px-6 py-6">
+            <section className="space-y-3">
+              <h2 className={SECTION_HEADING}>Significance</h2>
+              <Controller
+                control={form.control}
+                name="significance"
+                render={({ field }) => (
+                  <SignificanceControl
+                    value={field.value}
+                    onChange={field.onChange}
+                  />
+                )}
+              />
+            </section>
+
+            <section className="space-y-2">
+              <h2 className={SECTION_HEADING}>Published</h2>
+              <p className="text-sm text-foreground-muted">
+                Draft — publish from the period’s detail page once it’s ready.
+              </p>
+            </section>
+
+            <Controller
+              control={form.control}
+              name="slug"
+              render={({ field }) => (
+                <SlugField
+                  label="Slug"
+                  value={field.value}
+                  onChange={field.onChange}
+                  sourceValue={watchedTitle}
+                  mode={isEdit ? "edit" : "create"}
+                  warning={
+                    isEdit
+                      ? "Changing the slug will break existing links to this period."
+                      : undefined
+                  }
+                  description="Auto-generated from title."
+                />
+              )}
+            />
+          </div>
+        </div>
+      </form>
+
+      {/* Discard-changes confirmation */}
+      <Dialog
+        open={guard.isConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) guard.cancelNavigation();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Discard unsaved changes?</DialogTitle>
+            <DialogDescription>
+              You have unsaved changes to this period. Leaving now will lose
+              them.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={guard.cancelNavigation}>
+              Keep editing
+            </Button>
+            <Button variant="destructive" onClick={guard.confirmNavigation}>
+              Discard
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Form>
+  );
+}

--- a/apps/admin/app/(protected)/periods/_components/period-form-client.tsx
+++ b/apps/admin/app/(protected)/periods/_components/period-form-client.tsx
@@ -112,8 +112,10 @@ function SignificanceControl({
 
 /**
  * Returns a soft, non-blocking message when the child's span falls outside the
- * chosen parent's span. Returns null when either span is incomplete or the
- * child sits inside the parent (wireframe 22 edge case).
+ * chosen parent's span. Returns null when both starts are unknown or the child
+ * sits inside the parent (wireframe 22 edge case). An **open-ended** child
+ * (no end) against a parent with a finite end counts as extending past the
+ * parent — an unbounded span runs beyond any closed one.
  */
 function outOfParentRangeWarning(
   childStart: TemporalData | null,
@@ -125,9 +127,8 @@ function outOfParentRangeWarning(
   if (childStart === null || parentStart === null) return null;
   const startsBefore = compareTemporal(childStart, parentStart) < 0;
   const endsAfter =
-    childEnd !== null &&
     parentEnd !== null &&
-    compareTemporal(childEnd, parentEnd) > 0;
+    (childEnd === null || compareTemporal(childEnd, parentEnd) > 0);
   if (!startsBefore && !endsAfter) return null;
   return `This period's span extends outside ${parentTitle}. Period boundaries can overlap — this is allowed, just double-check.`;
 }

--- a/apps/admin/app/(protected)/periods/_components/period-form-mappers.test.ts
+++ b/apps/admin/app/(protected)/periods/_components/period-form-mappers.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import type { PeriodWithRelations } from "@repo/services/period-service";
+import {
+  periodFormSchema,
+  BLANK_VALUES,
+  mapRowToFormValues,
+  toCreateInput,
+  toUpdateData,
+  seedForAddAnother,
+  type PeriodFormValues,
+} from "./period-form-mappers";
+
+const start: TemporalData = { era: "MYA", year: 201, precision: "approximate" };
+const end: TemporalData = { era: "MYA", year: 145, precision: "approximate" };
+
+const validValues: PeriodFormValues = {
+  title: "Jurassic",
+  slug: "jurassic",
+  summary: "The middle period of the Mesozoic.",
+  detail: "Dinosaurs diversified.",
+  temporal_data: start,
+  end_temporal_data: end,
+  parent_period_id: "11111111-1111-4111-8111-111111111111",
+  significance: "high",
+  characteristics: ["reptiles", "warm"],
+};
+
+describe("periodFormSchema", () => {
+  it("accepts a well-formed value", () => {
+    expect(periodFormSchema.safeParse(validValues).success).toBe(true);
+  });
+
+  it("requires a title", () => {
+    const result = periodFormSchema.safeParse({ ...validValues, title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("requires a start date", () => {
+    const result = periodFormSchema.safeParse({
+      ...validValues,
+      temporal_data: null,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(["temporal_data"]);
+    }
+  });
+
+  it("rejects an end that precedes the start", () => {
+    const result = periodFormSchema.safeParse({
+      ...validValues,
+      temporal_data: end, // 145 MYA
+      end_temporal_data: start, // 201 MYA — earlier in real time, so invalid
+    });
+    // In MYA, larger year = older = earlier; compareTemporal handles the era
+    // direction. Here start(145) is later than end(201), so it must fail.
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(["end_temporal_data"]);
+    }
+  });
+
+  it("allows an open-ended span (null end)", () => {
+    const result = periodFormSchema.safeParse({
+      ...validValues,
+      end_temporal_data: null,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("mapRowToFormValues", () => {
+  it("maps a row, defaulting nullable fields", () => {
+    const row = {
+      title: "Jurassic",
+      slug: "jurassic",
+      summary: null,
+      detail: null,
+      temporal_data: start,
+      end_temporal_data: end,
+      parent_period_id: "abc",
+      significance: null,
+      characteristics: null,
+    } as unknown as PeriodWithRelations;
+
+    expect(mapRowToFormValues(row)).toEqual({
+      title: "Jurassic",
+      slug: "jurassic",
+      summary: "",
+      detail: "",
+      temporal_data: start,
+      end_temporal_data: end,
+      parent_period_id: "abc",
+      significance: "medium",
+      characteristics: [],
+    });
+  });
+});
+
+describe("toCreateInput", () => {
+  it("omits empty optional fields and the slug when blank", () => {
+    const input = toCreateInput({
+      ...BLANK_VALUES,
+      title: "Jurassic",
+      temporal_data: start,
+    });
+    expect(input).toEqual({
+      title: "Jurassic",
+      slug: undefined,
+      summary: undefined,
+      detail: undefined,
+      temporal_data: start,
+      end_temporal_data: null,
+      parent_period_id: undefined,
+      significance: "medium",
+      characteristics: undefined,
+    });
+  });
+
+  it("passes through populated fields", () => {
+    const input = toCreateInput(validValues);
+    expect(input.slug).toBe("jurassic");
+    expect(input.parent_period_id).toBe(validValues.parent_period_id);
+    expect(input.characteristics).toEqual(["reptiles", "warm"]);
+  });
+
+  it("throws when the start date is missing", () => {
+    expect(() => toCreateInput(BLANK_VALUES)).toThrow(/start date/i);
+  });
+});
+
+describe("toUpdateData", () => {
+  it("includes text fields as-is and omits a null start", () => {
+    const data = toUpdateData({ ...validValues, temporal_data: null });
+    expect(data.temporal_data).toBeUndefined();
+    expect(data.end_temporal_data).toEqual(end);
+    expect(data.summary).toBe(validValues.summary);
+  });
+
+  it("includes the start when present", () => {
+    const data = toUpdateData(validValues);
+    expect(data.temporal_data).toEqual(start);
+    expect(data.parent_period_id).toBe(validValues.parent_period_id);
+  });
+});
+
+describe("seedForAddAnother", () => {
+  it("carries significance and parent into a fresh blank form", () => {
+    const seeded = seedForAddAnother(validValues);
+    expect(seeded).toEqual({
+      ...BLANK_VALUES,
+      significance: "high",
+      parent_period_id: validValues.parent_period_id,
+    });
+  });
+});

--- a/apps/admin/app/(protected)/periods/_components/period-form-mappers.ts
+++ b/apps/admin/app/(protected)/periods/_components/period-form-mappers.ts
@@ -1,0 +1,168 @@
+import { z } from "zod";
+
+import { slugSchema } from "@repo/services/schemas/slug";
+import { significanceEnum } from "@repo/services/schemas/character";
+import {
+  temporalDataSchema,
+  compareTemporal,
+} from "@repo/services/schemas/temporal";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import type { PeriodInput } from "@repo/services/schemas/period";
+import type {
+  CreatePeriodInput,
+  PeriodWithRelations,
+} from "@repo/services/period-service";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Significance = z.infer<typeof significanceEnum>;
+
+/**
+ * The period editor's working value type. Field names mirror the persisted
+ * `periods` row (snake_case) so `zodResolver` validates a shape close to what
+ * is stored.
+ *
+ * `published` is intentionally absent — the editor is draft-only; publication
+ * runs through the dedicated publish/unpublish calls on the detail page
+ * (wireframe 16 + 22 annotation #6).
+ */
+export interface PeriodFormValues {
+  title: string;
+  slug: string;
+  summary: string;
+  detail: string;
+  /** Start of the span — required at submit, but nullable while editing. */
+  temporal_data: TemporalData | null;
+  /** End of the span — open-ended (null) is allowed. */
+  end_temporal_data: TemporalData | null;
+  parent_period_id: string | null;
+  significance: Significance;
+  characteristics: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Validation — form-only schema (mirrors periodSchema's span rule)
+// ---------------------------------------------------------------------------
+
+/**
+ * Form-only schema. The canonical `periodSchema` still runs server-side in
+ * `createPeriod`/`updatePeriod`; this validates the editor's own value shape and
+ * surfaces two rules inline before the round-trip: the start of the span is
+ * required, and the end must not precede the start.
+ */
+export const periodFormSchema = z
+  .object({
+    title: z.string().min(1, "Title is required.").max(2000),
+    slug: slugSchema,
+    summary: z.string(),
+    detail: z.string(),
+    temporal_data: temporalDataSchema.nullable(),
+    end_temporal_data: temporalDataSchema.nullable(),
+    parent_period_id: z.string().uuid().nullable(),
+    significance: significanceEnum,
+    characteristics: z.array(z.string()),
+  })
+  .superRefine((data, ctx) => {
+    if (data.temporal_data === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["temporal_data"],
+        message: "A start date is required.",
+      });
+      return;
+    }
+    if (
+      data.end_temporal_data !== null &&
+      compareTemporal(data.temporal_data, data.end_temporal_data) > 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["end_temporal_data"],
+        message: "End must be the same as or later than start.",
+      });
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Pure mappers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+export const BLANK_VALUES: PeriodFormValues = {
+  title: "",
+  slug: "",
+  summary: "",
+  detail: "",
+  temporal_data: null,
+  end_temporal_data: null,
+  parent_period_id: null,
+  significance: "medium",
+  characteristics: [],
+};
+
+export function mapRowToFormValues(row: PeriodWithRelations): PeriodFormValues {
+  return {
+    title: row.title,
+    slug: row.slug,
+    summary: row.summary ?? "",
+    detail: row.detail ?? "",
+    temporal_data: (row.temporal_data as TemporalData | null) ?? null,
+    end_temporal_data: (row.end_temporal_data as TemporalData | null) ?? null,
+    parent_period_id: row.parent_period_id,
+    significance: (row.significance as Significance | null) ?? "medium",
+    characteristics: row.characteristics ?? [],
+  };
+}
+
+export function toCreateInput(values: PeriodFormValues): CreatePeriodInput {
+  if (values.temporal_data === null) {
+    // Guarded by periodFormSchema; this keeps the type honest.
+    throw new Error("A period requires a start date.");
+  }
+  return {
+    title: values.title,
+    // The service generates + collision-resolves the slug; only pass a base
+    // when the user has typed one, otherwise omit so it derives from the title.
+    slug: values.slug || undefined,
+    summary: values.summary || undefined,
+    detail: values.detail || undefined,
+    temporal_data: values.temporal_data,
+    end_temporal_data: values.end_temporal_data,
+    parent_period_id: values.parent_period_id ?? undefined,
+    significance: values.significance,
+    characteristics:
+      values.characteristics.length > 0 ? values.characteristics : undefined,
+  };
+}
+
+export function toUpdateData(values: PeriodFormValues): Partial<PeriodInput> {
+  return {
+    title: values.title,
+    slug: values.slug,
+    // Text fields are sent as-is (including "") so clearing a field on an
+    // existing record actually persists the clear.
+    summary: values.summary,
+    detail: values.detail,
+    ...(values.temporal_data !== null
+      ? { temporal_data: values.temporal_data }
+      : {}),
+    end_temporal_data: values.end_temporal_data,
+    parent_period_id: values.parent_period_id,
+    significance: values.significance,
+    characteristics: values.characteristics,
+  };
+}
+
+/**
+ * "Save and add another" carries the significance and parent forward into the
+ * next blank form — an author entering a run of sibling sub-periods (Triassic,
+ * Jurassic, Cretaceous) keeps the shared parent + importance, retypes the rest.
+ */
+export function seedForAddAnother(values: PeriodFormValues): PeriodFormValues {
+  return {
+    ...BLANK_VALUES,
+    significance: values.significance,
+    parent_period_id: values.parent_period_id,
+  };
+}

--- a/apps/admin/app/(protected)/periods/_components/period-list-client.tsx
+++ b/apps/admin/app/(protected)/periods/_components/period-list-client.tsx
@@ -1,0 +1,554 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus } from "lucide-react";
+import type { TemporalData } from "@repo/services/schemas/temporal";
+import {
+  deletePeriod,
+  publishPeriod,
+  unpublishPeriod,
+} from "@repo/services/period-service";
+import { periodKeys, usePeriods } from "@repo/ui/hooks/use-periods";
+import { toast } from "@repo/ui/components/sonner";
+import { BulkActionBar } from "@repo/ui/components/bulk-action-bar";
+import { Button } from "@repo/ui/components/button";
+import {
+  DataTable,
+  createSelectColumn,
+  type DataTableProps,
+  type RowSelectionState,
+} from "@repo/ui/components/data-table";
+import {
+  FilterRail,
+  type FilterGroup,
+  type RadioValue,
+} from "@repo/ui/components/filter-rail";
+import { Skeleton } from "@repo/ui/components/skeleton";
+import { StatusBadge } from "@repo/ui/components/status-badge";
+import { TemporalDisplay } from "@repo/ui/components/temporal-display";
+
+import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import { SignificanceRamp, type Significance } from "./significance-ramp";
+
+// A period row as returned by getPeriods (the generated Row type).
+type PeriodRow = {
+  id: string;
+  user_id: string;
+  slug: string;
+  title: string;
+  temporal_data: TemporalData;
+  end_temporal_data: TemporalData | null;
+  parent_period_id: string | null;
+  significance: string | null;
+  characteristics: string[] | null;
+  published: boolean | null;
+  sort_order_start: number | null;
+  updated_at: string | null;
+};
+
+const SIG_ORDER: Significance[] = ["low", "medium", "high", "critical"];
+const SIG_RANK: Record<Significance, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+const SIG_LABEL: Record<Significance, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  critical: "Critical",
+};
+
+const ERAS = ["CE", "BCE", "KYA", "MYA", "BYA"] as const;
+
+const SORT_LABELS: Record<string, string> = {
+  start: "Start date",
+  title: "Title",
+  significance: "Significance",
+  updated_at: "Last updated",
+};
+
+function sigOf(row: PeriodRow): Significance {
+  return (row.significance as Significance | null) ?? "medium";
+}
+
+// ---------------------------------------------------------------------------
+// Cells
+// ---------------------------------------------------------------------------
+
+function TitleCell({
+  row,
+  parentTitle,
+}: {
+  row: PeriodRow;
+  parentTitle: string | null;
+}) {
+  const nested = row.parent_period_id !== null;
+  const characteristics = row.characteristics ?? [];
+  const shown = characteristics.slice(0, 3);
+  const extra = characteristics.length - shown.length;
+  return (
+    <div
+      className="flex min-w-0 flex-col gap-0.5"
+      style={{ paddingLeft: nested ? 16 : 0 }}
+    >
+      <span className="flex items-center gap-1.5">
+        <span className="text-foreground-muted" aria-hidden>
+          {nested ? "↳" : "⌒"}
+        </span>
+        <span
+          className="truncate font-medium text-foreground"
+          title={row.title}
+        >
+          {row.title}
+        </span>
+      </span>
+      <span className="flex flex-wrap items-center gap-1.5 pl-5 text-xs text-foreground-muted">
+        {nested && parentTitle && <span>in {parentTitle}</span>}
+        {shown.map((c) => (
+          <span key={c} className="rounded bg-surface-2 px-1.5 py-0.5">
+            {c}
+          </span>
+        ))}
+        {extra > 0 && <span>+{extra}</span>}
+      </span>
+    </div>
+  );
+}
+
+function buildColumns(
+  parentTitles: Map<string, string>,
+): DataTableProps<PeriodRow, unknown>["columns"] {
+  return [
+    createSelectColumn<PeriodRow>(),
+    {
+      id: "title",
+      header: "Title",
+      enableSorting: false,
+      cell: ({ row }: { row: { original: PeriodRow } }) => (
+        <TitleCell
+          row={row.original}
+          parentTitle={
+            row.original.parent_period_id !== null
+              ? (parentTitles.get(row.original.parent_period_id) ?? null)
+              : null
+          }
+        />
+      ),
+    },
+    {
+      id: "span",
+      header: "Span",
+      enableSorting: false,
+      cell: ({ row }: { row: { original: PeriodRow } }) => (
+        <span className="text-xs text-foreground-muted">
+          {row.original.temporal_data && (
+            <TemporalDisplay
+              value={row.original.temporal_data}
+              endValue={row.original.end_temporal_data ?? undefined}
+              format="compact"
+            />
+          )}
+        </span>
+      ),
+    },
+    {
+      id: "significance",
+      header: "Significance",
+      enableSorting: false,
+      cell: ({ row }: { row: { original: PeriodRow } }) => (
+        <div className="flex justify-end">
+          <SignificanceRamp value={sigOf(row.original)} showLabel={false} />
+        </div>
+      ),
+    },
+    {
+      accessorKey: "published",
+      header: "Status",
+      enableSorting: false,
+      cell: ({ getValue }: { getValue: () => unknown }) => (
+        <StatusBadge status={getValue() === true ? "published" : "draft"} />
+      ),
+    },
+  ];
+}
+
+function TableSkeleton() {
+  const ids = ["row-1", "row-2", "row-3", "row-4", "row-5", "row-6"];
+  return (
+    <div className="space-y-2">
+      {ids.map((id) => (
+        <Skeleton key={id} className="h-16 w-full rounded-md" />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function PeriodListClient() {
+  const router = useRouter();
+  const client = React.useMemo(() => getBrowserSupabaseClient(), []);
+  const queryClient = useQueryClient();
+
+  const { data: userId = "" } = useQuery({
+    queryKey: ["auth", "user-id"],
+    queryFn: async () => {
+      const {
+        data: { user },
+      } = await client.auth.getUser();
+      return user?.id ?? "";
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  const { data, isPending, isError, refetch } = usePeriods(
+    client,
+    { userId, pageSize: 100 },
+    { enabled: userId !== "" },
+  ) as unknown as {
+    data: PeriodRow[] | undefined;
+    isPending: boolean;
+    isError: boolean;
+    refetch: () => void;
+  };
+  const allPeriods = React.useMemo(() => data ?? [], [data]);
+
+  // Filter + sort state (local — not URL-persisted for this view).
+  const [search, setSearch] = React.useState("");
+  const [sigFilter, setSigFilter] = React.useState<string[]>([]);
+  const [eraFilter, setEraFilter] = React.useState<string[]>([]);
+  const [statusFilter, setStatusFilter] = React.useState<string[]>([]);
+  const [nesting, setNesting] = React.useState<RadioValue>("any");
+  const [sortBy, setSortBy] = React.useState("start");
+  const [sortDir, setSortDir] = React.useState<"asc" | "desc">("asc");
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+  const [bulkBusy, setBulkBusy] = React.useState(false);
+
+  const parentTitles = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of allPeriods) map.set(p.id, p.title);
+    return map;
+  }, [allPeriods]);
+
+  // Facet counts over the full set.
+  const facets = React.useMemo(() => {
+    const sig: Record<string, number> = {};
+    const era: Record<string, number> = {};
+    let published = 0;
+    let draft = 0;
+    for (const p of allPeriods) {
+      const s = sigOf(p);
+      sig[s] = (sig[s] ?? 0) + 1;
+      const e = (p.temporal_data as TemporalData | null)?.era;
+      if (e) era[e] = (era[e] ?? 0) + 1;
+      if (p.published === true) published += 1;
+      else draft += 1;
+    }
+    return { sig, era, published, draft };
+  }, [allPeriods]);
+
+  const filtered = React.useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const rows = allPeriods.filter((p) => {
+      if (q && !p.title.toLowerCase().includes(q)) return false;
+      if (sigFilter.length > 0 && !sigFilter.includes(sigOf(p))) return false;
+      if (eraFilter.length > 0) {
+        const e = (p.temporal_data as TemporalData | null)?.era;
+        if (!e || !eraFilter.includes(e)) return false;
+      }
+      if (statusFilter.length === 1) {
+        const wantPublished = statusFilter[0] === "published";
+        if ((p.published === true) !== wantPublished) return false;
+      }
+      if (nesting === "yes" && p.parent_period_id !== null) return false;
+      if (nesting === "no" && p.parent_period_id === null) return false;
+      return true;
+    });
+
+    const dir = sortDir === "asc" ? 1 : -1;
+    const compare = (a: PeriodRow, b: PeriodRow): number => {
+      if (sortBy === "title") return a.title.localeCompare(b.title);
+      if (sortBy === "significance")
+        return SIG_RANK[sigOf(a)] - SIG_RANK[sigOf(b)];
+      if (sortBy === "updated_at")
+        return (a.updated_at ?? "").localeCompare(b.updated_at ?? "");
+      return (a.sort_order_start ?? 0) - (b.sort_order_start ?? 0);
+    };
+    return [...rows].sort((a, b) => compare(a, b) * dir);
+  }, [
+    allPeriods,
+    search,
+    sigFilter,
+    eraFilter,
+    statusFilter,
+    nesting,
+    sortBy,
+    sortDir,
+  ]);
+
+  // Selection is over the filtered rows; reset when the filtered set changes id-set.
+  const selectedRows = React.useMemo(
+    () => filtered.filter((r) => rowSelection[r.id]),
+    [filtered, rowSelection],
+  );
+  const ownedSelected = React.useMemo(
+    () => selectedRows.filter((r) => r.user_id === userId),
+    [selectedRows, userId],
+  );
+  const skippedCount = selectedRows.length - ownedSelected.length;
+
+  async function runBulk(action: "publish" | "unpublish" | "delete") {
+    const ids = ownedSelected.map((r) => r.id);
+    if (ids.length === 0) return;
+    setBulkBusy(true);
+    const fn =
+      action === "publish"
+        ? publishPeriod
+        : action === "unpublish"
+          ? unpublishPeriod
+          : deletePeriod;
+    const results = await Promise.allSettled(ids.map((id) => fn(client, id)));
+    setBulkBusy(false);
+    await queryClient.invalidateQueries({ queryKey: periodKeys.all });
+    setRowSelection({});
+
+    const failed = results.filter((r) => r.status === "rejected").length;
+    const ok = ids.length - failed;
+    const verb =
+      action === "publish"
+        ? "Published"
+        : action === "unpublish"
+          ? "Unpublished"
+          : "Deleted";
+    const noun = (n: number) => `period${n !== 1 ? "s" : ""}`;
+    if (failed === 0) toast.success(`${verb} ${ok} ${noun(ok)}.`);
+    else if (ok === 0)
+      toast.error(`Couldn't ${action} ${failed} ${noun(failed)}. Try again.`);
+    else toast.warning(`${verb} ${ok} ${noun(ok)}; ${failed} failed.`);
+  }
+
+  const hasFilters =
+    search.length > 0 ||
+    sigFilter.length > 0 ||
+    eraFilter.length > 0 ||
+    statusFilter.length === 1 ||
+    nesting !== "any";
+
+  function clearAll() {
+    setSearch("");
+    setSigFilter([]);
+    setEraFilter([]);
+    setStatusFilter([]);
+    setNesting("any");
+  }
+
+  const columns = React.useMemo(
+    () => buildColumns(parentTitles),
+    [parentTitles],
+  );
+
+  const filterGroups: FilterGroup[] = [
+    {
+      type: "checkbox",
+      id: "significance",
+      label: "Significance",
+      options: SIG_ORDER.map((s) => ({
+        value: s,
+        label: SIG_LABEL[s],
+        count: facets.sig[s],
+      })),
+      value: sigFilter,
+      onChange: setSigFilter,
+    },
+    {
+      type: "radio",
+      id: "nesting",
+      label: "Show",
+      value: nesting,
+      onChange: setNesting,
+      yesLabel: "Top-level only",
+      noLabel: "Nested only",
+    },
+    {
+      type: "checkbox",
+      id: "era",
+      label: "Era",
+      options: ERAS.filter((e) => facets.era[e]).map((e) => ({
+        value: e,
+        label: e,
+        count: facets.era[e],
+      })),
+      value: eraFilter,
+      onChange: setEraFilter,
+    },
+    {
+      type: "checkbox",
+      id: "status",
+      label: "Status",
+      options: [
+        { value: "published", label: "Published", count: facets.published },
+        { value: "draft", label: "Draft", count: facets.draft },
+      ],
+      value: statusFilter,
+      onChange: setStatusFilter,
+    },
+  ];
+
+  return (
+    <div className="flex h-full">
+      <main className="flex flex-1 flex-col overflow-auto min-w-0">
+        <div className="flex items-center justify-between border-b border-border px-6 py-4 shrink-0">
+          <div>
+            <h1 className="font-display text-xl text-foreground">Periods</h1>
+            <p className="mt-0.5 text-xs text-foreground-muted">
+              {isPending
+                ? "Loading…"
+                : hasFilters
+                  ? `${filtered.length} of ${allPeriods.length} shown`
+                  : `${allPeriods.length} period${allPeriods.length !== 1 ? "s" : ""}`}
+            </p>
+          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            className="gap-1.5"
+            onClick={() => router.push("/periods/new")}
+          >
+            <Plus className="h-3.5 w-3.5" aria-hidden />
+            New period
+          </Button>
+        </div>
+
+        <div className="flex items-center gap-3 border-b border-border px-6 py-3 shrink-0">
+          <input
+            type="search"
+            placeholder="Search by title…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-foreground-muted focus:outline-none focus:ring-2 focus:ring-ring"
+            aria-label="Search periods"
+          />
+        </div>
+
+        <div className="flex-1 overflow-auto p-6">
+          {isError && (
+            <div
+              role="alert"
+              className="flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-8 text-center"
+            >
+              <p className="text-sm text-destructive">
+                Failed to load periods.
+              </p>
+              <Button variant="secondary" size="sm" onClick={() => refetch()}>
+                Retry
+              </Button>
+            </div>
+          )}
+
+          {!isError && isPending && <TableSkeleton />}
+
+          {!isError && !isPending && allPeriods.length === 0 && (
+            <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+              <p className="max-w-sm text-sm text-foreground-muted">
+                No periods yet. Periods are the named spans — eras, ages, epochs
+                — your events fall within.
+              </p>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => router.push("/periods/new")}
+              >
+                <Plus className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+                New period
+              </Button>
+            </div>
+          )}
+
+          {!isError &&
+            !isPending &&
+            allPeriods.length > 0 &&
+            filtered.length === 0 && (
+              <div className="flex flex-col items-center justify-center gap-2 py-20 text-center">
+                <p className="text-sm text-foreground-muted">
+                  No periods match these filters.
+                </p>
+                <button
+                  type="button"
+                  onClick={clearAll}
+                  className="text-xs text-primary underline underline-offset-2 hover:opacity-80"
+                >
+                  Clear filters
+                </button>
+              </div>
+            )}
+
+          {!isError && !isPending && filtered.length > 0 && (
+            <div className="space-y-3">
+              <BulkActionBar
+                count={ownedSelected.length}
+                skippedCount={skippedCount}
+                entityLabel="period"
+                busy={bulkBusy}
+                onPublish={() => void runBulk("publish")}
+                onUnpublish={() => void runBulk("unpublish")}
+                onDelete={() => void runBulk("delete")}
+                onClear={() => setRowSelection({})}
+              />
+              <DataTable
+                columns={columns}
+                data={filtered}
+                onRowClick={(row) => router.push(`/periods/${row.slug}`)}
+                getRowId={(row) => row.id}
+                rowSelection={rowSelection}
+                onRowSelectionChange={setRowSelection}
+              />
+            </div>
+          )}
+        </div>
+
+        {!isError && !isPending && filtered.length > 0 && (
+          <div className="flex items-center justify-end gap-2 border-t border-border px-6 py-3 shrink-0">
+            <label
+              htmlFor="period-sort-select"
+              className="text-xs text-foreground-muted"
+            >
+              Sort:
+            </label>
+            <select
+              id="period-sort-select"
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value)}
+              className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              {Object.entries(SORT_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
+              aria-label={
+                sortDir === "asc"
+                  ? "Sort ascending, click for descending"
+                  : "Sort descending, click for ascending"
+              }
+              className="rounded border border-border px-2 py-1 text-xs text-foreground-muted hover:text-foreground"
+            >
+              {sortDir === "asc" ? "▴" : "▾"}
+            </button>
+          </div>
+        )}
+      </main>
+
+      <FilterRail groups={filterGroups} onClearAll={clearAll} />
+    </div>
+  );
+}

--- a/apps/admin/app/(protected)/periods/_components/period-list-client.tsx
+++ b/apps/admin/app/(protected)/periods/_components/period-list-client.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import type { TemporalData } from "@repo/services/schemas/temporal";
+import type { Database } from "@repo/services/supabase/types";
 import {
   deletePeriod,
   publishPeriod,
@@ -32,21 +33,9 @@ import { TemporalDisplay } from "@repo/ui/components/temporal-display";
 import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
 import { SignificanceRamp, type Significance } from "./significance-ramp";
 
-// A period row as returned by getPeriods (the generated Row type).
-type PeriodRow = {
-  id: string;
-  user_id: string;
-  slug: string;
-  title: string;
-  temporal_data: TemporalData;
-  end_temporal_data: TemporalData | null;
-  parent_period_id: string | null;
-  significance: string | null;
-  characteristics: string[] | null;
-  published: boolean | null;
-  sort_order_start: number | null;
-  updated_at: string | null;
-};
+// The generated periods row, exactly as getPeriods returns it. Temporal columns
+// are `Json` on this type and are narrowed to TemporalData at the point of use.
+type PeriodRow = Database["public"]["Tables"]["periods"]["Row"];
 
 const SIG_ORDER: Significance[] = ["low", "medium", "high", "critical"];
 const SIG_RANK: Record<Significance, number> = {
@@ -147,8 +136,11 @@ function buildColumns(
         <span className="text-xs text-foreground-muted">
           {row.original.temporal_data && (
             <TemporalDisplay
-              value={row.original.temporal_data}
-              endValue={row.original.end_temporal_data ?? undefined}
+              value={row.original.temporal_data as TemporalData}
+              endValue={
+                (row.original.end_temporal_data as TemporalData | null) ??
+                undefined
+              }
               format="compact"
             />
           )}
@@ -211,13 +203,8 @@ export function PeriodListClient() {
     client,
     { userId, pageSize: 100 },
     { enabled: userId !== "" },
-  ) as unknown as {
-    data: PeriodRow[] | undefined;
-    isPending: boolean;
-    isError: boolean;
-    refetch: () => void;
-  };
-  const allPeriods = React.useMemo(() => data ?? [], [data]);
+  );
+  const allPeriods = React.useMemo<PeriodRow[]>(() => data ?? [], [data]);
 
   // Filter + sort state (local — not URL-persisted for this view).
   const [search, setSearch] = React.useState("");
@@ -445,7 +432,11 @@ export function PeriodListClient() {
               <p className="text-sm text-destructive">
                 Failed to load periods.
               </p>
-              <Button variant="secondary" size="sm" onClick={() => refetch()}>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => void refetch()}
+              >
                 Retry
               </Button>
             </div>

--- a/apps/admin/app/(protected)/periods/_components/period-parent-picker.tsx
+++ b/apps/admin/app/(protected)/periods/_components/period-parent-picker.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+import { Button } from "@repo/ui/components/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@repo/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@repo/ui/components/popover";
+import { cn } from "@repo/ui/lib/utils";
+
+import {
+  collectSelfAndDescendantIds,
+  orderedForPicker,
+  type PeriodLite,
+} from "./period-tree-utils";
+
+/**
+ * Searchable parent selector for the period editor. Options are the user's
+ * periods in hierarchical reading order (indented by depth), plus a
+ * "— none (top-level) —" choice.
+ *
+ * Cycle prevention (wireframe 22 #4): when editing an existing period, that
+ * period and all its descendants are excluded — a period can't be parented
+ * under itself or its own child. The service `assertNoPeriodCycle` is the
+ * backstop for any raced write. In create mode (`currentId` undefined) the full
+ * list is selectable.
+ */
+export function PeriodParentPicker({
+  id,
+  periods,
+  currentId,
+  value,
+  onChange,
+  onBlur,
+}: {
+  id?: string;
+  periods: PeriodLite[];
+  currentId?: string;
+  value: string | null;
+  onChange: (parentId: string | null) => void;
+  onBlur?: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+
+  const excluded = React.useMemo(
+    () =>
+      currentId === undefined
+        ? new Set<string>()
+        : collectSelfAndDescendantIds(periods, currentId),
+    [periods, currentId],
+  );
+
+  const options = React.useMemo(
+    () =>
+      orderedForPicker(periods).filter(({ node }) => !excluded.has(node.id)),
+    [periods, excluded],
+  );
+
+  const selectedLabel =
+    value === null
+      ? "— none (top-level) —"
+      : (options.find(({ node }) => node.id === value)?.node.title ??
+        "— none (top-level) —");
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) onBlur?.();
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="secondary"
+          role="combobox"
+          aria-expanded={open}
+          className={cn(
+            "w-full justify-between font-normal",
+            value === null && "text-foreground-muted",
+          )}
+        >
+          <span className="truncate">{selectedLabel}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput placeholder="Search periods…" />
+          <CommandList>
+            <CommandEmpty>No periods found.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="__root__"
+                onSelect={() => {
+                  onChange(null);
+                  setOpen(false);
+                }}
+              >
+                <Check
+                  className={cn(
+                    "mr-2 h-4 w-4",
+                    value === null ? "opacity-100" : "opacity-0",
+                  )}
+                />
+                — none (top-level) —
+              </CommandItem>
+              {options.map(({ node, depth }) => (
+                <CommandItem
+                  key={node.id}
+                  value={`${node.title} ${node.id}`}
+                  onSelect={() => {
+                    onChange(node.id === value ? null : node.id);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === node.id ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span
+                    className="truncate"
+                    style={{ paddingLeft: `${depth * 12}px` }}
+                  >
+                    {node.title}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/admin/app/(protected)/periods/_components/period-tree-utils.test.ts
+++ b/apps/admin/app/(protected)/periods/_components/period-tree-utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectSelfAndDescendantIds,
+  orderedForPicker,
+  type PeriodLite,
+} from "./period-tree-utils";
+
+// Mesozoic ⊃ {Triassic, Jurassic ⊃ EarlyJurassic}; plus a standalone root.
+const periods: PeriodLite[] = [
+  { id: "meso", title: "Mesozoic", parent_period_id: null },
+  { id: "tri", title: "Triassic", parent_period_id: "meso" },
+  { id: "jur", title: "Jurassic", parent_period_id: "meso" },
+  { id: "ejur", title: "Early Jurassic", parent_period_id: "jur" },
+  { id: "ind", title: "Industrial", parent_period_id: null },
+];
+
+describe("collectSelfAndDescendantIds", () => {
+  it("returns self plus all transitive descendants", () => {
+    expect(collectSelfAndDescendantIds(periods, "meso")).toEqual(
+      new Set(["meso", "tri", "jur", "ejur"]),
+    );
+  });
+
+  it("returns just self for a leaf", () => {
+    expect(collectSelfAndDescendantIds(periods, "ejur")).toEqual(
+      new Set(["ejur"]),
+    );
+  });
+
+  it("does not loop on a pre-existing cycle", () => {
+    const cyclic: PeriodLite[] = [
+      { id: "a", title: "A", parent_period_id: "b" },
+      { id: "b", title: "B", parent_period_id: "a" },
+    ];
+    expect(collectSelfAndDescendantIds(cyclic, "a")).toEqual(
+      new Set(["a", "b"]),
+    );
+  });
+});
+
+describe("orderedForPicker", () => {
+  it("orders depth-first with nesting depth annotations", () => {
+    const ordered = orderedForPicker(periods).map((o) => [o.node.id, o.depth]);
+    expect(ordered).toEqual([
+      ["meso", 0],
+      ["tri", 1],
+      ["jur", 1],
+      ["ejur", 2],
+      ["ind", 0],
+    ]);
+  });
+
+  it("treats a node whose parent is absent as a root", () => {
+    const orphan: PeriodLite[] = [
+      { id: "x", title: "X", parent_period_id: "missing" },
+    ];
+    expect(orderedForPicker(orphan)).toEqual([{ node: orphan[0], depth: 0 }]);
+  });
+
+  it("appends nodes trapped in a cycle rather than dropping them", () => {
+    const cyclic: PeriodLite[] = [
+      { id: "a", title: "A", parent_period_id: "b" },
+      { id: "b", title: "B", parent_period_id: "a" },
+    ];
+    const ids = orderedForPicker(cyclic).map((o) => o.node.id);
+    expect(ids.sort()).toEqual(["a", "b"]);
+  });
+});

--- a/apps/admin/app/(protected)/periods/_components/period-tree-utils.ts
+++ b/apps/admin/app/(protected)/periods/_components/period-tree-utils.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure helpers over a flat list of periods (each carrying `parent_period_id`).
+ * Periods are stored flat, not as a nested tree, so these reconstruct the
+ * hierarchy the parent picker and breadcrumbs need — kept pure for unit testing.
+ */
+
+export interface PeriodLite {
+  id: string;
+  title: string;
+  parent_period_id: string | null;
+}
+
+/**
+ * The id set that a period may **not** be parented under: itself plus every
+ * descendant. Used by the parent picker to prevent cycles client-side
+ * (the service `assertNoPeriodCycle` is the backstop for any raced write).
+ */
+export function collectSelfAndDescendantIds<T extends PeriodLite>(
+  periods: T[],
+  rootId: string,
+): Set<string> {
+  const childrenByParent = new Map<string, string[]>();
+  for (const p of periods) {
+    if (p.parent_period_id !== null) {
+      const list = childrenByParent.get(p.parent_period_id) ?? [];
+      list.push(p.id);
+      childrenByParent.set(p.parent_period_id, list);
+    }
+  }
+
+  const excluded = new Set<string>();
+  const stack = [rootId];
+  while (stack.length > 0) {
+    const id = stack.pop() as string;
+    if (excluded.has(id)) continue; // guard against a pre-existing cycle
+    excluded.add(id);
+    for (const childId of childrenByParent.get(id) ?? []) {
+      stack.push(childId);
+    }
+  }
+  return excluded;
+}
+
+export interface OrderedPeriod<T> {
+  node: T;
+  depth: number;
+}
+
+/**
+ * Depth-first ordering of the flat period list into hierarchical reading order,
+ * annotating each with its nesting depth (for indentation in the picker). Roots
+ * (null parent, or a parent not present in the list) are ordered first, each
+ * followed by its subtree. Ordering within a level preserves input order.
+ */
+export function orderedForPicker<T extends PeriodLite>(
+  periods: T[],
+): OrderedPeriod<T>[] {
+  const byId = new Map(periods.map((p) => [p.id, p]));
+  const childrenByParent = new Map<string, T[]>();
+  const roots: T[] = [];
+  for (const p of periods) {
+    const parent = p.parent_period_id;
+    if (parent !== null && byId.has(parent)) {
+      const list = childrenByParent.get(parent) ?? [];
+      list.push(p);
+      childrenByParent.set(parent, list);
+    } else {
+      roots.push(p);
+    }
+  }
+
+  const out: OrderedPeriod<T>[] = [];
+  const visited = new Set<string>();
+  const walk = (node: T, depth: number): void => {
+    if (visited.has(node.id)) return; // guard against a pre-existing cycle
+    visited.add(node.id);
+    out.push({ node, depth });
+    for (const child of childrenByParent.get(node.id) ?? []) {
+      walk(child, depth + 1);
+    }
+  };
+  for (const root of roots) walk(root, 0);
+  // Any nodes left unvisited (part of a stored cycle) are appended flat so the
+  // picker never silently drops an option.
+  for (const p of periods) {
+    if (!visited.has(p.id)) out.push({ node: p, depth: 0 });
+  }
+  return out;
+}

--- a/apps/admin/app/(protected)/periods/_components/significance-ramp.tsx
+++ b/apps/admin/app/(protected)/periods/_components/significance-ramp.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+export type Significance = "low" | "medium" | "high" | "critical";
+
+const LEVELS: Significance[] = ["low", "medium", "high", "critical"];
+
+const RANK: Record<Significance, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+// Single-hue amber importance ramp reused for significance (03-aesthetic-notes
+// § Significance scale). The active level tints all filled steps.
+const BAR_COLOR: Record<Significance, string> = {
+  low: "bg-importance-low",
+  high: "bg-importance-high",
+  medium: "bg-importance-medium",
+  critical: "bg-importance-critical",
+};
+
+const LABEL: Record<Significance, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  critical: "Critical",
+};
+
+/**
+ * A four-step sequential bar + label for a period's `significance`. Deliberately
+ * the same visual language as event importance (sequential, single-hue amber).
+ */
+export function SignificanceRamp({
+  value,
+  showLabel = true,
+  className,
+}: {
+  value: Significance;
+  showLabel?: boolean;
+  className?: string;
+}) {
+  const rank = RANK[value];
+  return (
+    <span
+      className={cn("inline-flex items-center gap-2", className)}
+      title={`${LABEL[value]} significance`}
+    >
+      <span className="inline-flex items-end gap-0.5" aria-hidden>
+        {LEVELS.map((level) => {
+          const filled = RANK[level] <= rank;
+          return (
+            <span
+              key={level}
+              className={cn(
+                "w-1 rounded-sm",
+                filled ? BAR_COLOR[value] : "bg-border",
+              )}
+              style={{ height: `${4 + RANK[level] * 2}px` }}
+            />
+          );
+        })}
+      </span>
+      {showLabel && (
+        <span className="text-xs text-foreground-muted">{LABEL[value]}</span>
+      )}
+      <span className="sr-only">{LABEL[value]} significance</span>
+    </span>
+  );
+}

--- a/apps/admin/app/(protected)/periods/_components/use-unsaved-changes-guard.ts
+++ b/apps/admin/app/(protected)/periods/_components/use-unsaved-changes-guard.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Guards a dirty form against accidental navigation loss.
+ *
+ * Two surfaces are covered:
+ *  - **Hard navigation** (reload / tab close / external link): a `beforeunload`
+ *    listener triggers the browser's native confirmation while `isDirty`.
+ *  - **In-app navigation** the form controls (Cancel button, breadcrumbs):
+ *    call `requestNavigate(href)` instead of `router.push`. When dirty it
+ *    defers the push and exposes `isConfirmOpen` so the caller can render a
+ *    confirm dialog; on confirm it completes the navigation.
+ *
+ * (Route-local copy of the character/timeline/story editor guard — kept
+ * per-route rather than promoted to a shared hook to avoid a cross-route
+ * import.)
+ */
+export function useUnsavedChangesGuard(isDirty: boolean) {
+  const router = useRouter();
+  const [pendingHref, setPendingHref] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!isDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // Required for Chrome to show the native prompt.
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+
+  const requestNavigate = React.useCallback(
+    (href: string) => {
+      if (isDirty) {
+        setPendingHref(href);
+      } else {
+        router.push(href);
+      }
+    },
+    [isDirty, router],
+  );
+
+  const confirmNavigation = React.useCallback(() => {
+    setPendingHref((href) => {
+      if (href !== null) router.push(href);
+      return null;
+    });
+  }, [router]);
+
+  const cancelNavigation = React.useCallback(() => setPendingHref(null), []);
+
+  return {
+    requestNavigate,
+    isConfirmOpen: pendingHref !== null,
+    confirmNavigation,
+    cancelNavigation,
+  };
+}

--- a/apps/admin/app/(protected)/periods/new/page.tsx
+++ b/apps/admin/app/(protected)/periods/new/page.tsx
@@ -1,0 +1,9 @@
+import { PeriodFormClient } from "../_components/period-form-client";
+
+export const metadata = {
+  title: "New period",
+};
+
+export default function NewPeriodPage() {
+  return <PeriodFormClient mode="create" />;
+}

--- a/apps/admin/app/(protected)/periods/page.tsx
+++ b/apps/admin/app/(protected)/periods/page.tsx
@@ -1,11 +1,9 @@
-import { PlaceholderPage } from "../../../components/placeholder-page";
+import { PeriodListClient } from "./_components/period-list-client";
+
+export const metadata = {
+  title: "Periods",
+};
 
 export default function PeriodsPage() {
-  return (
-    <PlaceholderPage
-      title="Periods"
-      description="Named temporal spans — eras, ages, dynasties, geological epochs."
-      trackedIn="Batch F (list primitives)"
-    />
-  );
+  return <PeriodListClient />;
 }

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -25,6 +25,8 @@ export default defineConfig({
         "app/**/event-form-mappers.ts",
         "app/**/story-form-mappers.ts",
         "app/**/timeline-form-mappers.ts",
+        "app/**/period-form-mappers.ts",
+        "app/**/period-tree-utils.ts",
       ],
       exclude: ["app/**/*.test.{ts,tsx}"],
       thresholds: {

--- a/packages/services/src/modules/period-service.test.ts
+++ b/packages/services/src/modules/period-service.test.ts
@@ -12,6 +12,9 @@ import {
   getChildPeriods,
   addPeriodToTimeline,
   removePeriodFromTimeline,
+  getPeriodTimelines,
+  publishPeriod,
+  unpublishPeriod,
   assertNoPeriodCycle,
   getEventsInPeriod,
 } from "./period-service";
@@ -217,13 +220,19 @@ describe("getPeriodById", () => {
       id: "period-2",
       parent_period_id: "period-1",
     };
-    // Query 1: the period (via .single()); query 2: getChildPeriods (thenable).
+    // Query 1: the period (.single()); query 2: getChildPeriods (thenable);
+    // query 3: getPeriodTimelines (thenable).
     const { client } = makeSequenceClient([
       { data: samplePeriod, error: null },
       { data: [child], error: null },
+      { data: [{ timeline_id: "timeline-1" }], error: null },
     ]);
     const result = await getPeriodById(client, "period-1");
-    expect(result).toEqual({ ...samplePeriod, child_periods: [child] });
+    expect(result).toEqual({
+      ...samplePeriod,
+      child_periods: [child],
+      period_timelines: [{ timeline_id: "timeline-1" }],
+    });
   });
 
   it("throws on error", async () => {
@@ -245,9 +254,14 @@ describe("getPeriodBySlug", () => {
     const { client, builders } = makeSequenceClient([
       { data: samplePeriod, error: null },
       { data: [], error: null },
+      { data: [], error: null },
     ]);
     const result = await getPeriodBySlug(client, "user-123", "middle-ages");
-    expect(result).toEqual({ ...samplePeriod, child_periods: [] });
+    expect(result).toEqual({
+      ...samplePeriod,
+      child_periods: [],
+      period_timelines: [],
+    });
     expect(builders[0]?.eq).toHaveBeenCalledWith("user_id", "user-123");
     expect(builders[0]?.eq).toHaveBeenCalledWith("slug", "middle-ages");
   });
@@ -819,6 +833,92 @@ describe("getEventsInPeriod", () => {
     ]);
     await expect(getEventsInPeriod(client, "period-1")).rejects.toThrow(
       "PeriodService.getEventsInPeriod(period): not found",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPeriodTimelines
+// ---------------------------------------------------------------------------
+
+describe("getPeriodTimelines", () => {
+  it("returns the junction rows for a period", async () => {
+    const rows = [{ timeline_id: "timeline-1" }, { timeline_id: "timeline-2" }];
+    const client = makeClient({ fromResult: { data: rows, error: null } });
+    const result = await getPeriodTimelines(client, "period-1");
+    expect(result).toEqual(rows);
+    expect(client.from).toHaveBeenCalledWith("period_timelines");
+  });
+
+  it("returns an empty array when there are no overlays", async () => {
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    const result = await getPeriodTimelines(client, "period-1");
+    expect(result).toEqual([]);
+  });
+
+  it("throws on error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "boom" } },
+    });
+    await expect(getPeriodTimelines(client, "period-1")).rejects.toThrow(
+      "PeriodService.getPeriodTimelines: boom",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// publishPeriod / unpublishPeriod
+// ---------------------------------------------------------------------------
+
+describe("publishPeriod", () => {
+  it("sets published=true and stamps published_at", async () => {
+    const published = { ...samplePeriod, published: true };
+    const client = makeClient({ fromResult: { data: published, error: null } });
+    const result = await publishPeriod(client, "period-1");
+    expect(result).toEqual(published);
+
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as { update: ReturnType<typeof vi.fn> };
+    expect(builder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ published: true }),
+    );
+    const arg = builder.update.mock.calls[0]?.[0] as {
+      published_at: string | null;
+    };
+    expect(typeof arg.published_at).toBe("string");
+  });
+
+  it("throws on error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "denied" } },
+    });
+    await expect(publishPeriod(client, "period-1")).rejects.toThrow(
+      "PeriodService.publishPeriod: denied",
+    );
+  });
+});
+
+describe("unpublishPeriod", () => {
+  it("sets published=false and clears published_at", async () => {
+    const draft = { ...samplePeriod, published: false };
+    const client = makeClient({ fromResult: { data: draft, error: null } });
+    const result = await unpublishPeriod(client, "period-1");
+    expect(result).toEqual(draft);
+
+    const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
+      ?.value as { update: ReturnType<typeof vi.fn> };
+    expect(builder.update).toHaveBeenCalledWith({
+      published: false,
+      published_at: null,
+    });
+  });
+
+  it("throws on error", async () => {
+    const client = makeClient({
+      fromResult: { data: null, error: { message: "denied" } },
+    });
+    await expect(unpublishPeriod(client, "period-1")).rejects.toThrow(
+      "PeriodService.unpublishPeriod: denied",
     );
   });
 });

--- a/packages/services/src/modules/period-service.test.ts
+++ b/packages/services/src/modules/period-service.test.ts
@@ -23,7 +23,11 @@ import {
 // Mock builder helpers
 // ---------------------------------------------------------------------------
 
-function makeBuilder(result: { data: unknown; error: unknown }) {
+function makeBuilder(result: {
+  data: unknown;
+  error: unknown;
+  count?: number;
+}) {
   const terminal = vi.fn().mockResolvedValue(result);
   const builder = {
     select: vi.fn().mockReturnThis(),
@@ -50,7 +54,9 @@ function makeBuilder(result: { data: unknown; error: unknown }) {
 // Successive `from()` calls return successive builders — used to script the
 // multi-step ancestor walk in `assertNoPeriodCycle` and the multi-query
 // `getEventsInPeriod` scoped path.
-function makeSequenceClient(results: { data: unknown; error: unknown }[]) {
+function makeSequenceClient(
+  results: { data: unknown; error: unknown; count?: number }[],
+) {
   const builders = results.map(makeBuilder);
   let callCount = 0;
   const client = {
@@ -747,13 +753,37 @@ describe("getEventsInPeriod", () => {
         },
         error: null,
       },
-      { data: [sampleEvent], error: null },
+      { data: [sampleEvent], error: null, count: 1 },
     ]);
     const result = await getEventsInPeriod(client, "period-1");
-    expect(result).toEqual([sampleEvent]);
+    expect(result).toEqual({ rows: [sampleEvent], total: 1 });
     const eventsBuilder = builders[1];
     expect(eventsBuilder?.gte).toHaveBeenCalledWith("sort_order_years", 100);
     expect(eventsBuilder?.lte).toHaveBeenCalledWith("sort_order_years", 200);
+    // Default first page: range(0, 24) and an exact count for the total.
+    expect(eventsBuilder?.select).toHaveBeenCalledWith("*", { count: "exact" });
+    expect(eventsBuilder?.range).toHaveBeenCalledWith(0, 24);
+  });
+
+  it("applies page/pageSize as a server-side range (unscoped)", async () => {
+    const { client, builders } = makeSequenceClient([
+      {
+        data: {
+          sort_order_start: 100,
+          sort_order_end: 200,
+          end_temporal_data: { era: "CE", year: 200 },
+        },
+        error: null,
+      },
+      { data: [sampleEvent], error: null, count: 42 },
+    ]);
+    const result = await getEventsInPeriod(client, "period-1", {
+      page: 3,
+      pageSize: 10,
+    });
+    expect(result.total).toBe(42);
+    // page 3, size 10 → rows 20..29.
+    expect(builders[1]?.range).toHaveBeenCalledWith(20, 29);
   });
 
   it("collapses an open-ended period to its start instant", async () => {
@@ -803,7 +833,8 @@ describe("getEventsInPeriod", () => {
       timelineScoped: true,
     });
     // De-duplicated and sorted by sort_order_years ascending.
-    expect(result.map((e) => e.id)).toEqual(["event-guest", "event-home"]);
+    expect(result.rows.map((e) => e.id)).toEqual(["event-guest", "event-home"]);
+    expect(result.total).toBe(2);
     expect(builders[1]?.eq).toHaveBeenCalledWith("period_id", "period-1");
     expect(builders[2]?.in).toHaveBeenCalledWith("timeline_id", ["tl-1"]);
   });
@@ -823,7 +854,7 @@ describe("getEventsInPeriod", () => {
     const result = await getEventsInPeriod(client, "period-1", {
       timelineScoped: true,
     });
-    expect(result).toEqual([]);
+    expect(result).toEqual({ rows: [], total: 0 });
     expect(client.from).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/services/src/modules/period-service.ts
+++ b/packages/services/src/modules/period-service.ts
@@ -22,6 +22,12 @@ export interface PeriodFilters {
 
 export interface PeriodWithRelations extends PeriodRow {
   child_periods?: PeriodRow[];
+  /**
+   * The `period_timelines` junction rows for this period — the timelines it
+   * overlays. Timeline titles/spans are resolved separately by the UI (via the
+   * timelines list) rather than embedded, mirroring the story ⇄ period pattern.
+   */
+  period_timelines?: { timeline_id: string }[];
 }
 
 export type CreatePeriodInput = Omit<z.input<typeof periodSchema>, "slug"> & {
@@ -104,7 +110,8 @@ export async function getPeriodById(
     .single();
   assertNoError(error, "getPeriodById");
   const child_periods = await getChildPeriods(client, data.id);
-  return { ...data, child_periods };
+  const period_timelines = await getPeriodTimelines(client, data.id);
+  return { ...data, child_periods, period_timelines };
 }
 
 /**
@@ -129,7 +136,8 @@ export async function getPeriodBySlug(
     .single();
   assertNoError(error, "getPeriodBySlug");
   const child_periods = await getChildPeriods(client, data.id);
-  return { ...data, child_periods };
+  const period_timelines = await getPeriodTimelines(client, data.id);
+  return { ...data, child_periods, period_timelines };
 }
 
 /**
@@ -339,6 +347,52 @@ export async function deletePeriod(
 }
 
 /**
+ * Publish a period: set `published=true` and stamp `published_at`.
+ *
+ * Publish is a dedicated call (not part of {@link updatePeriod}) because the
+ * `periods` Zod schema intentionally omits `published`/`published_at`, so an
+ * update would strip them. Mirrors `story-service.publishStory`.
+ *
+ * @param client - Supabase client instance
+ * @param id - Period UUID
+ * @returns The updated period row
+ */
+export async function publishPeriod(
+  client: SupabaseClient<Database>,
+  id: string,
+): Promise<PeriodRow> {
+  const { data, error } = await client
+    .from("periods")
+    .update({ published: true, published_at: new Date().toISOString() })
+    .eq("id", id)
+    .select()
+    .single();
+  assertNoError(error, "publishPeriod");
+  return data;
+}
+
+/**
+ * Revert a period to draft: set `published=false` and clear `published_at`.
+ *
+ * @param client - Supabase client instance
+ * @param id - Period UUID
+ * @returns The updated period row
+ */
+export async function unpublishPeriod(
+  client: SupabaseClient<Database>,
+  id: string,
+): Promise<PeriodRow> {
+  const { data, error } = await client
+    .from("periods")
+    .update({ published: false, published_at: null })
+    .eq("id", id)
+    .select()
+    .single();
+  assertNoError(error, "unpublishPeriod");
+  return data;
+}
+
+/**
  * Return all direct child periods of a given parent period.
  *
  * @param client - Supabase client instance
@@ -405,6 +459,28 @@ export async function removePeriodFromTimeline(
     .eq("period_id", periodId)
     .eq("timeline_id", timelineId);
   assertNoError(error, "removePeriodFromTimeline");
+}
+
+/**
+ * Return the `period_timelines` junction rows for a period — i.e. the ids of
+ * the timelines it overlays. Timeline titles/spans are resolved by the caller
+ * against the timelines list (the junction carries no timeline detail), keeping
+ * this a single, cheap key lookup.
+ *
+ * @param client - Supabase client instance
+ * @param periodId - Period UUID
+ * @returns Array of `{ timeline_id }` rows
+ */
+export async function getPeriodTimelines(
+  client: SupabaseClient<Database>,
+  periodId: string,
+): Promise<{ timeline_id: string }[]> {
+  const { data, error } = await client
+    .from("period_timelines")
+    .select("timeline_id")
+    .eq("period_id", periodId);
+  assertNoError(error, "getPeriodTimelines");
+  return data ?? [];
 }
 
 export interface EventsInPeriodOptions {

--- a/packages/services/src/modules/period-service.ts
+++ b/packages/services/src/modules/period-service.ts
@@ -109,8 +109,12 @@ export async function getPeriodById(
     .eq("id", id)
     .single();
   assertNoError(error, "getPeriodById");
-  const child_periods = await getChildPeriods(client, data.id);
-  const period_timelines = await getPeriodTimelines(client, data.id);
+  // The children + overlays reads are independent — fetch them in parallel
+  // rather than waterfalling, to cut latency on the detail/editor critical path.
+  const [child_periods, period_timelines] = await Promise.all([
+    getChildPeriods(client, data.id),
+    getPeriodTimelines(client, data.id),
+  ]);
   return { ...data, child_periods, period_timelines };
 }
 
@@ -135,8 +139,11 @@ export async function getPeriodBySlug(
     .eq("slug", slug)
     .single();
   assertNoError(error, "getPeriodBySlug");
-  const child_periods = await getChildPeriods(client, data.id);
-  const period_timelines = await getPeriodTimelines(client, data.id);
+  // Independent follow-up reads — run them in parallel (see getPeriodById).
+  const [child_periods, period_timelines] = await Promise.all([
+    getChildPeriods(client, data.id),
+    getPeriodTimelines(client, data.id),
+  ]);
   return { ...data, child_periods, period_timelines };
 }
 
@@ -492,6 +499,16 @@ export interface EventsInPeriodOptions {
    * regardless of timeline.
    */
   timelineScoped?: boolean;
+  /** 1-based page number. Defaults to 1; clamped to ≥ 1. */
+  page?: number;
+  /** Page size. Defaults to 25; clamped to [1, 200]. */
+  pageSize?: number;
+}
+
+/** A page of events-in-range plus the total count of matches. */
+export interface EventsInPeriodPage {
+  rows: EventRow[];
+  total: number;
 }
 
 /**
@@ -508,18 +525,32 @@ export interface EventsInPeriodOptions {
  * DB-generated from the era formula (docs/system-design.md §4).
  *
  * With `timelineScoped: true`, results are further limited to the timelines the
- * period overlays; a period that overlays no timeline yields an empty list.
+ * period overlays; a period that overlays no timeline yields an empty page.
+ *
+ * Paginated: a wide (e.g. BYA-spanning) period can match many events, so the
+ * result is a single page plus the total count. The unscoped path paginates in
+ * the database (`.range()` + exact count); the scoped path must build the
+ * home+guest union first, then slices that union server-side (its `total` is the
+ * full union size).
  *
  * @param client - Supabase client instance
  * @param periodId - Period UUID
  * @param options - See {@link EventsInPeriodOptions}
- * @returns Matching event rows, ordered by `sort_order_years` ascending
+ * @returns A page of matching event rows (ordered by `sort_order_years`) + total
  */
 export async function getEventsInPeriod(
   client: SupabaseClient<Database>,
   periodId: string,
   options: EventsInPeriodOptions = {},
-): Promise<EventRow[]> {
+): Promise<EventsInPeriodPage> {
+  const safePage = Math.max(1, Math.floor(options.page ?? 1));
+  const safePageSize = Math.min(
+    200,
+    Math.max(1, Math.floor(options.pageSize ?? 25)),
+  );
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+
   const { data: period, error: periodError } = await client
     .from("periods")
     .select("sort_order_start, sort_order_end, end_temporal_data")
@@ -535,14 +566,15 @@ export async function getEventsInPeriod(
     typeof endEra === "string" ? (period.sort_order_end ?? start) : start;
 
   if (options.timelineScoped !== true) {
-    const { data, error } = await client
+    const { data, error, count } = await client
       .from("events")
-      .select("*")
+      .select("*", { count: "exact" })
       .gte("sort_order_years", start)
       .lte("sort_order_years", end)
-      .order("sort_order_years", { ascending: true });
+      .order("sort_order_years", { ascending: true })
+      .range(from, to);
     assertNoError(error, "getEventsInPeriod");
-    return data ?? [];
+    return { rows: data ?? [], total: count ?? 0 };
   }
 
   // Scoped: the union of events on any timeline this period overlays, as home
@@ -555,7 +587,7 @@ export async function getEventsInPeriod(
 
   const timelineIds = (overlays ?? []).map((r) => r.timeline_id);
   if (timelineIds.length === 0) {
-    return [];
+    return { rows: [], total: 0 };
   }
 
   const { data: homeEvents, error: homeError } = await client
@@ -591,7 +623,11 @@ export async function getEventsInPeriod(
   for (const ev of [...(homeEvents ?? []), ...guestEvents]) {
     byId.set(ev.id, ev);
   }
-  return [...byId.values()].sort(
+  const merged = [...byId.values()].sort(
     (a, b) => (a.sort_order_years ?? 0) - (b.sort_order_years ?? 0),
   );
+  return {
+    rows: merged.slice(from, from + safePageSize),
+    total: merged.length,
+  };
 }

--- a/packages/ui/src/hooks/use-periods.test.tsx
+++ b/packages/ui/src/hooks/use-periods.test.tsx
@@ -13,6 +13,9 @@ import {
   useEventsInPeriod,
   useAddPeriodToTimeline,
   useRemovePeriodFromTimeline,
+  usePeriodTimelines,
+  usePublishPeriod,
+  useUnpublishPeriod,
   periodKeys,
 } from "./use-periods";
 
@@ -27,6 +30,9 @@ vi.mock("@repo/services/period-service", () => ({
   getEventsInPeriod: vi.fn(),
   addPeriodToTimeline: vi.fn(),
   removePeriodFromTimeline: vi.fn(),
+  getPeriodTimelines: vi.fn(),
+  publishPeriod: vi.fn(),
+  unpublishPeriod: vi.fn(),
 }));
 
 import {
@@ -40,6 +46,9 @@ import {
   getEventsInPeriod,
   addPeriodToTimeline,
   removePeriodFromTimeline,
+  getPeriodTimelines,
+  publishPeriod,
+  unpublishPeriod,
 } from "@repo/services/period-service";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -245,6 +254,10 @@ describe("useUpdatePeriod", () => {
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: periodKeys.lists() }),
     );
+    // The detail page reads via bySlug, so the slug namespace must refresh too.
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: periodKeys.slugs() }),
+    );
   });
 });
 
@@ -315,6 +328,62 @@ describe("useRemovePeriodFromTimeline", () => {
     );
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: periodKeys.detail("period-1") }),
+    );
+  });
+});
+
+describe("usePeriodTimelines", () => {
+  it("fetches the period's overlaid-timeline junction rows", async () => {
+    vi.mocked(getPeriodTimelines).mockResolvedValue([
+      { timeline_id: "tl-1" },
+    ] as never);
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => usePeriodTimelines(mockClient, "period-1"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ timeline_id: "tl-1" }]);
+    expect(getPeriodTimelines).toHaveBeenCalledWith(mockClient, "period-1");
+  });
+});
+
+describe("usePublishPeriod", () => {
+  it("calls publishPeriod and invalidates all period queries", async () => {
+    vi.mocked(publishPeriod).mockResolvedValue(mockPeriod as never);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => usePublishPeriod(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate("period-1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(publishPeriod).toHaveBeenCalledWith(mockClient, "period-1");
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: periodKeys.all }),
+    );
+  });
+});
+
+describe("useUnpublishPeriod", () => {
+  it("calls unpublishPeriod and invalidates all period queries", async () => {
+    vi.mocked(unpublishPeriod).mockResolvedValue(mockPeriod as never);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnpublishPeriod(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate("period-1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(unpublishPeriod).toHaveBeenCalledWith(mockClient, "period-1");
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: periodKeys.all }),
     );
   });
 });

--- a/packages/ui/src/hooks/use-periods.test.tsx
+++ b/packages/ui/src/hooks/use-periods.test.tsx
@@ -131,13 +131,15 @@ describe("useChildPeriods", () => {
 
 describe("useEventsInPeriod", () => {
   const mockEvents = [{ id: "event-1", title: "Fall of Rome" }];
+  // getEventsInPeriod returns a page ({ rows, total }), not a bare array.
+  const mockPage = { rows: mockEvents, total: mockEvents.length };
 
   beforeEach(() => {
     vi.mocked(getEventsInPeriod).mockClear();
   });
 
   it("calls getEventsInPeriod with client, periodId and default options", async () => {
-    vi.mocked(getEventsInPeriod).mockResolvedValue(mockEvents as never);
+    vi.mocked(getEventsInPeriod).mockResolvedValue(mockPage as never);
     const { wrapper } = createWrapper();
     const { result } = renderHook(
       () => useEventsInPeriod(mockClient, "period-1"),
@@ -146,11 +148,11 @@ describe("useEventsInPeriod", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(getEventsInPeriod).toHaveBeenCalledWith(mockClient, "period-1", {});
-    expect(result.current.data).toEqual(mockEvents);
+    expect(result.current.data).toEqual(mockPage);
   });
 
   it("forwards the timelineScoped option to the service", async () => {
-    vi.mocked(getEventsInPeriod).mockResolvedValue(mockEvents as never);
+    vi.mocked(getEventsInPeriod).mockResolvedValue(mockPage as never);
     const { wrapper } = createWrapper();
     const { result } = renderHook(
       () => useEventsInPeriod(mockClient, "period-1", { timelineScoped: true }),
@@ -164,7 +166,7 @@ describe("useEventsInPeriod", () => {
   });
 
   it("refetches when the parent period detail is invalidated", async () => {
-    vi.mocked(getEventsInPeriod).mockResolvedValue(mockEvents as never);
+    vi.mocked(getEventsInPeriod).mockResolvedValue(mockPage as never);
     const { wrapper, queryClient } = createWrapper();
     const { result } = renderHook(
       () => useEventsInPeriod(mockClient, "period-1"),

--- a/packages/ui/src/hooks/use-periods.tsx
+++ b/packages/ui/src/hooks/use-periods.tsx
@@ -19,7 +19,10 @@ import {
   getChildPeriods,
   addPeriodToTimeline,
   removePeriodFromTimeline,
+  getPeriodTimelines,
   getEventsInPeriod,
+  publishPeriod,
+  unpublishPeriod,
 } from "@repo/services/period-service";
 import type {
   PeriodFilters,
@@ -41,9 +44,11 @@ export const periodKeys = {
   list: (filters: PeriodFilters) => [...periodKeys.lists(), filters] as const,
   details: () => [...periodKeys.all, "detail"] as const,
   detail: (id: string) => [...periodKeys.details(), id] as const,
+  slugs: () => [...periodKeys.all, "slug"] as const,
   bySlug: (userId: string, slug: string) =>
-    [...periodKeys.all, "slug", userId, slug] as const,
+    [...periodKeys.slugs(), userId, slug] as const,
   children: (id: string) => [...periodKeys.all, "children", id] as const,
+  timelines: (id: string) => [...periodKeys.detail(id), "timelines"] as const,
   events: (id: string, options: EventsInPeriodOptions = {}) =>
     [...periodKeys.detail(id), "events", options] as const,
 };
@@ -139,6 +144,23 @@ export function useEventsInPeriod(
   });
 }
 
+/** Fetch the `period_timelines` junction rows (overlaid timeline ids) for a period. */
+export function usePeriodTimelines(
+  client: ServiceClient,
+  periodId: string,
+  options?: Omit<
+    UseQueryOptions<Awaited<ReturnType<typeof getPeriodTimelines>>>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery({
+    queryKey: periodKeys.timelines(periodId),
+    queryFn: () => getPeriodTimelines(client, periodId),
+    staleTime: 30_000,
+    ...options,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Mutation hooks
 // ---------------------------------------------------------------------------
@@ -173,6 +195,10 @@ export function useUpdatePeriod(client: ServiceClient) {
     onSuccess: (_data, { id }) => {
       void queryClient.invalidateQueries({ queryKey: periodKeys.detail(id) });
       void queryClient.invalidateQueries({ queryKey: periodKeys.lists() });
+      // The detail page reads via bySlug (not detail(id)); invalidate the whole
+      // slug namespace so an edit is reflected immediately after the redirect,
+      // rather than showing a stale row until staleTime elapses.
+      void queryClient.invalidateQueries({ queryKey: periodKeys.slugs() });
     },
   });
 }
@@ -185,6 +211,30 @@ export function useDeletePeriod(client: ServiceClient) {
     onSuccess: (_data, id) => {
       queryClient.removeQueries({ queryKey: periodKeys.detail(id) });
       void queryClient.invalidateQueries({ queryKey: periodKeys.lists() });
+    },
+  });
+}
+
+/** Publish a period (set published=true and record published_at). */
+export function usePublishPeriod(client: ServiceClient) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => publishPeriod(client, id),
+    onSuccess: () => {
+      // Invalidate by prefix so lists, detail, and bySlug queries stay
+      // consistent with the RLS visibility change.
+      void queryClient.invalidateQueries({ queryKey: periodKeys.all });
+    },
+  });
+}
+
+/** Unpublish a period (set published=false and clear published_at). */
+export function useUnpublishPeriod(client: ServiceClient) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => unpublishPeriod(client, id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: periodKeys.all });
     },
   });
 }


### PR DESCRIPTION
Closes #64.

Builds the Period management surface in `apps/admin` on the **span-overlay model**: periods are labeled temporal spans that nest hierarchically, overlay timelines, and gather events **by date** (no `period_events` junction).

## What's included

### Routes (`app/(protected)/periods/`)
- **List** — chronological (default `sort_order_start`) with `⌒`/`↳` nesting indicators + "in [Parent]", `TemporalDisplay` spans (open-ended aware), significance ramp, `StatusBadge`. Filters: significance / era / nesting (top-level vs nested) / status, with live facet counts; sort by start·title·significance·updated; bulk publish·unpublish·delete; empty / filtered-empty / loading / error states.
- **Editor** (`new`, `[slug]/edit`) — `TemporalInput` start (required) / end, four-way significance control, characteristics chips, **cycle-excluded parent picker** (self + descendants), soft out-of-parent-range warning, autosave + unsaved-changes guard, save → redirect to detail.
- **Detail** (`[slug]`) — breadcrumb + hierarchy panel (parent/children navigation), owner-only publish, **Overlaid timelines** tab (add/remove) and lazy **Events in range** tab (computed, read-only, scope toggle, paginated), Danger zone with cascade blast-radius confirm.

### Service / hook layer (net-new, consumed by the UI)
- `publishPeriod` / `unpublishPeriod` (+ hooks) — the Zod schema omits `published`, so publish can't route through `updatePeriod`.
- `getPeriodTimelines` (+ `usePeriodTimelines`); `period_timelines` embedded in `getPeriodById` / `getPeriodBySlug`.
- `useUpdatePeriod` now also invalidates the `bySlug` namespace so an edit is reflected immediately on the detail page.

### Design decisions
- **Client-side list** (single fetch, local filter/sort/facet) — fits the modest period counts the wireframe anticipates; no new query surface.
- **Honor cascade** on delete (schema is `ON DELETE CASCADE`); a reparent-to-grandparent policy remains an app-layer follow-up.

## Testing
- Unit: `period-form-mappers`, `period-tree-utils`, and all new service fns + hooks covered (admin ≥ 80%; `use-periods.tsx` 100%).
- Full gate green: `format` · `check-types` · `lint` (0 warnings) · `test:coverage` · `build`.
- **Manual smoke test** (Playwright, against seeded local stack): login, list, filters, detail + tabs, events-in-range, edit render (fixes the reported `useFormField` crash), parent picker, edit-save round-trip, new-period render — **12/12 checks, no console/page errors**.

## Follow-ups
- #349 — the shared `useUpdateStory` has the same stale-detail (`bySlug`) pattern fixed here for periods.
- Not exercised in smoke: from-scratch `TemporalInput` create flow and publish/bulk round-trips (single seed period).

🤖 Generated with [Claude Code](https://claude.com/claude-code)