### PR TITLE
fix(admin): repair broken password-reset flow + auth-flow e2e coverage

### DIFF
--- a/apps/admin/app/auth/_actions/index.ts
+++ b/apps/admin/app/auth/_actions/index.ts
@@ -91,7 +91,11 @@ export const resetPasswordAction = async (input: {
   const client = await getServerSupabaseClient();
   return resetPasswordCore(client, {
     email: input.email,
-    redirectTo: await callbackUrl("/auth/update-password"),
+    // Route through the callback so the recovery `code` is exchanged for a
+    // session before the user lands on the update-password form. Pointing the
+    // email link straight at /auth/update-password skips that exchange, so the
+    // form's updateUser() fails with "Auth session missing".
+    redirectTo: await callbackUrl("/auth/callback?next=/auth/update-password"),
   });
 };
 

--- a/apps/admin/app/auth/callback/route.ts
+++ b/apps/admin/app/auth/callback/route.ts
@@ -2,12 +2,12 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getServerSupabaseClient } from "../_lib/server-supabase";
 
 /**
- * OAuth / magic-link / email-confirmation callback. Supabase redirects
- * here with a `code` query param; we exchange it for a session and
- * forward to the post-auth target (`?next=`, defaulting to `/dashboard`).
- * The reset-password flow passes `redirectTo: /auth/update-password`
- * directly to Supabase so it is already baked into the email link before
- * this callback is invoked — the `?next=` param is not used for that flow.
+ * OAuth / magic-link / email-confirmation / password-recovery callback.
+ * Supabase redirects here with a `code` query param; we exchange it for a
+ * session and forward to the post-auth target (`?next=`, defaulting to
+ * `/dashboard`). The password-reset flow sets `next=/auth/update-password`,
+ * so the recovery session is established here before the user sets a new
+ * password (the proxy exempts that route from the signed-in bounce).
  */
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   const url = new URL(request.url);

