### PR TITLE
perf(admin): dedupe per-request auth lookups via cached getServerUser() (#372)

### DIFF
--- a/apps/admin/app/(admin)/layout.tsx
+++ b/apps/admin/app/(admin)/layout.tsx
@@ -1,7 +1,10 @@
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
-import { getProfile, getUser } from "../../lib/auth";
-import { getServerSupabaseClient } from "../auth/_lib/server-supabase";
+import { getProfile } from "../../lib/auth";
+import {
+  getServerSupabaseClient,
+  getServerUser,
+} from "../auth/_lib/server-supabase";
 
 /**
  * Admin route group gate. Belt-and-suspenders with `proxy.ts`'s edge-
@@ -21,10 +24,10 @@ export default async function AdminLayout({
 }: {
   children: ReactNode;
 }) {
-  const client = await getServerSupabaseClient();
-  const user = await getUser(client);
+  const user = await getServerUser();
   if (!user) redirect("/auth/login");
 
+  const client = await getServerSupabaseClient();
   const profile = await getProfile(client, user.id);
   if (profile?.role !== "admin") {
     redirect("/dashboard?error=forbidden");

--- a/apps/admin/app/(protected)/characters/[slug]/edit/page.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/edit/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
-import { getUser } from "../../../../../lib/auth";
-import { getServerSupabaseClient } from "../../../../auth/_lib/server-supabase";
+import { getServerUser } from "../../../../auth/_lib/server-supabase";
 import { CharacterFormClient } from "../../_components/character-form-client";
 
 interface EditCharacterPageProps {
@@ -15,8 +14,7 @@ export default async function EditCharacterPage({
   // Resolve the owner id server-side (session already validated by the
   // protected layout) so the client hook can build its (userId, slug) query
   // key on first render without an auth round-trip / loading flash.
-  const client = await getServerSupabaseClient();
-  const user = await getUser(client);
+  const user = await getServerUser();
   if (!user) redirect("/auth/login");
 
   return <CharacterFormClient mode="edit" userId={user.id} slug={slug} />;

--- a/apps/admin/app/(protected)/characters/[slug]/page.tsx
+++ b/apps/admin/app/(protected)/characters/[slug]/page.tsx
@@ -1,8 +1,7 @@
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { Skeleton } from "@repo/ui/components/skeleton";
-import { getUser } from "../../../../lib/auth";
-import { getServerSupabaseClient } from "../../../auth/_lib/server-supabase";
+import { getServerUser } from "../../../auth/_lib/server-supabase";
 import { CharacterDetailClient } from "./_components/character-detail-client";
 
 export const metadata = {
@@ -20,8 +19,7 @@ export default async function CharacterDetailPage({
   // protected layout) so the client hook can build its (userId, slug) query
   // key on first render without an auth round-trip / loading flash. Mirrors
   // the character editor's edit/page.tsx.
-  const client = await getServerSupabaseClient();
-  const user = await getUser(client);
+  const user = await getServerUser();
   if (!user) redirect("/auth/login");
 
   return (

--- a/apps/admin/app/(protected)/events/[slug]/edit/page.tsx
+++ b/apps/admin/app/(protected)/events/[slug]/edit/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
-import { getUser } from "../../../../../lib/auth";
-import { getServerSupabaseClient } from "../../../../auth/_lib/server-supabase";
+import { getServerUser } from "../../../../auth/_lib/server-supabase";
 import { EventFormClient } from "../../_components/event-form-client";
 
 interface EditEventPageProps {
@@ -13,8 +12,7 @@ export default async function EditEventPage({ params }: EditEventPageProps) {
   // Resolve the owner id server-side (session already validated by the
   // protected layout) so the client hook can build its (userId, slug) query
   // key on first render without an auth round-trip / loading flash.
-  const client = await getServerSupabaseClient();
-  const user = await getUser(client);
+  const user = await getServerUser();
   if (!user) redirect("/auth/login");
 
   return <EventFormClient mode="edit" userId={user.id} slug={slug} />;

--- a/apps/admin/app/(protected)/layout.tsx
+++ b/apps/admin/app/(protected)/layout.tsx
@@ -1,8 +1,11 @@
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import type { ShellUser } from "@repo/ui/components/shell";
-import { getUser, getProfile } from "../../lib/auth";
-import { getServerSupabaseClient } from "../auth/_lib/server-supabase";
+import { getProfile } from "../../lib/auth";
+import {
+  getServerSupabaseClient,
+  getServerUser,
+} from "../auth/_lib/server-supabase";
 import { ProtectedShell } from "./_components/protected-shell";
 
 /**
@@ -16,10 +19,10 @@ export default async function ProtectedLayout({
 }: {
   children: ReactNode;
 }) {
-  const client = await getServerSupabaseClient();
-  const user = await getUser(client);
+  const user = await getServerUser();
   if (!user || !user.email) redirect("/auth/login");
 
+  const client = await getServerSupabaseClient();
   const profile = await getProfile(client, user.id);
   const shellUser: ShellUser = {
     name: profile ? `${profile.firstName} ${profile.lastName}` : user.email,

--- a/apps/admin/app/(protected)/periods/[slug]/edit/page.tsx
+++ b/apps/admin/app/(protected)/periods/[slug]/edit/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
-import { getUser } from "../../../../../lib/auth";
-import { getServerSupabaseClient } from "../../../../auth/_lib/server-supabase";
+import { getServerUser } from "../../../../auth/_lib/server-supabase";
 import { PeriodFormClient } from "../../_components/period-form-client";
 
 interface EditPeriodPageProps {
@@ -13,8 +12,7 @@ export default async function EditPeriodPage({ params }: EditPeriodPageProps) {
   // Resolve the owner id server-side (session already validated by the
   // protected layout) so the client hook can build its (userId, slug) query
   // key on first render without an auth round-trip / loading flash.
-  const client = await getServerSupabaseClient();
-  const user = await getUser(client);
+  const user = await getServerUser();
   if (!user) redirect("/auth/login");
 
   return <PeriodFormClient mode="edit" userId={user.id} slug={slug} />;

--- a/apps/admin/app/(protected)/periods/[slug]/page.tsx
+++ b/apps/admin/app/(protected)/periods/[slug]/page.tsx
@@ -1,8 +1,7 @@
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { Skeleton } from "@repo/ui/components/skeleton";
-import { getUser } from "../../../../lib/auth";
-import { getServerSupabaseClient } from "../../../auth/_lib/server-supabase";
+import { getServerUser } from "../../../auth/_lib/server-supabase";
 import { PeriodDetailClient } from "./_components/period-detail-client";
 
 export const metadata = {
@@ -19,8 +18,7 @@ export default async function PeriodDetailPage({
   // Resolve the owner id server-side (session already validated by the
   // protected layout) so the client hook can build its (userId, slug) query
   // key on first render without an auth round-trip / loading flash.
-  const client = await getServerSupabaseClient();
-  const user = await getUser(client);
+  const user = await getServerUser();
   if (!user) redirect("/auth/login");
 
   return (

--- a/apps/admin/app/(protected)/stories/[slug]/edit/page.tsx
+++ b/apps/admin/app/(protected)/stories/[slug]/edit/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
-import { getUser } from "../../../../../lib/auth";
-import { getServerSupabaseClient } from "../../../../auth/_lib/server-supabase";
+import { getServerUser } from "../../../../auth/_lib/server-supabase";
 import { StoryFormClient } from "../../_components/story-form-client";
 
 interface EditStoryPageProps {
@@ -13,8 +12,7 @@ export default async function EditStoryPage({ params }: EditStoryPageProps) {
   // Resolve the owner id server-side (session already validated by the
   // protected layout) so the client hook can build its (userId, slug) query
   // key on first render without an auth round-trip / loading flash.
-  const client = await getServerSupabaseClient();
-  const user = await getUser(client);
+  const user = await getServerUser();
   if (!user) redirect("/auth/login");
 
   return <StoryFormClient mode="edit" userId={user.id} slug={slug} />;

--- a/apps/admin/app/(protected)/stories/[slug]/page.tsx
+++ b/apps/admin/app/(protected)/stories/[slug]/page.tsx
@@ -1,8 +1,7 @@
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { Skeleton } from "@repo/ui/components/skeleton";
-import { getUser } from "../../../../lib/auth";
-import { getServerSupabaseClient } from "../../../auth/_lib/server-supabase";
+import { getServerUser } from "../../../auth/_lib/server-supabase";
 import { StoryDetailClient } from "./_components/story-detail-client";
 
 export const metadata = {
@@ -19,8 +18,7 @@ export default async function StoryDetailPage({
   // Resolve the owner id server-side (session already validated by the
   // protected layout) so the client hook can build its (userId, slug) query
   // key on first render without an auth round-trip / loading flash.
-  const client = await getServerSupabaseClient();
-  const user = await getUser(client);
+  const user = await getServerUser();
   if (!user) redirect("/auth/login");
 
   return (


### PR DESCRIPTION
## Context

PR #370 introduced a request-memoized `getServerUser()` and wrapped `getServerSupabaseClient()` in React `cache()`, then adopted it in the **categories** routes to collapse a 3× sequential GoTrue round-trip into one per request. This PR finishes the job for every other protected server route (the #370 review follow-up).

The old pattern: the shared `(protected)/layout.tsx` resolved the user, and each nested detail/edit page independently rebuilt a client and called `getUser()` again. Because a layout `await`s before rendering its children, these redundant JWT-validating GoTrue round-trips were **sequential** and stacked directly onto TTFB.

## Changes (9 files)

- **7 detail/edit pages** (characters/periods/stories `[slug]` + `edit`, events `[slug]/edit`) — replaced the two-line `getServerSupabaseClient()` + `getUser(client)` sequence with a single `getServerUser()` call; dropped the now-unused imports.
- **2 layouts** (`(protected)/layout.tsx`, `(admin)/layout.tsx`) — resolve the user via `getServerUser()`, then keep the now-cached `getServerSupabaseClient()` for `getProfile` (free — same request-scoped instance). Preserved the `(protected)` layout's `!user.email` guard and the `(admin)` admin-role gate.

**Left alone** (as scoped in #372): browser-side client components, the `_actions`/`callback` route handlers, and `events/[slug]/page.tsx` (resolves no user server-side).

## Acceptance criteria

- [x] Every protected server route resolves the user via memoized `getServerUser()`; no route fires more than one GoTrue round-trip per request.
- [x] The protected layout still loads the profile via the cached client.
- [x] Unauthenticated behavior unchanged — still redirects to `/auth/login`.
- [x] `check-types` / `lint` / `build` green; `pnpm verify` and `pnpm test:e2e` pass locally.

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)