### PR TITLE
fix(admin): drop stale (public)/timelines proxy exemption (#210)

### DIFF
--- a/apps/admin/proxy.ts
+++ b/apps/admin/proxy.ts
@@ -31,33 +31,17 @@ import { createServerSupabaseClient } from "./lib/auth";
 const AUTH_PREFIX = "/auth";
 const ADMIN_PREFIX = "/admin";
 
-/**
- * Public URLs (no auth required). Auth pages live here so the redirect
- * rule below ("already signed in → /dashboard") can run before the gate.
- * Public timeline detail (`/timelines/<slug>`) is handled by the regex
- * below since it shares the `/timelines` prefix with a protected list.
- *
- * WORKAROUND (#210): The (public)/timelines/[slug] placeholder was removed
- * because it conflicted with the new (protected)/timelines/[slug] admin detail
- * page. Until the routing strategy is decided (#210), unauthenticated visitors
- * to /timelines/<slug> will pass through this proxy but be redirected to login
- * by the (protected) layout. The regex below is kept intentionally to make the
- * intent explicit — remove it once a public reader route is established.
- */
-const PUBLIC_TIMELINE_DETAIL = /^\/timelines\/[^/]+\/?$/;
-
 const isAuthRoute = (path: string) =>
   path === AUTH_PREFIX || path.startsWith(`${AUTH_PREFIX}/`);
 
-const isPublicRoute = (path: string) => {
-  // Normalise trailing slash so /timelines/new/ can't bypass the explicit
-  // deny below by slipping through the PUBLIC_TIMELINE_DETAIL regex.
-  const p = path.length > 1 ? path.replace(/\/$/, "") : path;
-  if (isAuthRoute(p)) return true;
-  if (p === "/timelines") return false; // protected list
-  if (p === "/timelines/new") return false; // protected new-page stub
-  return PUBLIC_TIMELINE_DETAIL.test(p);
-};
+/**
+ * Public URLs (no auth required). Only auth pages are public in the admin
+ * app: the redirect rule below ("already signed in → /dashboard") runs
+ * before the gate. The public timeline reader lives in the dedicated
+ * `apps/reader` app (ADR-0030, #254), so every admin route — including
+ * `/timelines/<slug>` — requires a session.
+ */
+const isPublicRoute = (path: string) => isAuthRoute(path);
 
 const isAdminRoute = (path: string) =>
   path === ADMIN_PREFIX || path.startsWith(`${ADMIN_PREFIX}/`);


### PR DESCRIPTION
## Summary

Cleans up the last remnant of the `#210` route-conflict workaround. The hard failure (two parallel pages resolving to `/timelines/[slug]`) was resolved long ago — the `(public)` route group no longer exists, and the public reader now lives in the dedicated `apps/reader` app per [ADR-0030](docs/adr/adr-0030-public-reader-app-placement.md) (scaffolded in #254, closed).

What remained was a stale exemption in [`apps/admin/proxy.ts`](apps/admin/proxy.ts): `PUBLIC_TIMELINE_DETAIL` still marked `/timelines/<slug>` as a **public** route, so the proxy passed unauthenticated requests through and relied solely on the `(protected)` layout to redirect them. This PR removes that exemption so the path is gated at the proxy *and* the layout — restoring defense-in-depth and matching the settled routing decision.

## Changes

- Remove the `PUBLIC_TIMELINE_DETAIL` regex and the `/timelines`, `/timelines/new`, and trailing-slash special-casing that only existed to keep the slug route public.
- `isPublicRoute` is now simply "auth pages are the only public routes."
- Rewrite the comment to reference the settled decision (ADR-0030, #254) instead of an open question.

Net: **8 insertions, 24 deletions**, no behavior change for authenticated users; unauthenticated hits to `/timelines/<slug>` now redirect at the proxy instead of the layout.

## Verification

- `pnpm run format` ✅ · `check-types` ✅ · `lint` ✅ (max-warnings 0) · `build` ✅
- No proxy/admin tests exist; coverage unaffected.
- Repo grep confirms no remaining references to `PUBLIC_TIMELINE_DETAIL` or `(public)/timelines`.

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)