### PR TITLE
test(admin): characters CRUD spine e2e + fix stale-detail cache bug it caught

### DIFF
--- a/apps/admin/e2e/authenticated/character-crud.spec.ts
+++ b/apps/admin/e2e/authenticated/character-crud.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Character CRUD spine — drives create → view → edit → delete through the UI
+ * (no seeding). Self-cleaning: the character it creates is removed in the
+ * final step. Simpler than the timeline/event spines — character_type
+ * defaults and the temporal (birth/death) spans are optional, so a name is
+ * all that's required to create.
+ *
+ * Runs under the `authenticated` project (starts signed in).
+ */
+test.describe("character CRUD spine", () => {
+  test("create, view, edit, then delete a character", async ({ page }) => {
+    const stamp = Date.now();
+    const name = `E2E CRUD Character ${stamp}`;
+    const editedName = `${name} (edited)`;
+
+    // ── Create ──────────────────────────────────────────────────────────
+    // Type defaults to the first option; birth/death spans are optional.
+    await page.goto("/characters/new");
+    await page.getByPlaceholder("Character name").fill(name);
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+
+    // ── View ────────────────────────────────────────────────────────────
+    // The <h1> only renders on the detail page, so seeing it also confirms
+    // the create → redirect landed.
+    await expect(page.getByRole("heading", { level: 1, name })).toBeVisible();
+    const slug = new URL(page.url()).pathname.split("/").pop() ?? "";
+    expect(slug).not.toBe("new");
+
+    // ── Edit ────────────────────────────────────────────────────────────
+    await page.goto(`/characters/${slug}/edit`);
+    const nameField = page.getByPlaceholder("Character name");
+    await expect(nameField).toHaveValue(name);
+    await nameField.fill(editedName);
+    // Guard against a late form.reset() racing the fill before we submit.
+    await expect(nameField).toHaveValue(editedName);
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: editedName }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/characters/${slug}$`));
+
+    // ── Delete ──────────────────────────────────────────────────────────
+    await page.getByRole("button", { name: "Danger zone" }).click();
+    await page.getByRole("button", { name: "Delete character" }).click();
+    const dialog = page.getByRole("dialog", { name: "Delete character?" });
+    await dialog.getByRole("button", { name: "Delete", exact: true }).click();
+
+    // Deleting redirects to the list; the character is gone.
+    await page.waitForURL("**/characters");
+    await expect(page.getByText(editedName)).toHaveCount(0);
+  });
+});

--- a/packages/ui/src/hooks/use-characters.test.tsx
+++ b/packages/ui/src/hooks/use-characters.test.tsx
@@ -274,7 +274,7 @@ describe("useCreateCharacter", () => {
 // ---------------------------------------------------------------------------
 
 describe("useUpdateCharacter", () => {
-  it("calls updateCharacter and invalidates detail + list caches on success", async () => {
+  it("invalidates by prefix on success so the detail page's bySlug query refreshes", async () => {
     const updated = { ...mockCharacter, slug: "strider" };
     vi.mocked(updateCharacter).mockResolvedValue(updated as never);
     vi.mocked(getCharacters).mockResolvedValue(mockCharacters as never);
@@ -295,11 +295,11 @@ describe("useUpdateCharacter", () => {
     expect(updateCharacter).toHaveBeenCalledWith(mockClient, "char-1", {
       slug: "strider",
     });
+    // Regression: invalidating only detail(id)+lists() left the detail page
+    // (which reads characterKeys.bySlug) stale after an edit. Prefix
+    // invalidation covers bySlug too.
     expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: characterKeys.detail("char-1") }),
-    );
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: characterKeys.lists() }),
+      expect.objectContaining({ queryKey: characterKeys.all }),
     );
   });
 

--- a/packages/ui/src/hooks/use-characters.tsx
+++ b/packages/ui/src/hooks/use-characters.tsx
@@ -252,11 +252,12 @@ export function useUpdateCharacter(client: ServiceClient) {
         queryClient.setQueryData(characterKeys.detail(id), context.previous);
       }
     },
-    onSuccess: (_data, { id }) => {
-      void queryClient.invalidateQueries({
-        queryKey: characterKeys.detail(id),
-      });
-      void queryClient.invalidateQueries({ queryKey: characterKeys.lists() });
+    onSuccess: () => {
+      // Invalidate by prefix so bySlug (used by the detail page) and other
+      // derived queries stay consistent — mirrors usePublish/useDelete.
+      // Invalidating only detail(id)+lists() left the detail page stale after
+      // a rename, since the detail page reads characterKeys.bySlug.
+      void queryClient.invalidateQueries({ queryKey: characterKeys.all });
     },
   });
 }


### PR DESCRIPTION
## Summary

Adds the **characters CRUD spine** e2e spec (tracking #355) — and, like the events spine, it **caught a real bug**, which this PR also fixes. That's now two shipped bugs surfaced by the CRUD spines.

Same shape as the timeline/event spines (create → view → edit → delete, self-cleaning). Characters are the simplest — `character_type` defaults and birth/death spans are optional, so a name is all that's required to create.

## The bug it caught 🐛

After **editing a character**, the detail page kept showing the **old data** (name unchanged) until a hard refresh.

Root cause: `useUpdateCharacter`'s `onSuccess` invalidated `characterKeys.detail(id)` + `lists()` — but **not** `characterKeys.bySlug`, which is the key the detail page actually reads (`useCharacterBySlug`). The sibling hooks (`usePublish` / `useUnpublish` / `useDelete`) already invalidate **by prefix** "so bySlug ... stays consistent"; the update hook just missed it.

**Fix**: `onSuccess` now invalidates `characterKeys.all` (prefix — covers `bySlug`), mirroring the siblings. The hook's existing unit test is updated to assert the prefix invalidation, so the **CI gate** guards it (the e2e that caught it is off the gate per [ADR-0036](docs/adr/adr-0036-e2e-testing-strategy.md)).

## Changes

- `packages/ui/src/hooks/use-characters.tsx` — `useUpdateCharacter` prefix invalidation (+ comment).
- `packages/ui/src/hooks/use-characters.test.tsx` — regression test asserts `characterKeys.all` invalidation.
- `apps/admin/e2e/authenticated/character-crud.spec.ts` — the characters CRUD spine spec.

## Verification

- `pnpm test:e2e` → **12 passed** · `@repo/ui` `use-characters` units **27 passed** · `lint` ✓ · `check-types` ✓ · `format` ✓.
- Confirmed the e2e fails before the fix (stale name) and passes after.

Advances #355. Three CRUD spines in, two real bugs found — the shared form-driving patterns are now proven enough to extract into helpers (proposed as the next follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)