### PR TITLE
test(admin): stories CRUD spine e2e + fix stale-detail cache bug it caught

### DIFF
--- a/apps/admin/e2e/authenticated/story-crud.spec.ts
+++ b/apps/admin/e2e/authenticated/story-crud.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import {
+  deleteViaDangerZone,
+  expectDetailAndReadSlug,
+  saveForm,
+} from "../support/crud-helpers";
+
+/**
+ * Story CRUD spine — drives create → view → edit → delete through the UI
+ * (no seeding). Self-cleaning: the story it creates is removed in the final
+ * step. Stories have no required temporal span, so a title is all that's
+ * needed to create.
+ *
+ * Runs under the `authenticated` project (starts signed in).
+ */
+test.describe("story CRUD spine", () => {
+  test("create, view, edit, then delete a story", async ({ page }) => {
+    const stamp = Date.now();
+    const title = `E2E CRUD Story ${stamp}`;
+    const editedTitle = `${title} (edited)`;
+
+    // ── Create ──────────────────────────────────────────────────────────
+    await page.goto("/stories/new");
+    await page.getByPlaceholder("The story's title").fill(title);
+    await saveForm(page);
+
+    // ── View ────────────────────────────────────────────────────────────
+    const slug = await expectDetailAndReadSlug(page, title);
+
+    // ── Edit ────────────────────────────────────────────────────────────
+    await page.goto(`/stories/${slug}/edit`);
+    const titleField = page.getByPlaceholder("The story's title");
+    await expect(titleField).toHaveValue(title);
+    await titleField.fill(editedTitle);
+    await saveForm(page);
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: editedTitle }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/stories/${slug}$`));
+
+    // ── Delete ──────────────────────────────────────────────────────────
+    await deleteViaDangerZone(page, "story");
+    await page.waitForURL("**/stories");
+    await expect(page.getByText(editedTitle)).toHaveCount(0);
+  });
+});

--- a/packages/ui/src/hooks/use-stories.test.tsx
+++ b/packages/ui/src/hooks/use-stories.test.tsx
@@ -210,6 +210,29 @@ describe("useUpdateStory", () => {
     result.current.mutate({ id: "story-1", data: { title: "Bad" } as never });
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
+  it("invalidates by prefix on success so the detail page's bySlug query refreshes", async () => {
+    vi.mocked(updateStory).mockResolvedValue(mockStory as never);
+    vi.mocked(getStories).mockResolvedValue(mockStories as never);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateStory(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate({
+      id: "story-1",
+      data: { title: "Renamed" } as never,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // Regression: invalidating only detail(id)+lists() left the detail page
+    // (which reads storyKeys.bySlug) stale after an edit. Prefix invalidation
+    // covers bySlug too.
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: storyKeys.all }),
+    );
+  });
 });
 
 describe("useDeleteStory", () => {

--- a/packages/ui/src/hooks/use-stories.tsx
+++ b/packages/ui/src/hooks/use-stories.tsx
@@ -195,9 +195,12 @@ export function useUpdateStory(client: ServiceClient) {
         queryClient.setQueryData(storyKeys.detail(id), context.previous);
       }
     },
-    onSuccess: (_data, { id }) => {
-      void queryClient.invalidateQueries({ queryKey: storyKeys.detail(id) });
-      void queryClient.invalidateQueries({ queryKey: storyKeys.lists() });
+    onSuccess: () => {
+      // Invalidate by prefix so lists, page, bySlug, and detail queries stay
+      // consistent — mirrors usePublish/useDelete. Invalidating only
+      // detail(id)+lists() left the detail page (which reads storyKeys.bySlug)
+      // stale after an edit.
+      void queryClient.invalidateQueries({ queryKey: storyKeys.all });
     },
   });
 }


### PR DESCRIPTION
## Summary

Adds the **stories CRUD spine** e2e spec (tracking #355) — and it **caught the same class of bug** the characters spine did (#358), now in stories. That's **three shipped bugs** surfaced by these spines.

Create → view → edit → delete, self-cleaning. Stories have no required temporal, so a title is all that's needed to create.

## The bug it caught 🐛

After **editing a story**, the detail page kept showing the **old data** until a hard refresh — identical to the character bug (#358).

Root cause: `useUpdateStory`'s `onSuccess` invalidated `storyKeys.detail(id)` + `lists()` but **not** `storyKeys.bySlug`, the key the detail page reads (`useStoryBySlug`). Sibling hooks (`usePublish` / `useDelete`) already invalidate **by prefix**; the update hook missed it.

**Fix**: `onSuccess` invalidates `storyKeys.all` (prefix — covers `bySlug`), plus a hook unit test asserting the prefix invalidation so the **CI gate** guards it.

> Pattern note: this is now the second entity (characters, stories) whose `useUpdate*` hook under-invalidated `bySlug`. Worth a quick audit of the remaining update hooks (periods/media/categories) as a follow-up — I can do that as a small standalone pass.

## Changes

- `packages/ui/src/hooks/use-stories.tsx` — `useUpdateStory` prefix invalidation (+ comment).
- `packages/ui/src/hooks/use-stories.test.tsx` — regression test asserts `storyKeys.all` invalidation.
- `apps/admin/e2e/authenticated/story-crud.spec.ts` — the stories CRUD spine spec.

## Verification

- `pnpm test:e2e` → **14 passed** · `@repo/ui` `use-stories` units **22 passed** · `lint` ✓ · `check-types` ✓ · `format` ✓.

Advances #355. Remaining: categories + media (which diverge — modal/upload-based; I'll recon and propose an approach before writing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)