### PR TITLE
test(admin): media CRUD spine e2e (external-URL path)

### DIFF
--- a/apps/admin/e2e/authenticated/media-crud.spec.ts
+++ b/apps/admin/e2e/authenticated/media-crud.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Media CRUD spine — external-URL path.
+ *
+ * Media diverges from the other entities: a single `/media` library surface
+ * with an add dialog and a detail drawer, no per-item routes. This drives
+ * create (external URL — no Storage upload) → view in the grid → edit metadata
+ * in the drawer → delete-with-confirm. Self-cleaning.
+ *
+ * The file-upload path (real file → Supabase Storage) is tracked separately on
+ * #355 as an optional follow-up.
+ *
+ * Runs under the `authenticated` project (starts signed in).
+ */
+test.describe("media CRUD spine (external URL)", () => {
+  test("add external media, view, edit its metadata, then delete", async ({
+    page,
+  }) => {
+    const stamp = Date.now();
+    const alt = `E2E Media ${stamp}`;
+    const editedAlt = `${alt} (edited)`;
+
+    // ── Create (external URL) ───────────────────────────────────────────
+    await page.goto("/media");
+    await page.getByRole("button", { name: "External URL" }).click();
+    const addDialog = page.getByRole("dialog", { name: "Add to library" });
+    await addDialog
+      .getByLabel("URL", { exact: true })
+      .fill(`https://example.com/e2e-${stamp}.jpg`);
+    // Alt text becomes the item's label (media_label = alt_text || caption || slug).
+    await addDialog.getByLabel("Alt text").fill(alt);
+    await addDialog.getByRole("button", { name: "Add", exact: true }).click();
+
+    // ── View in the grid ────────────────────────────────────────────────
+    await expect(page.getByRole("button", { name: alt })).toBeVisible();
+
+    // ── Edit metadata via the drawer ────────────────────────────────────
+    await page.getByRole("button", { name: alt }).click();
+    const drawer = page.getByRole("dialog", { name: alt });
+    await expect(drawer).toBeVisible();
+    await drawer.getByLabel("Alt text").fill(editedAlt);
+    await drawer.getByRole("button", { name: "Save changes" }).click();
+    await page.keyboard.press("Escape");
+
+    // The grid reflects the edited label (persisted + list invalidated).
+    await expect(page.getByRole("button", { name: editedAlt })).toBeVisible();
+
+    // ── Delete (blast-radius confirm) ───────────────────────────────────
+    await page.getByRole("button", { name: editedAlt }).click();
+    await page.getByRole("button", { name: "Delete original" }).click();
+    const confirm = page.getByRole("alertdialog", {
+      name: "Delete this media?",
+    });
+    // The trigger is "Delete original…" (ellipsis); the confirm action is
+    // "Delete original" (scoped to the alertdialog).
+    await confirm
+      .getByRole("button", { name: "Delete original", exact: true })
+      .click();
+
+    await expect(page.getByText(editedAlt)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **media CRUD spine** e2e spec — the last of the entity spines (tracking #355) — via the **external-URL** path.

Media diverges the most: a single `/media` library surface with an add **dialog** and a detail **drawer**, no per-item routes. So this spec drives those directly rather than reusing the route-based `crud-helpers`.

## What it exercises

- **Add** — click "External URL" → the "Add to library" dialog → fill URL + alt text → "Add" (no Storage/file upload).
- **View** — the item appears in the grid, labelled by its alt text.
- **Edit** — open the detail drawer, change the alt text, "Save changes"; close and confirm the **grid reflects the edit** (proves persistence + list invalidation).
- **Delete** — "Delete original…" → the "Delete this media?" blast-radius confirm → "Delete original"; item is gone.

Self-cleaning.

## Notes

- **No cache bug this time** — the drawer edit persisted and the grid refreshed, so `useUpdateMedia` invalidates correctly (unlike the character/story `useUpdate*` hooks earlier).
- The **file-upload path** (real file → Supabase Storage via `setInputFiles` + a fixture image) is intentionally **out of scope** here and tracked as an optional follow-up on #355. Local Storage is confirmed available for when we do it.

## Verification

- `pnpm test:e2e` → **19 passed** · `lint` ✓ · `check-types` ✓ · `format` ✓.

With this, **all seven entity CRUD spines are covered** (timeline, event, character, period, story, category, media). Advances #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)