### PR TITLE
fix(services): getTimelineById returns null for missing rows, not a raw throw

### DIFF
--- a/apps/admin/app/(protected)/timelines/[id]/_components/timeline-detail-client.tsx
+++ b/apps/admin/app/(protected)/timelines/[id]/_components/timeline-detail-client.tsx
@@ -781,7 +781,11 @@ export function TimelineDetailClient({ id }: { id: string }) {
     staleTime: 60_000,
   });
 
-  const timeline = authAndTimeline?.timeline as TimelineRow | undefined;
+  // getTimelineById returns null for a missing/deleted/RLS-hidden row (e.g. the
+  // brief refetch after this timeline is deleted). Treat null as undefined so
+  // the not-found branch below renders instead of surfacing a query error.
+  const timeline = (authAndTimeline?.timeline ?? undefined) as
+    TimelineRow | undefined;
   const userId = authAndTimeline?.userId ?? "";
 
   // --- Events union ---

--- a/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
+++ b/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
@@ -230,7 +230,9 @@ export function TimelineFormClient(props: Props) {
   const hydratedRef = React.useRef(false);
   const editRow = editQuery.data;
   React.useEffect(() => {
-    if (!isEdit || hydratedRef.current || editRow === undefined) return;
+    // `editRow == null` covers both the pending (undefined) and not-found
+    // (null) cases — never hydrate the form from a missing timeline.
+    if (!isEdit || hydratedRef.current || editRow == null) return;
     form.reset(mapRowToFormValues(editRow));
     hydratedRef.current = true;
   }, [isEdit, editRow, form]);
@@ -380,6 +382,21 @@ export function TimelineFormClient(props: Props) {
             {editQuery.error instanceof Error
               ? editQuery.error.message
               : "Unknown error."}
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  // Fetch succeeded but the timeline is gone (deleted / RLS-hidden). getTimelineById
+  // returns null rather than throwing, so this is not an `isError` state.
+  if (isEdit && editRow === null) {
+    return (
+      <div className="p-6">
+        <Alert role="alert">
+          <AlertTitle>Timeline not found</AlertTitle>
+          <AlertDescription>
+            This timeline no longer exists or you don’t have access to it.
           </AlertDescription>
         </Alert>
       </div>

--- a/packages/services/src/modules/timeline-service.test.ts
+++ b/packages/services/src/modules/timeline-service.test.ts
@@ -405,12 +405,18 @@ describe("getTimelineById", () => {
     expect(result).toEqual(full);
   });
 
+  it("returns null when no row matches (missing / deleted / RLS-hidden)", async () => {
+    // maybeSingle() → data null, error null for zero rows.
+    const client = makeClient({ fromResult: { data: null, error: null } });
+    await expect(getTimelineById(client, "gone")).resolves.toBeNull();
+  });
+
   it("throws on Supabase error", async () => {
     const client = makeClient({
-      fromResult: { data: null, error: { message: "not found" } },
+      fromResult: { data: null, error: { message: "boom" } },
     });
     await expect(getTimelineById(client, "x")).rejects.toThrow(
-      "TimelineService.getTimelineById: not found",
+      "TimelineService.getTimelineById: boom",
     );
   });
 });

--- a/packages/services/src/modules/timeline-service.ts
+++ b/packages/services/src/modules/timeline-service.ts
@@ -226,22 +226,26 @@ export async function getTimelinesPage(
  * is globally unique, so it resolves deterministically for owners *and*
  * collaborators (RLS `read_timelines` = owner OR is_timeline_collaborator).
  * Routing on the UUID avoids the slug ambiguity of `UNIQUE (user_id, slug)`
- * (#234). Throws (via `.single()`) when the id is unknown or RLS-hidden.
+ * (#234). Returns `null` when the id is unknown, deleted, or RLS-hidden — a
+ * missing row is a not-found, not an exception (cf. ADR-0029 IMP-004). This
+ * also avoids a raw PostgREST coercion error during the brief window a detail
+ * page refetches an entity that was just deleted. Still throws on a real DB
+ * error.
  */
 export async function getTimelineById(
   client: SupabaseClient<Database>,
   id: string,
-): Promise<TimelineWithRelations> {
+): Promise<TimelineWithRelations | null> {
   const { data, error } = await client
     .from("timelines")
     .select(
       "*, timeline_collaborators(*), timeline_events(*), timeline_media(*)",
     )
     .eq("id", id)
-    .single();
+    .maybeSingle();
 
   assertNoError(error, "getTimelineById");
-  return data as TimelineWithRelations;
+  return data as TimelineWithRelations | null;
 }
 
 /**

--- a/packages/ui/src/hooks/use-timelines.tsx
+++ b/packages/ui/src/hooks/use-timelines.tsx
@@ -106,12 +106,12 @@ export function useTimelinesPage(
   });
 }
 
-/** Fetch a single timeline by UUID with related data. */
+/** Fetch a single timeline by UUID with related data (null when not found). */
 export function useTimeline(
   client: ServiceClient,
   id: string,
   options?: Omit<
-    UseQueryOptions<TimelineWithRelations>,
+    UseQueryOptions<TimelineWithRelations | null>,
     "queryKey" | "queryFn"
   >,
 ) {


### PR DESCRIPTION
## Summary

Follow-up to #365 (timeline detail routes on UUID). Running the admin e2e suite surfaced a noisy server-log error even though the tests pass:

```
[QueryClient] query error: Error: TimelineService.getTimelineById: Cannot coerce the result to a single JSON object
    at getTimelineById (packages/services/src/modules/timeline-service.ts)
    at TimelineDetailClient.useQuery (…/timelines/[id]/_components/timeline-detail-client.tsx:778)
```

### Root cause — benign delete-then-refetch race

The timeline detail page keys a live `detail-auth` query on `[...timelineKeys.detail(id), "detail-auth"]`. When a timeline is **deleted from that page**, `useDeleteTimeline.onSuccess` runs `removeQueries(detail(id))` + `invalidateQueries(timelineKeys.all)` while the component is still briefly mounted (before `router.replace("/timelines")` unmounts it). The active observer refetches against the just-deleted id, and `getTimelineById` used `.single()`, which throws PostgREST `PGRST116` ("Cannot coerce the result to a single JSON object") on zero rows.

The e2e passes (it's only a logged query error, and the page navigates away), but the raw error is misleading log noise.

## Fix

Switch `getTimelineById` to `.maybeSingle()` and **return `null`** for a missing / deleted / RLS-hidden row — a not-found is not an exception (cf. [ADR-0029](docs/adr/adr-0029-public-reader-route-scheme.md) IMP-004). Real DB errors still throw via `assertNoError`.

Callers updated for the nullable return:
- **Detail client** already branches on `!timeline` → "Timeline not found"; null now flows there cleanly (coalesced to `undefined`).
- **`useTimeline`** hook generic → `TimelineWithRelations | null`.
- **Edit form** (`timeline-form-client`): the hydrate guard is now null-safe (`editRow == null`), and a new not-found alert renders when the edited timeline is gone (previously relied on `.single()` throwing into the `isError` branch).
- Service test adds a "returns null when no row matches" case.

## Verification

`format` ✅ · `check-types` ✅ · `lint` ✅ (max-warnings 0) · `test` ✅ (services 955, admin 214, ui 486) · `build` ✅. Re-ran `timeline-crud` + `fractal-drill-down` e2e against the local stack — both pass, and the PGRST116 log line is gone.

Refs #234, #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)