### PR TITLE
feat(ui): token-driven CharacterTypeBadge primitive — #284

### DIFF
--- a/packages/ui/src/components/character-type-badge.stories.tsx
+++ b/packages/ui/src/components/character-type-badge.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { characterTypeEnum } from "@repo/services/schemas/character";
+import { CharacterTypeBadge } from "./character-type-badge";
+
+const meta = {
+  title: "Components/CharacterTypeBadge",
+  component: CharacterTypeBadge,
+  parameters: { layout: "centered" },
+  argTypes: {
+    type: {
+      control: "select",
+      options: characterTypeEnum.options,
+    },
+  },
+} satisfies Meta<typeof CharacterTypeBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Human: Story = { args: { type: "human" } };
+export const Animal: Story = { args: { type: "animal" } };
+export const Mythological: Story = { args: { type: "mythological" } };
+export const Fictional: Story = { args: { type: "fictional" } };
+export const Organization: Story = { args: { type: "organization" } };
+export const Divine: Story = { args: { type: "divine" } };
+export const Artifact: Story = { args: { type: "artifact" } };
+
+/**
+ * All seven type badges together — the Storybook pass that finalizes the icon
+ * choices against the era palette (icon set is locked; this confirms each reads
+ * distinctly at badge size).
+ */
+export const AllTypes: Story = {
+  args: { type: "human" }, // required by the story type; the render ignores it
+  render: () => (
+    <div className="flex flex-wrap gap-3">
+      {characterTypeEnum.options.map((type) => (
+        <CharacterTypeBadge key={type} type={type} />
+      ))}
+    </div>
+  ),
+};
+
+// ─── Batch J accessibility gate ───────────────────────────────────────────────
+// The dense-row story below is where the type tints are verified co-occurring
+// with the era accents and the importance gradient (they share a table row in
+// the character/event lists). Two checks are eyeballed here:
+//   1. red-green colorblind: era hues + the 7 type tints + importance stay
+//      distinguishable together;
+//   2. meaning survives with hue removed — the icon + literal label carry it,
+//      so the badge is never icon-/color-alone.
+
+// Each row pairs a type with a different era code + importance bracket to force
+// maximum hue co-occurrence in a single dense scan.
+const DENSE_ROWS = [
+  { type: "human", era: "CE", year: "1961", importance: 9 },
+  { type: "animal", era: "KYA", year: "12", importance: 4 },
+  { type: "mythological", era: "BCE", year: "800", importance: 6 },
+  { type: "fictional", era: "CE", year: "1851", importance: 2 },
+  { type: "organization", era: "CE", year: "1969", importance: 8 },
+  { type: "divine", era: "BCE", year: "1200", importance: 7 },
+  { type: "artifact", era: "MYA", year: "3.3", importance: 5 },
+] as const;
+
+const ERA_CLASS: Record<string, string> = {
+  CE: "text-era-ce",
+  BCE: "text-era-bce",
+  KYA: "text-era-kya",
+  MYA: "text-era-mya",
+  BYA: "text-era-bya",
+};
+
+function importanceCssVar(importance: number): string {
+  if (importance <= 3) return "var(--color-importance-low)";
+  if (importance <= 6) return "var(--color-importance-medium)";
+  if (importance <= 8) return "var(--color-importance-high)";
+  return "var(--color-importance-critical)";
+}
+
+export const DenseRow: Story = {
+  args: { type: "human" }, // required by the story type; the render ignores it
+  render: () => (
+    <table className="w-[28rem] border-separate border-spacing-y-1 text-sm">
+      <tbody>
+        {DENSE_ROWS.map(({ type, era, year, importance }) => (
+          <tr key={type} className="bg-surface-2">
+            <td className="px-3 py-2">
+              <CharacterTypeBadge type={type} />
+            </td>
+            <td className="px-3 py-2 font-mono tabular-nums">
+              <span className={ERA_CLASS[era]}>
+                {year} {era}
+              </span>
+            </td>
+            <td className="px-3 py-2">
+              <span className="inline-flex items-center gap-1.5">
+                <span
+                  aria-hidden
+                  className="inline-block h-2 w-2 rounded-full"
+                  style={{ backgroundColor: importanceCssVar(importance) }}
+                />
+                <span className="text-foreground-muted">
+                  Importance {importance}
+                </span>
+              </span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+};

--- a/packages/ui/src/components/character-type-badge.test.tsx
+++ b/packages/ui/src/components/character-type-badge.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { characterTypeEnum } from "@repo/services/schemas/character";
+
+import { CharacterTypeBadge } from "./character-type-badge";
+
+const EXPECTED_LABEL: Record<
+  (typeof characterTypeEnum.options)[number],
+  string
+> = {
+  human: "Human",
+  animal: "Animal",
+  mythological: "Mythological",
+  fictional: "Fictional",
+  organization: "Organization",
+  divine: "Divine",
+  artifact: "Artifact",
+};
+
+describe("CharacterTypeBadge", () => {
+  it.each(characterTypeEnum.options)(
+    "renders the icon, token tint, and literal label for %s",
+    (type) => {
+      render(<CharacterTypeBadge type={type} data-testid="badge" />);
+
+      const badge = screen.getByTestId("badge");
+      expect(badge).toHaveTextContent(EXPECTED_LABEL[type]);
+      expect(badge.className).toContain(`text-type-${type}`);
+      expect(badge.querySelector("svg")).not.toBeNull();
+    },
+  );
+
+  it("carries meaning in the label, not the icon (icon is aria-hidden)", () => {
+    render(<CharacterTypeBadge type="human" data-testid="badge" />);
+
+    const badge = screen.getByTestId("badge");
+    // The literal label is the text the badge exposes — never icon-alone.
+    expect(badge.textContent).toBe("Human");
+
+    const icon = badge.querySelector("svg");
+    expect(icon).not.toBeNull();
+    expect(icon).toHaveAttribute("aria-hidden");
+  });
+
+  it("uses a custom label when provided", () => {
+    render(
+      <CharacterTypeBadge
+        type="human"
+        label="Protagonist"
+        data-testid="badge"
+      />,
+    );
+
+    const badge = screen.getByTestId("badge");
+    expect(badge).toHaveTextContent("Protagonist");
+    expect(badge).not.toHaveTextContent("Human");
+  });
+});

--- a/packages/ui/src/components/character-type-badge.tsx
+++ b/packages/ui/src/components/character-type-badge.tsx
@@ -3,9 +3,9 @@
 // identity without a cross-route import.
 //
 // Token-driven `cva` primitive (#284): each of the 7 `character_type` values
-// gets a low-chroma `--color-type-*` tint (source of truth in styles/tokens.css)
-// + a lucide icon + an always-visible literal label. The icon/color mapping
-// matches docs/design/admin/03-aesthetic-notes.md § Character-type identity.
+// gets a low-chroma `--color-type-*` tint (source of truth in styles/tokens.ts,
+// mirrored in styles/tokens.css) + a lucide icon + an always-visible literal label.
+// The icon/color mapping matches docs/design/admin/03-aesthetic-notes.md § Character-type identity.
 import * as React from "react";
 import {
   User,

--- a/packages/ui/src/components/character-type-badge.tsx
+++ b/packages/ui/src/components/character-type-badge.tsx
@@ -2,10 +2,10 @@
 // to @repo/ui in #62 so the stories pages can render the perspective-character
 // identity without a cross-route import.
 //
-// This still uses inline low-chroma Tailwind classes (not `cva` + the
-// `--color-type-*` tokens) — building the fully token-driven primitive remains
-// #284's job. The icon/color mapping matches
-// docs/design/admin/03-aesthetic-notes.md § Character-type identity.
+// Token-driven `cva` primitive (#284): each of the 7 `character_type` values
+// gets a low-chroma `--color-type-*` tint (source of truth in styles/tokens.css)
+// + a lucide icon + an always-visible literal label. The icon/color mapping
+// matches docs/design/admin/03-aesthetic-notes.md § Character-type identity.
 import * as React from "react";
 import {
   User,
@@ -16,10 +16,35 @@ import {
   Sparkles,
   Gem,
 } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@repo/ui/lib/utils";
 import { characterTypeEnum } from "@repo/services/schemas/character";
 
 export type CharacterType = (typeof characterTypeEnum.options)[number];
+
+const characterTypeBadgeVariants = cva(
+  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+  {
+    variants: {
+      type: {
+        human:
+          "bg-type-human/10 text-type-human ring-1 ring-inset ring-type-human/20",
+        animal:
+          "bg-type-animal/10 text-type-animal ring-1 ring-inset ring-type-animal/20",
+        mythological:
+          "bg-type-mythological/10 text-type-mythological ring-1 ring-inset ring-type-mythological/20",
+        fictional:
+          "bg-type-fictional/10 text-type-fictional ring-1 ring-inset ring-type-fictional/20",
+        organization:
+          "bg-type-organization/10 text-type-organization ring-1 ring-inset ring-type-organization/20",
+        divine:
+          "bg-type-divine/10 text-type-divine ring-1 ring-inset ring-type-divine/20",
+        artifact:
+          "bg-type-artifact/10 text-type-artifact ring-1 ring-inset ring-type-artifact/20",
+      },
+    },
+  },
+);
 
 /** Exported for reuse as the type-icon placeholder in list name-cell hover
  * thumbnails (no media → show the type icon instead). */
@@ -46,24 +71,10 @@ const TYPE_LABEL: Record<CharacterType, string> = {
   artifact: "Artifact",
 };
 
-const TYPE_CLASS: Record<CharacterType, string> = {
-  human: "bg-slate-500/10 text-slate-400 ring-1 ring-inset ring-slate-500/20",
-  animal:
-    "bg-emerald-500/10 text-emerald-400 ring-1 ring-inset ring-emerald-500/20",
-  mythological:
-    "bg-orange-500/10 text-orange-400 ring-1 ring-inset ring-orange-500/20",
-  fictional:
-    "bg-violet-500/10 text-violet-400 ring-1 ring-inset ring-violet-500/20",
-  organization: "bg-sky-500/10 text-sky-400 ring-1 ring-inset ring-sky-500/20",
-  divine: "bg-amber-500/10 text-amber-400 ring-1 ring-inset ring-amber-500/20",
-  artifact:
-    "bg-yellow-700/10 text-yellow-600 ring-1 ring-inset ring-yellow-700/20",
-};
-
-export interface CharacterTypeBadgeProps extends Omit<
-  React.HTMLAttributes<HTMLSpanElement>,
-  "children"
-> {
+export interface CharacterTypeBadgeProps
+  extends
+    Omit<React.HTMLAttributes<HTMLSpanElement>, "children">,
+    VariantProps<typeof characterTypeBadgeVariants> {
   /** The character_type value this badge represents (required). */
   type: CharacterType;
   /** Optional label override; defaults to the canonical name for the type. */
@@ -84,11 +95,7 @@ export const CharacterTypeBadge = React.forwardRef<
   return (
     <span
       ref={ref}
-      className={cn(
-        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
-        TYPE_CLASS[type],
-        className,
-      )}
+      className={cn(characterTypeBadgeVariants({ type, className }))}
       {...props}
     >
       <Icon className="h-3 w-3" aria-hidden />
@@ -97,3 +104,5 @@ export const CharacterTypeBadge = React.forwardRef<
   );
 });
 CharacterTypeBadge.displayName = "CharacterTypeBadge";
+
+export { characterTypeBadgeVariants };

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -53,6 +53,16 @@
   --color-importance-high: oklch(0.74 0.14 55); /* 7–8 */
   --color-importance-critical: oklch(0.81 0.18 55); /* 9–10 */
 
+  /* Character-type identity tints — CharacterTypeBadge (Batch J). Low-chroma;
+     icon + label carry meaning, hue is a reinforcement layer (colorblind-safe). */
+  --color-type-human: oklch(0.72 0.04 250); /* slate */
+  --color-type-animal: oklch(0.74 0.06 150); /* muted green */
+  --color-type-mythological: oklch(0.76 0.07 30); /* terracotta */
+  --color-type-fictional: oklch(0.74 0.06 300); /* muted violet */
+  --color-type-organization: oklch(0.72 0.03 230); /* steel */
+  --color-type-divine: oklch(0.80 0.08 90); /* gold */
+  --color-type-artifact: oklch(0.70 0.04 60); /* bronze */
+
   /* ------------------------------------------------------------------ */
   /* shadcn vocabulary aliases                                          */
   /* The shadcn primitive registry uses a fixed semantic vocabulary     */

--- a/packages/ui/src/styles/tokens.ts
+++ b/packages/ui/src/styles/tokens.ts
@@ -60,6 +60,17 @@ export const colors = {
   importanceMedium: "oklch(0.65 0.09 55)", // 4–6 — mid amber
   importanceHigh: "oklch(0.74 0.14 55)", // 7–8 — bright amber
   importanceCritical: "oklch(0.81 0.18 55)", // 9–10 — saturated gold
+
+  // Character-type identity tints — CharacterTypeBadge (Batch J). Low-chroma so
+  // the 7 categorical tints don't fight the era accents / importance gradient in
+  // a dense row. Icon + label carry the signal; hue is reinforcement only.
+  typeHuman: "oklch(0.72 0.04 250)", // slate
+  typeAnimal: "oklch(0.74 0.06 150)", // muted green
+  typeMythological: "oklch(0.76 0.07 30)", // terracotta
+  typeFictional: "oklch(0.74 0.06 300)", // muted violet
+  typeOrganization: "oklch(0.72 0.03 230)", // steel
+  typeDivine: "oklch(0.80 0.08 90)", // gold
+  typeArtifact: "oklch(0.70 0.04 60)", // bronze
 } as const;
 
 export const fonts = {


### PR DESCRIPTION
Closes #284.

Finishes the shared `CharacterTypeBadge` "Batch J" visual-language primitive in `@repo/ui`. The component already existed as a scaffold (promoted from #55 in #62) using inline Tailwind palette classes; its header comment named #284 as the job to finish. This refactors it to a **`cva` + design-token** implementation mirroring `StatusBadge`, and adds stories + a test.

## Changes
- **Seven `--color-type-*` tokens** — hand-synced with byte-identical OKLCH values in `tokens.ts` (camelCase) and `tokens.css` (`@theme`, kebab-case). Tailwind 4 generates `bg-type-*` / `text-type-*` / `ring-type-*` from the `@theme` block.
- **`character-type-badge.tsx`** — rebuilt on `characterTypeBadgeVariants` (`cva`, exported), keyed by the 7 `character_type` values (each `bg-type-x/10 text-type-x ring-1 ring-inset ring-type-x/20`). Keeps `forwardRef`, `displayName`, the `characterTypeEnum`-sourced union (no redeclared literals), and the `CHARACTER_TYPE_ICON` export. Icon is `aria-hidden`; the literal label carries the accessible name (never icon-/color-alone).
- **Stories** — one per type, an `AllTypes` row, and a `DenseRow` story that co-occurs the type tints with era accents + the importance gradient (the **Batch J colorblind gate**).
- **Test** — icon/tint/label per type, aria-hidden + label-carries-meaning, and label override (9 cases).

## Verification
- `check-types`, `lint` (zero warnings), `test` (478 pass, 9 new), full `build`, and `test:coverage` (pre-push) all green.
- Storybook compiles all 9 stories with no errors.
- **Batch J gate (needs a human eyeball):** the red-green colorblind check on the `DenseRow` story (era hues + 7 type tints + importance together) is an inherently visual design judgment — reviewer should glance at Components/CharacterTypeBadge/DenseRow in Storybook.

## Non-goals (per issue)
- Light-mode token values (deferred with the rest of light mode).
- Filter-rail checkbox rendering (#55 owns that).
- Any character route work / consumer edits — exports stay backward-compatible plus the new `characterTypeBadgeVariants`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)