--- a/apps/admin/e2e/auth-flows.spec.ts
+++ b/apps/admin/e2e/auth-flows.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+import { createConfirmedUser } from "./support/supabase-admin";
+
+/**
+ * Auth flows — form submission + resulting state, and sign-out.
+ *
+ * These run in the anonymous `chromium` project (no shared session): they
+ * cover the logged-out → in transitions and manage their own accounts. The
+ * register / reset / magic-link cases assert the app's part — the form
+ * submits and the correct "check your email" state renders — without chasing
+ * the email (that's Supabase's delivery, not our code). The full reset
+ * round-trip (email → link → new password) lives in auth-password-reset.spec.
+ */
+
+const PASSWORD = "e2e-Password-123!";
+const uniqueEmail = (tag: string) =>
+  `e2e-${tag}-${Date.now()}@timetraveler.test`;
+
+test.describe("auth flows", () => {
+  test("register submits and shows the confirm-email state", async ({
+    page,
+  }) => {
+    await page.goto("/auth/register");
+    await page.getByLabel("First name").fill("Ada");
+    await page.getByLabel("Last name").fill("Lovelace");
+    await page.getByLabel("Email").fill(uniqueEmail("register"));
+    await page.getByLabel("Password", { exact: true }).fill(PASSWORD);
+    await page.getByLabel("Confirm password").fill(PASSWORD);
+    await page.getByRole("button", { name: "Create account" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Check your email" }),
+    ).toBeVisible();
+  });
+
+  test("password-reset request shows the check-email state", async ({
+    page,
+  }) => {
+    await page.goto("/auth/reset-password");
+    await page.getByLabel("Email").fill(uniqueEmail("reset"));
+    await page.getByRole("button", { name: "Send reset link" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Check your email" }),
+    ).toBeVisible();
+  });
+
+  test("magic-link request shows the check-email state", async ({ page }) => {
+    await page.goto("/auth/magic-link");
+    await page.getByLabel("Email").fill(uniqueEmail("magic"));
+    await page.getByRole("button", { name: "Send magic link" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Check your email" }),
+    ).toBeVisible();
+  });
+
+  test("a signed-in user can sign out", async ({ page }) => {
+    // Own confirmed account — separate from the shared `authenticated` session.
+    const email = uniqueEmail("logout");
+    await createConfirmedUser(email, PASSWORD);
+
+    await page.goto("/auth/login");
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password", { exact: true }).fill(PASSWORD);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.waitForURL("**/dashboard");
+
+    // Sign out via the shell user menu → back to the login page.
+    await page.getByRole("button", { name: "Open user menu" }).click();
+    await page.getByRole("menuitem", { name: "Sign out" }).click();
+    await page.waitForURL("**/auth/login");
+  });
+});

--- a/apps/admin/e2e/auth-password-reset.spec.ts
+++ b/apps/admin/e2e/auth-password-reset.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { waitForEmailLink } from "./support/mailbox";
+import { createConfirmedUser } from "./support/supabase-admin";
+
+/**
+ * Password reset — full round-trip (the one email flow worth completing).
+ *
+ * Request the reset, pull the recovery link from Mailpit, follow it to the
+ * update-password page, set a new password, and prove it works by signing in
+ * with it. This exercises real app logic — the recovery-session handling and
+ * the update-password page — not just Supabase's email delivery.
+ *
+ * Runs in the anonymous `chromium` project with its own isolated account (a
+ * password change must not disturb the shared `authenticated` session).
+ */
+test.describe("password reset", () => {
+  test("request → email link → set a new password → sign in with it", async ({
+    page,
+  }) => {
+    const email = `e2e-reset-rt-${Date.now()}@timetraveler.test`;
+    const oldPassword = "e2e-Password-OLD-1!";
+    const newPassword = "e2e-Password-NEW-2!";
+    await createConfirmedUser(email, oldPassword);
+
+    // ── Request the reset ───────────────────────────────────────────────
+    await page.goto("/auth/reset-password");
+    await page.getByLabel("Email").fill(email);
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Check your email" }),
+    ).toBeVisible();
+
+    // ── Follow the recovery link from the email ─────────────────────────
+    const link = await waitForEmailLink(
+      email,
+      /verify|recover|type=recovery|update-password/i,
+    );
+    await page.goto(link);
+
+    // ── Set a new password on the update-password page ──────────────────
+    await page.waitForURL("**/auth/update-password**");
+    await page.getByLabel("New password", { exact: true }).fill(newPassword);
+    await page.getByLabel("Confirm new password").fill(newPassword);
+    await page.getByRole("button", { name: "Set new password" }).click();
+    await page.waitForURL("**/dashboard");
+
+    // ── Prove the new password works: sign out, sign back in with it ────
+    await page.getByRole("button", { name: "Open user menu" }).click();
+    await page.getByRole("menuitem", { name: "Sign out" }).click();
+    await page.waitForURL("**/auth/login");
+
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password", { exact: true }).fill(newPassword);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.waitForURL("**/dashboard");
+  });
+});

--- a/apps/admin/e2e/support/mailbox.ts
+++ b/apps/admin/e2e/support/mailbox.ts
@@ -65,5 +65,5 @@ function extractLink(body: string, pattern: RegExp): string | null {
 }
 
 function decodeEntities(s: string): string {
-  return s.replace(/&amp;/g, "&").replace(/&#38;/g, "&");
+  return s.replace(/&#38;/g, "&").replace(/&amp;/g, "&");
 }

--- a/apps/admin/e2e/support/mailbox.ts
+++ b/apps/admin/e2e/support/mailbox.ts
@@ -1,0 +1,69 @@
+/*
+ * Supabase local routes auth emails to Mailpit (HTTP API on :54324). This
+ * helper reads captured mail so a spec can complete an email round-trip
+ * (e.g. password reset). Local-only — never used against a real inbox.
+ *
+ * MAILPIT_URL configures the e2e run directly (outside the turbo task graph),
+ * so the turbo env-var declaration rule doesn't apply here.
+ */
+/* eslint-disable turbo/no-undeclared-env-vars */
+const MAILPIT_URL = process.env.MAILPIT_URL ?? "http://127.0.0.1:54324";
+
+interface MailpitSummary {
+  ID: string;
+  To: Array<{ Address: string }>;
+}
+
+/**
+ * Poll Mailpit for the newest message addressed to `toAddress` and return the
+ * first link in its body matching `linkPattern`. Throws if none arrives within
+ * `timeoutMs`.
+ */
+export async function waitForEmailLink(
+  toAddress: string,
+  linkPattern: RegExp,
+  { timeoutMs = 15_000 }: { timeoutMs?: number } = {},
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  const target = toAddress.toLowerCase();
+
+  while (Date.now() < deadline) {
+    const list = await fetch(`${MAILPIT_URL}/api/v1/messages?limit=50`);
+    if (list.ok) {
+      const { messages } = (await list.json()) as {
+        messages: MailpitSummary[];
+      };
+      const match = messages.find((m) =>
+        m.To.some((t) => t.Address.toLowerCase() === target),
+      );
+      if (match) {
+        const full = await fetch(`${MAILPIT_URL}/api/v1/message/${match.ID}`);
+        if (full.ok) {
+          const body = (await full.json()) as { HTML?: string; Text?: string };
+          const link = extractLink(
+            `${body.HTML ?? ""}\n${body.Text ?? ""}`,
+            linkPattern,
+          );
+          if (link) return link;
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(
+    `No email to ${toAddress} matching ${linkPattern} within ${timeoutMs}ms`,
+  );
+}
+
+function extractLink(body: string, pattern: RegExp): string | null {
+  const hrefs = [...body.matchAll(/href="([^"]+)"/g)].map((m) =>
+    decodeEntities(m[1] ?? ""),
+  );
+  const bare = [...body.matchAll(/https?:\/\/[^\s"'<>]+/g)].map((m) => m[0]);
+  return [...hrefs, ...bare].find((url) => pattern.test(url)) ?? null;
+}
+
+function decodeEntities(s: string): string {
+  return s.replace(/&amp;/g, "&").replace(/&#38;/g, "&");
+}

--- a/apps/admin/e2e/support/mailbox.ts
+++ b/apps/admin/e2e/support/mailbox.ts
@@ -65,5 +65,5 @@ function extractLink(body: string, pattern: RegExp): string | null {
 }
 
 function decodeEntities(s: string): string {
-  return s.replace(/&#38;/g, "&").replace(/&amp;/g, "&");
+  return s.replace(/(?:&#38;|&amp;)/g, "&");
 }

--- a/apps/admin/e2e/support/supabase-admin.ts
+++ b/apps/admin/e2e/support/supabase-admin.ts
@@ -20,3 +20,31 @@ export function createServiceRoleClient(): SupabaseClient {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 }
+
+/**
+ * Create an already-confirmed user (email verification pre-satisfied) so an
+ * auth-flow spec can sign in immediately. Used for isolated accounts — e.g.
+ * logout and the password-reset round-trip — that must NOT share the seeded
+ * `authenticated` session (a global signOut / password change would disrupt
+ * it). Idempotent on a re-run against a warm database.
+ */
+export async function createConfirmedUser(
+  email: string,
+  password: string,
+): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: { first_name: "E2E", last_name: "User" },
+  });
+  if (error) {
+    const alreadyExists =
+      error.code === "email_exists" ||
+      /already been registered|already exists/i.test(error.message);
+    if (!alreadyExists) {
+      throw error;
+    }
+  }
+}

--- a/apps/admin/proxy.ts
+++ b/apps/admin/proxy.ts
@@ -69,9 +69,14 @@ export const proxy = async (request: NextRequest): Promise<NextResponse> => {
     data: { user },
   } = await client.auth.getUser();
 
-  // Auth pages: redirect signed-in users away.
+  // Auth pages: redirect signed-in users away — except the two recovery
+  // routes. `/auth/callback` exchanges the code; `/auth/update-password` is
+  // the password-recovery form, which the user reaches *with* a (recovery)
+  // session, so bouncing "authenticated" users off it would break reset.
   if (isAuthRoute(pathname)) {
-    if (user && pathname !== "/auth/callback") {
+    const recoveryExempt =
+      pathname === "/auth/callback" || pathname === "/auth/update-password";
+    if (user && !recoveryExempt) {
       return NextResponse.redirect(new URL("/dashboard", origin));
     }
     return response;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -153,7 +153,16 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+# The admin app runs at http://localhost:3000 in dev/e2e, so its auth-email
+# redirect targets (/auth/update-password, /auth/callback) must be allow-listed
+# under both localhost and 127.0.0.1 — otherwise GoTrue rejects the redirect_to
+# and falls back to site_url, dead-ending reset/magic-link/confirm at the login
+# page (both here and in manual local dev).
+additional_redirect_urls = [
+  "https://127.0.0.1:3000",
+  "http://127.0.0.1:3000/**",
+  "http://localhost:3000/**",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).


### PR DESCRIPTION
## Summary

Adds auth-flow e2e coverage (tracking #355) — and the reset round-trip **caught a real, security-critical bug: password reset was broken end to end.** This PR fixes it (the round-trip is the regression guard) plus a local-dev config bug the same flow surfaced.

⚠️ **Security-sensitive** (auth routing + proxy) — please review the fix carefully.

## The bug 🐛

Clicking the password-reset email link dead-ended: the email linked **straight to `/auth/update-password`**, so the recovery `code` was never exchanged for a session, and "Set new password" failed with **"Auth session missing"**. A second latent issue: `proxy.ts` bounced *authenticated* users off `/auth/update-password` (only `/auth/callback` was exempt), so even a correctly-recovered session couldn't reach the form.

### Fix (2 parts)
- **`resetPasswordAction`** now routes the email link through `/auth/callback?next=/auth/update-password`, so the callback exchanges the `code` (establishes the recovery session) *before* the user reaches the form.
- **`proxy.ts`** exempts `/auth/update-password` from the signed-in → `/dashboard` bounce (alongside `/auth/callback`).

## Also: local-dev config fix

The same flow surfaced that `additional_redirect_urls` only allowed `https://127.0.0.1:3000`, but the app runs at `http://localhost:3000` — so GoTrue rejected the `redirect_to` and fell back to `site_url`, dead-ending reset/magic/confirm at login (in e2e **and** manual local dev). Added `http://localhost:3000/**` + `http://127.0.0.1:3000/**` to the allow-list. (Requires `supabase stop && start` to take effect — already applied locally.)

## Auth-flow e2e (anon `chromium` project, own isolated accounts)

- **`auth-flows.spec.ts`** — register, reset-request, magic-link-request (form → "check your email") + logout. These assert the app's part (form + state) without chasing email — Supabase's delivery is not ours to test.
- **`auth-password-reset.spec.ts`** — the one full round-trip: request → read the recovery link from **Mailpit** → set a new password → sign in with it. This is the regression guard for the fix above.
- **`support/mailbox.ts`** (Mailpit reader) + **`createConfirmedUser`** (isolated accounts, so a password change can't disturb the shared `authenticated` session).

Scope was kept deliberately pragmatic per discussion: full round-trip only for reset (highest value); magic-link/confirmation round-trips intentionally skipped.

## Verification

- `pnpm test:e2e` → **24 passed** (incl. the reset round-trip and the anon redirect tests that exercise the proxy change) · `lint` ✓ · `check-types` ✓ · `format` ✓.
- Confirmed the round-trip fails before the fix ("Auth session missing") and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)