### PR TITLE
fix(ui): useUpdateEvent invalidates by prefix (detail-auth parity)

### DIFF
--- a/packages/ui/src/hooks/use-events.test.tsx
+++ b/packages/ui/src/hooks/use-events.test.tsx
@@ -217,6 +217,28 @@ describe("useUpdateEvent", () => {
     result.current.mutate({ id: "evt-1", data: { title: "Bad" } as never });
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
+  it("invalidates by prefix on success so the detail view refreshes", async () => {
+    vi.mocked(updateEvent).mockResolvedValue(mockEvent as never);
+    vi.mocked(getEvents).mockResolvedValue(mockEvents as never);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateEvent(mockClient), {
+      wrapper,
+    });
+
+    result.current.mutate({
+      id: "evt-1",
+      data: { title: "Renamed" } as never,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // Parity with usePublishEvent: prefix invalidation covers the detail
+    // view's `detail-auth` query, not just detail(id)+lists().
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: eventKeys.all }),
+    );
+  });
 });
 
 describe("useDeleteEvent", () => {

--- a/packages/ui/src/hooks/use-events.tsx
+++ b/packages/ui/src/hooks/use-events.tsx
@@ -196,9 +196,12 @@ export function useUpdateEvent(client: ServiceClient) {
         queryClient.setQueryData(eventKeys.detail(id), context.previous);
       }
     },
-    onSuccess: (_data, { id }) => {
-      void queryClient.invalidateQueries({ queryKey: eventKeys.detail(id) });
-      void queryClient.invalidateQueries({ queryKey: eventKeys.lists() });
+    onSuccess: () => {
+      // Invalidate by prefix so lists, bySlug, AND the detail view's
+      // `detail-auth` query (all under eventKeys.all) refresh — matching
+      // useUpdateTimeline and usePublishEvent. The narrower detail(id)+lists()
+      // did not cover the detail-auth key the detail page reads.
+      void queryClient.invalidateQueries({ queryKey: eventKeys.all });
     },
   });
 }


### PR DESCRIPTION
## Summary

Small hardening from the `useUpdate*` × `bySlug` audit (follow-up to the character #358 / story #361 stale-detail fixes).

The event detail view reads a `[...eventKeys.all, "detail-auth", slug]` query (`staleTime` 60s), but `useUpdateEvent` invalidated only `eventKeys.detail(id)` + `lists()` — neither of which covers that key. The edit e2e passes today via an incidental refresh path, but the invalidation was **inconsistent** with `useUpdateTimeline` and `usePublishEvent`, which invalidate the `eventKeys.all` prefix.

**Not a live bug** (event edit works and stays green), just removing the fragility so the detail refresh no longer relies on incidental behavior.

## Changes

- `packages/ui/src/hooks/use-events.tsx` — `useUpdateEvent` `onSuccess` invalidates `eventKeys.all` (prefix), matching the sibling hooks.
- `packages/ui/src/hooks/use-events.test.tsx` — unit test asserting the prefix invalidation.

## Verification

- `@repo/ui` `use-events` units **22 passed** · event-crud e2e still green · `lint` ✓ · `check-types` ✓ · `format` ✓.

The other audit finding — `categoryKeys.bySlug` looks like dead code — is intentionally **left out** pending the categories/media discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)