### PR TITLE
test(admin): events CRUD spine e2e + fix updateEvent null-guard bug it caught

### DIFF
--- a/apps/admin/e2e/authenticated/event-crud.spec.ts
+++ b/apps/admin/e2e/authenticated/event-crud.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Event CRUD spine — drives create → view → edit → delete through the UI
+ * (no seeding). Self-cleaning: the event it creates is removed in the final
+ * step. Mirrors the timeline CRUD spine; the only event-specific bits are the
+ * route/placeholder ("Event title") and the "Delete event?" dialog.
+ *
+ * Runs under the `authenticated` project (starts signed in).
+ */
+test.describe("event CRUD spine", () => {
+  test("create, view, edit, then delete an event", async ({ page }) => {
+    const stamp = Date.now();
+    const title = `E2E CRUD Event ${stamp}`;
+    const editedTitle = `${title} (edited)`;
+
+    // ── Create ──────────────────────────────────────────────────────────
+    // Type defaults to "milestone"; a primary timeline is optional.
+    await page.goto("/events/new");
+    await page.getByPlaceholder("Event title").fill(title);
+    // The Start span is a popover: open it, fill the year (era defaults to CE),
+    // Apply. "Year" is matched exactly so it doesn't hit "Uncertainty (± years)".
+    await page.getByRole("button", { name: "Add date" }).first().click();
+    await page.getByLabel("Year", { exact: true }).fill("1969");
+    await page.getByRole("button", { name: "Apply" }).click();
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+
+    // ── View ────────────────────────────────────────────────────────────
+    await expect(
+      page.getByRole("heading", { level: 1, name: title }),
+    ).toBeVisible();
+    const slug = new URL(page.url()).pathname.split("/").pop() ?? "";
+    expect(slug).not.toBe("new");
+
+    // ── Edit ────────────────────────────────────────────────────────────
+    await page.goto(`/events/${slug}/edit`);
+    const titleField = page.getByPlaceholder("Event title");
+    await expect(titleField).toHaveValue(title);
+    await titleField.fill(editedTitle);
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: editedTitle }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/events/${slug}$`));
+
+    // ── Delete ──────────────────────────────────────────────────────────
+    await page.getByRole("button", { name: "Danger zone" }).click();
+    await page.getByRole("button", { name: "Delete event" }).click();
+    const dialog = page.getByRole("dialog", { name: "Delete event?" });
+    await dialog.getByRole("button", { name: "Delete", exact: true }).click();
+
+    // Deleting redirects to the list; the event is gone.
+    await page.waitForURL("**/events");
+    await expect(page.getByText(editedTitle)).toHaveCount(0);
+  });
+});

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -859,6 +859,23 @@ describe("updateEvent", () => {
     ).rejects.toThrow("detail_timeline_id cannot equal timeline_id");
   });
 
+  it("allows an update when timeline_id and detail_timeline_id are both null (regression: no false self-cycle)", async () => {
+    // The form mapper sends a timeline-less event as { timeline_id: null,
+    // detail_timeline_id: null }. The cycle guard must treat that as "no
+    // relationship", not `null === null` — otherwise no timeline-less event
+    // could ever be edited.
+    const updated = { ...sampleEvent, title: "Untethered Event" };
+    const client = makeClient({ fromResult: { data: updated, error: null } });
+
+    const result = await updateEvent(client, "event-1", {
+      title: "Untethered Event",
+      timeline_id: null,
+      detail_timeline_id: null,
+    });
+
+    expect(result).toEqual(updated);
+  });
+
   it("rejects when detail_timeline_id transitively reaches the new timeline_id", async () => {
     const newHomeTimeline = "22222222-2222-4222-8222-222222222222";
     const detailTimeline = "11111111-1111-4111-8111-111111111111";

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -488,9 +488,12 @@ export async function updateEvent(
 ): Promise<EventRow> {
   const validated = eventSchema.partial().parse(data);
 
+  // `!= null` (not `!== undefined`) so a timeline-less event — which the form
+  // mapper sends as `timeline_id: null, detail_timeline_id: null` — is not
+  // mistaken for a self-cycle (`null === null`). Mirrors createEvent's guard.
   if (
-    validated.detail_timeline_id !== undefined &&
-    validated.timeline_id !== undefined &&
+    validated.detail_timeline_id != null &&
+    validated.timeline_id != null &&
     validated.detail_timeline_id === validated.timeline_id
   ) {
     throw new Error(


### PR DESCRIPTION
## Summary

Adds the **events CRUD spine** e2e spec (tracking #355) — and, in the process, it **caught a real bug**, which this PR also fixes.

Same shape as the timeline spine (#356): drives **create → view → edit → delete** through the UI, self-cleaning (deletes the event it creates).

## The bug it caught 🐛

Editing an event that has **no primary/sub timeline** failed with `updateEvent: detail_timeline_id cannot equal timeline_id (fractal cycle)`.

Root cause: `updateEvent`'s cycle guard used `!== undefined` where `createEvent` uses `!= null`. The event form mapper sends a timeline-less event as `{ timeline_id: null, detail_timeline_id: null }`, so the guard evaluated `null === null` and misfired — meaning **no timeline-less event could be edited at all**.

**Fix**: `updateEvent` guard `!== undefined` → `!= null` (mirrors `createEvent`), plus a service-level **regression unit test** (both-ids-null update succeeds) so the **CI gate** guards it — the e2e that caught it is off the gate per [ADR-0036](docs/adr/adr-0036-e2e-testing-strategy.md).

## Changes

- `packages/services/src/modules/event-service.ts` — the one-line guard fix (+ explanatory comment).
- `packages/services/src/modules/event-service.test.ts` — regression test (99 → passes; was 98).
- `apps/admin/e2e/authenticated/event-crud.spec.ts` — the events CRUD spine spec.

## Verification

- `pnpm test:e2e` → **11 passed** (event-crud ~4.8s) · `@repo/services` units **99 passed** · `lint` ✓ · `check-types` ✓ · `format` ✓.
- Confirmed the regression test fails before the guard fix and passes after.

Advances #355 (events item under "Remaining CRUD spines"). This is exactly the value the suite was meant to deliver — an on-demand safety net over already-shipped code that surfaces real defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)