### PR TITLE
test(admin): periods CRUD spine e2e

### DIFF
--- a/apps/admin/e2e/authenticated/period-crud.spec.ts
+++ b/apps/admin/e2e/authenticated/period-crud.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import {
+  deleteViaDangerZone,
+  expectDetailAndReadSlug,
+  saveForm,
+  setStartDate,
+} from "../support/crud-helpers";
+
+/**
+ * Period CRUD spine — drives create → view → edit → delete through the UI
+ * (no seeding). Self-cleaning: the period it creates is removed in the final
+ * step. Like timelines, the Start span is required. The delete dialog titles
+ * with the record (`Delete "<title>"?`) rather than the entity noun.
+ *
+ * Runs under the `authenticated` project (starts signed in).
+ */
+test.describe("period CRUD spine", () => {
+  test("create, view, edit, then delete a period", async ({ page }) => {
+    const stamp = Date.now();
+    const title = `E2E CRUD Period ${stamp}`;
+    const editedTitle = `${title} (edited)`;
+
+    // ── Create ──────────────────────────────────────────────────────────
+    await page.goto("/periods/new");
+    await page.getByPlaceholder("e.g. Jurassic").fill(title);
+    await setStartDate(page, 2000);
+    await saveForm(page);
+
+    // ── View ────────────────────────────────────────────────────────────
+    const slug = await expectDetailAndReadSlug(page, title);
+
+    // ── Edit ────────────────────────────────────────────────────────────
+    await page.goto(`/periods/${slug}/edit`);
+    const titleField = page.getByPlaceholder("e.g. Jurassic");
+    await expect(titleField).toHaveValue(title);
+    await titleField.fill(editedTitle);
+    await saveForm(page);
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: editedTitle }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/periods/${slug}$`));
+
+    // ── Delete ──────────────────────────────────────────────────────────
+    // The confirmation dialog titles with the record: Delete "<title>"?
+    await deleteViaDangerZone(page, "period", { dialogName: /^Delete .+\?$/ });
+    await page.waitForURL("**/periods");
+    await expect(page.getByText(editedTitle)).toHaveCount(0);
+  });
+});

--- a/apps/admin/e2e/support/crud-helpers.ts
+++ b/apps/admin/e2e/support/crud-helpers.ts
@@ -51,16 +51,21 @@ export async function expectDetailAndReadSlug(
 
 /**
  * Delete the current entity from its detail page: expand the owner-only
- * "Danger zone", trigger "Delete <entity>", and confirm the "Delete
- * <entity>?" dialog. `entity` is the lowercase noun as it appears in the UI
- * ("timeline", "event", "character").
+ * "Danger zone", trigger "Delete <entity>", and confirm the dialog. `entity`
+ * is the lowercase noun as it appears in the UI ("timeline", "event",
+ * "character"). Most confirmation dialogs are titled "Delete <entity>?"; pass
+ * `dialogName` to override for the ones that title with the record instead
+ * (periods use `Delete "<title>"?`).
  */
 export async function deleteViaDangerZone(
   page: Page,
   entity: string,
+  opts?: { dialogName?: string | RegExp },
 ): Promise<void> {
   await page.getByRole("button", { name: "Danger zone" }).click();
   await page.getByRole("button", { name: `Delete ${entity}` }).click();
-  const dialog = page.getByRole("dialog", { name: `Delete ${entity}?` });
+  const dialog = page.getByRole("dialog", {
+    name: opts?.dialogName ?? `Delete ${entity}?`,
+  });
   await dialog.getByRole("button", { name: "Delete", exact: true }).click();
 }


### PR DESCRIPTION
## Summary

Adds the **periods CRUD spine** e2e spec (tracking #355) — create → view → edit → delete, self-cleaning. First spine to build on the shared `crud-helpers`, and it shows the payoff: the spec is a ~15-line journey.

No bug this time — periods behaved (create, rename, and delete all worked on the first run).

## Notes

Periods differ from the earlier spines in two small ways, both handled:
- **Title placeholder** is `"e.g. Jurassic"` (not `"Period title"`).
- **Delete dialog** titles with the record — `Delete "<title>"?` — not `Delete period?`. So `deleteViaDangerZone` gains an optional `dialogName` override (backward-compatible; timeline/event/character specs are untouched and still green).

Like timelines, the Start temporal span is required, so it reuses `setStartDate`.

## Verification

- `pnpm test:e2e` → **13 passed** · `lint` ✓ · `check-types` ✓ · `format` ✓.

Advances #355 (periods). Remaining: stories (spine pattern), then categories + media (which diverge — no `/new` or `[slug]` routes; modal/upload-based — I'll flag the approach separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)