### PR TITLE
feat(admin): global unsaved-changes guard for app-shell navigation (#371)

### DIFF
--- a/apps/admin/app/(protected)/_components/protected-shell.tsx
+++ b/apps/admin/app/(protected)/_components/protected-shell.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { startTransition, useEffect, type ReactNode } from "react";
+import { Button } from "@repo/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
 import { Shell, type ShellUser } from "@repo/ui/components/shell";
 import { useUiStore } from "@repo/ui/stores";
 import { ShellLink } from "../../../components/shell-link";
@@ -22,6 +31,22 @@ interface ProtectedShellProps {
  */
 export const ProtectedShell = ({ user, children }: ProtectedShellProps) => {
   const pathname = usePathname() ?? "/dashboard";
+  const router = useRouter();
+
+  // Global unsaved-changes guard for shell navigation. `ShellLink` cancels the
+  // client-side navigation and stashes the target here when any editor is dirty;
+  // this dialog resolves it. See lib/use-register-unsaved-changes.ts.
+  const pendingNavigation = useUiStore((s) => s.pendingNavigation);
+  const cancelShellNavigate = useUiStore((s) => s.cancelShellNavigate);
+  const confirmShellNavigate = useUiStore((s) => s.confirmShellNavigate);
+
+  const handleDiscard = () => {
+    const href = pendingNavigation;
+    // Clear dirty flags + pending href first, then push in this handler — never
+    // inside a state updater, which would navigate mid-render.
+    confirmShellNavigate();
+    if (href) router.push(href);
+  };
 
   // Auto-collapse the sidebar on first mount when the viewport is below
   // Tailwind's `lg` breakpoint (1024px). Runs only on mount; the user can
@@ -42,15 +67,42 @@ export const ProtectedShell = ({ user, children }: ProtectedShellProps) => {
   };
 
   return (
-    <Shell
-      nav={NAV_ITEMS}
-      currentPath={pathname}
-      user={user}
-      quickCreateItems={QUICK_CREATE_ITEMS}
-      LinkComponent={ShellLink}
-      onSignOut={handleSignOut}
-    >
-      {children}
-    </Shell>
+    <>
+      <Shell
+        nav={NAV_ITEMS}
+        currentPath={pathname}
+        user={user}
+        quickCreateItems={QUICK_CREATE_ITEMS}
+        LinkComponent={ShellLink}
+        onSignOut={handleSignOut}
+      >
+        {children}
+      </Shell>
+
+      {/* Global discard-changes confirmation for app-shell navigation. */}
+      <Dialog
+        open={pendingNavigation !== null}
+        onOpenChange={(open) => {
+          if (!open) cancelShellNavigate();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Discard unsaved changes?</DialogTitle>
+            <DialogDescription>
+              You have unsaved changes. Leaving now will lose them.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={cancelShellNavigate}>
+              Keep editing
+            </Button>
+            <Button variant="destructive" onClick={handleDiscard}>
+              Discard
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };

--- a/apps/admin/app/(protected)/categories/_components/category-manager-shell.tsx
+++ b/apps/admin/app/(protected)/categories/_components/category-manager-shell.tsx
@@ -20,6 +20,7 @@ import {
   useCategoryUsageCounts,
 } from "@repo/ui/hooks/use-categories";
 import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import { useRegisterUnsavedChanges } from "../../../../lib/use-register-unsaved-changes";
 import { useUnsavedChangesGuard } from "../../../../lib/use-unsaved-changes-guard";
 
 import { CategoryTree } from "./category-tree";
@@ -50,6 +51,7 @@ export function CategoryManagerShell({
   const setDirty = React.useCallback((dirty: boolean) => setIsDirty(dirty), []);
   const guardValue = React.useMemo(() => ({ setDirty }), [setDirty]);
   const guard = useUnsavedChangesGuard(isDirty);
+  useRegisterUnsavedChanges(isDirty);
 
   const treeQuery = useCategoryTree(client, userId);
   const usageQuery = useCategoryUsageCounts(client, userId);

--- a/apps/admin/app/(protected)/characters/_components/character-form-client.tsx
+++ b/apps/admin/app/(protected)/characters/_components/character-form-client.tsx
@@ -57,6 +57,7 @@ import {
   type AttachedMedia,
 } from "../../_components/media/media-section";
 import { AttachMediaDialog } from "../../_components/media/attach-media-dialog";
+import { useRegisterUnsavedChanges } from "../../../../lib/use-register-unsaved-changes";
 import { useUnsavedChangesGuard } from "../../../../lib/use-unsaved-changes-guard";
 import {
   characterFormSchema,
@@ -406,6 +407,7 @@ export function CharacterFormClient(props: Props) {
 
   const isDirty = form.formState.isDirty;
   const guard = useUnsavedChangesGuard(isDirty);
+  useRegisterUnsavedChanges(isDirty);
 
   const [pendingTypeChange, setPendingTypeChange] =
     React.useState<PendingTypeChange | null>(null);

--- a/apps/admin/app/(protected)/events/_components/event-form-client.tsx
+++ b/apps/admin/app/(protected)/events/_components/event-form-client.tsx
@@ -68,6 +68,7 @@ import { cn } from "@repo/ui/lib/utils";
 
 import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
 // The unsaved-changes guard is feature-agnostic; reuse the timeline editor's.
+import { useRegisterUnsavedChanges } from "../../../../lib/use-register-unsaved-changes";
 import { useUnsavedChangesGuard } from "../../../../lib/use-unsaved-changes-guard";
 import {
   eventFormSchema,
@@ -360,6 +361,7 @@ export function EventFormClient(props: Props) {
 
   const isDirty = form.formState.isDirty;
   const guard = useUnsavedChangesGuard(isDirty);
+  useRegisterUnsavedChanges(isDirty);
 
   const addAnotherRef = React.useRef(false);
 

--- a/apps/admin/app/(protected)/periods/_components/period-form-client.tsx
+++ b/apps/admin/app/(protected)/periods/_components/period-form-client.tsx
@@ -48,6 +48,7 @@ import { TemporalDisplay } from "@repo/ui/components/temporal-display";
 import { cn } from "@repo/ui/lib/utils";
 
 import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import { useRegisterUnsavedChanges } from "../../../../lib/use-register-unsaved-changes";
 import { useUnsavedChangesGuard } from "../../../../lib/use-unsaved-changes-guard";
 import { SignificanceRamp, type Significance } from "./significance-ramp";
 import { PeriodParentPicker } from "./period-parent-picker";
@@ -179,6 +180,7 @@ export function PeriodFormClient(props: Props) {
 
   const isDirty = form.formState.isDirty;
   const guard = useUnsavedChangesGuard(isDirty);
+  useRegisterUnsavedChanges(isDirty);
 
   const [autosaveAt, setAutosaveAt] = React.useState<Date | null>(null);
   const [addAnotherNote, setAddAnotherNote] = React.useState(false);

--- a/apps/admin/app/(protected)/stories/_components/story-form-client.tsx
+++ b/apps/admin/app/(protected)/stories/_components/story-form-client.tsx
@@ -62,6 +62,7 @@ import {
 import { cn } from "@repo/ui/lib/utils";
 
 import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import { useRegisterUnsavedChanges } from "../../../../lib/use-register-unsaved-changes";
 import { useUnsavedChangesGuard } from "../../../../lib/use-unsaved-changes-guard";
 import {
   storyFormSchema,
@@ -223,6 +224,7 @@ export function StoryFormClient(props: Props) {
 
   const isDirty = form.formState.isDirty;
   const guard = useUnsavedChangesGuard(isDirty);
+  useRegisterUnsavedChanges(isDirty);
 
   const [autosaveAt, setAutosaveAt] = React.useState<Date | null>(null);
   const [addAnotherNote, setAddAnotherNote] = React.useState(false);

--- a/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
+++ b/apps/admin/app/(protected)/timelines/_components/timeline-form-client.tsx
@@ -64,6 +64,7 @@ import { Textarea } from "@repo/ui/components/textarea";
 import { cn } from "@repo/ui/lib/utils";
 
 import { getBrowserSupabaseClient } from "../../../../lib/auth/browser-client";
+import { useRegisterUnsavedChanges } from "../../../../lib/use-register-unsaved-changes";
 import { useUnsavedChangesGuard } from "../../../../lib/use-unsaved-changes-guard";
 import {
   timelineFormSchema,
@@ -239,6 +240,7 @@ export function TimelineFormClient(props: Props) {
 
   const isDirty = form.formState.isDirty;
   const guard = useUnsavedChangesGuard(isDirty);
+  useRegisterUnsavedChanges(isDirty);
 
   // Confirm dialog state for switching timeline_type away from biographical.
   const [pendingType, setPendingType] = React.useState<TimelineType | null>(

--- a/apps/admin/components/shell-link.test.tsx
+++ b/apps/admin/components/shell-link.test.tsx
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { useUiStore } from "@repo/ui/stores";
+import { ShellLink } from "./shell-link";
+
+// Capture the props next/link receives so we can drive its `onNavigate` directly
+// (jsdom doesn't perform real client-side navigation).
+const h = vi.hoisted(() => ({
+  onNavigate: undefined as
+    ((event: { preventDefault: () => void }) => void) | undefined,
+}));
+
+vi.mock("next/link", () => ({
+  default: (props: {
+    href: string;
+    children?: React.ReactNode;
+    onNavigate?: (event: { preventDefault: () => void }) => void;
+  }) => {
+    h.onNavigate = props.onNavigate;
+    return <a href={props.href}>{props.children}</a>;
+  },
+}));
+
+beforeEach(() => {
+  h.onNavigate = undefined;
+  useUiStore.setState({
+    dirtyEditors: new Set<string>(),
+    pendingNavigation: null,
+  });
+});
+
+describe("ShellLink onNavigate interception", () => {
+  it("intercepts navigation and defers it when an editor is dirty", () => {
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    render(<ShellLink href="/characters">Characters</ShellLink>);
+
+    const preventDefault = vi.fn();
+    h.onNavigate?.({ preventDefault });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(useUiStore.getState().pendingNavigation).toBe("/characters");
+  });
+
+  it("lets navigation proceed with no dialog when nothing is dirty", () => {
+    render(<ShellLink href="/timelines">Timelines</ShellLink>);
+
+    const preventDefault = vi.fn();
+    h.onNavigate?.({ preventDefault });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(useUiStore.getState().pendingNavigation).toBeNull();
+  });
+});

--- a/apps/admin/components/shell-link.tsx
+++ b/apps/admin/components/shell-link.tsx
@@ -2,20 +2,43 @@
 
 import Link from "next/link";
 import type { ShellLinkProps } from "@repo/ui/components/shell";
+import { useUiStore } from "@repo/ui/stores";
 
 /**
  * Next-specific adapter for the Shell's framework-agnostic
  * `LinkComponent` slot. Confines `next/link` to the app layer per
  * Batch C's design-for-extraction note in
  * docs/design/admin/fidelity-2-plan.md.
+ *
+ * Also the single client-side interception point for the global unsaved-changes
+ * guard: because all three shell nav surfaces (sidebar, quick-create,
+ * breadcrumbs) render through this component, cancelling the client-side
+ * navigation here via `onNavigate` covers all of them at once. When any editor
+ * is dirty we defer the navigation to the app-level discard dialog in
+ * `ProtectedShell` instead of letting it proceed.
  */
 export const ShellLink = ({
   href,
   className,
   children,
   ...rest
-}: ShellLinkProps) => (
-  <Link href={href} className={className} {...rest}>
-    {children}
-  </Link>
-);
+}: ShellLinkProps) => {
+  const hasUnsavedChanges = useUiStore((s) => s.dirtyEditors.size > 0);
+  const requestShellNavigate = useUiStore((s) => s.requestShellNavigate);
+
+  return (
+    <Link
+      href={href}
+      className={className}
+      onNavigate={(event) => {
+        if (hasUnsavedChanges) {
+          event.preventDefault();
+          requestShellNavigate(href);
+        }
+      }}
+      {...rest}
+    >
+      {children}
+    </Link>
+  );
+};

--- a/apps/admin/e2e/authenticated/category-crud.spec.ts
+++ b/apps/admin/e2e/authenticated/category-crud.spec.ts
@@ -269,4 +269,65 @@ test.describe("category CRUD spine", () => {
 
     expect(renderErrors).toEqual([]);
   });
+
+  test("warns before losing unsaved edits when navigating via the app shell", async ({
+    page,
+  }) => {
+    const stamp = Date.now();
+    const title = `E2E Shell ${stamp}`;
+
+    // Same render-phase regression guard as the in-manager case: the global
+    // confirm must push in the handler, never inside a state updater.
+    const renderErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (
+        msg.type() === "error" &&
+        msg.text().includes("while rendering a different component")
+      ) {
+        renderErrors.push(msg.text());
+      }
+    });
+
+    await page.goto("/categories/new");
+    await fillTitleAndSave(page, title);
+    await expectEditRouteAndReadId(page, title);
+    await page.getByPlaceholder(TITLE_PLACEHOLDER).fill(`${title} UNSAVED`);
+
+    const nav = page.getByRole("navigation", { name: "Primary navigation" });
+
+    // Sidebar navigation is a plain <Link>; the global guard intercepts it via
+    // onNavigate while any editor is dirty. (This is the gap #370's local guard
+    // couldn't see.)
+    await nav.getByRole("link", { name: "Timelines" }).click();
+    const confirm = page.getByRole("dialog", {
+      name: "Discard unsaved changes?",
+    });
+    await expect(confirm).toBeVisible();
+
+    // Keep editing → stay put on the category edit route with the edit intact.
+    await confirm.getByRole("button", { name: "Keep editing" }).click();
+    await expect(confirm).toBeHidden();
+    await expect(page).toHaveURL(/\/categories\/[0-9a-f-]{36}$/);
+    await expect(page.getByPlaceholder(TITLE_PLACEHOLDER)).toHaveValue(
+      `${title} UNSAVED`,
+    );
+
+    // Retry and Discard → the sidebar navigation proceeds.
+    await nav.getByRole("link", { name: "Timelines" }).click();
+    await page
+      .getByRole("dialog", { name: "Discard unsaved changes?" })
+      .getByRole("button", { name: "Discard" })
+      .click();
+    await expect(page).toHaveURL(/\/timelines$/);
+
+    // Clean up: the edit was discarded, so the node keeps its saved title.
+    await page.goto("/categories");
+    await treeItem(page, title).click();
+    const del = await openDeleteDialog(page);
+    await del.getByRole("button", { name: "Delete", exact: true }).click();
+    await page.waitForURL("**/categories");
+    await expect(treeItem(page, title)).toHaveCount(0);
+
+    expect(renderErrors).toEqual([]);
+  });
 });

--- a/apps/admin/lib/use-register-unsaved-changes.test.tsx
+++ b/apps/admin/lib/use-register-unsaved-changes.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useUiStore } from "@repo/ui/stores";
+import { useRegisterUnsavedChanges } from "./use-register-unsaved-changes";
+
+beforeEach(() => {
+  useUiStore.setState({
+    dirtyEditors: new Set<string>(),
+    pendingNavigation: null,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useRegisterUnsavedChanges", () => {
+  it("registers a dirty editor on mount", () => {
+    renderHook(() => useRegisterUnsavedChanges(true));
+    expect(useUiStore.getState().dirtyEditors.size).toBe(1);
+  });
+
+  it("does not register a clean editor", () => {
+    renderHook(() => useRegisterUnsavedChanges(false));
+    expect(useUiStore.getState().dirtyEditors.size).toBe(0);
+  });
+
+  it("clears its registration on unmount", () => {
+    const { unmount } = renderHook(() => useRegisterUnsavedChanges(true));
+    expect(useUiStore.getState().dirtyEditors.size).toBe(1);
+    unmount();
+    expect(useUiStore.getState().dirtyEditors.size).toBe(0);
+  });
+
+  it("tracks changes to the dirty flag", () => {
+    const { rerender } = renderHook(
+      ({ dirty }) => useRegisterUnsavedChanges(dirty),
+      { initialProps: { dirty: false } },
+    );
+    expect(useUiStore.getState().dirtyEditors.size).toBe(0);
+    rerender({ dirty: true });
+    expect(useUiStore.getState().dirtyEditors.size).toBe(1);
+    rerender({ dirty: false });
+    expect(useUiStore.getState().dirtyEditors.size).toBe(0);
+  });
+
+  it("ref-counts overlapping editors under distinct ids", () => {
+    const first = renderHook(() => useRegisterUnsavedChanges(true));
+    renderHook(() => useRegisterUnsavedChanges(true));
+    expect(useUiStore.getState().dirtyEditors.size).toBe(2);
+    // Unmounting one editor leaves the other still registered.
+    first.unmount();
+    expect(useUiStore.getState().dirtyEditors.size).toBe(1);
+  });
+
+  it("adds a beforeunload listener only while dirty", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+
+    const { rerender, unmount } = renderHook(
+      ({ dirty }) => useRegisterUnsavedChanges(dirty),
+      { initialProps: { dirty: true } },
+    );
+    expect(add).toHaveBeenCalledWith("beforeunload", expect.any(Function));
+
+    // Going clean removes the listener.
+    rerender({ dirty: false });
+    expect(remove).toHaveBeenCalledWith("beforeunload", expect.any(Function));
+
+    unmount();
+  });
+
+  it("beforeunload handler cancels the event (native prompt)", () => {
+    renderHook(() => useRegisterUnsavedChanges(true));
+    const event = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/apps/admin/lib/use-register-unsaved-changes.ts
+++ b/apps/admin/lib/use-register-unsaved-changes.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { useUiStore } from "@repo/ui/stores";
+
+/**
+ * Registers an editor's dirty state with the global unsaved-changes registry so
+ * the app shell can guard navigation away from it. Complements the per-editor
+ * `useUnsavedChangesGuard`, which covers caller-controlled in-app navigation
+ * (Cancel/breadcrumbs, category tree-node / "New category"); this hook covers
+ * the app-shell surfaces those can't see — sidebar, quick-create, breadcrumbs —
+ * via `ShellLink`'s `onNavigate` interception plus one app-level discard dialog
+ * in `ProtectedShell`.
+ *
+ * Also owns the `beforeunload` backstop (reload / tab close / external link), so
+ * hard-navigation coverage lives in one place. Every editor that opts into the
+ * shell guard gets it for free.
+ *
+ * The registry is keyed by a stable `useId`, so overlapping mounts / route
+ * transitions ref-count correctly rather than one editor clobbering another's flag.
+ */
+export function useRegisterUnsavedChanges(isDirty: boolean): void {
+  const id = React.useId();
+  const setEditorDirty = useUiStore((s) => s.setEditorDirty);
+
+  React.useEffect(() => {
+    setEditorDirty(id, isDirty);
+    // Clear on unmount so navigating away from the editor disarms the guard.
+    return () => setEditorDirty(id, false);
+  }, [id, isDirty, setEditorDirty]);
+
+  React.useEffect(() => {
+    if (!isDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // Required for Chrome to show the native prompt.
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+}

--- a/apps/admin/lib/use-unsaved-changes-guard.ts
+++ b/apps/admin/lib/use-unsaved-changes-guard.ts
@@ -4,38 +4,23 @@ import * as React from "react";
 import { useRouter } from "next/navigation";
 
 /**
- * Guards a dirty form against accidental navigation loss. Shared by every
- * editor (timeline, event, period, story, character, and the category
- * manager shell).
+ * Guards a dirty form against loss from **caller-controlled** in-app navigation:
+ * Cancel/breadcrumb buttons and — in the category manager — switching tree nodes
+ * and "New category". Call `requestNavigate(href)` instead of `router.push`; when
+ * dirty it defers the push and exposes `isConfirmOpen` so the caller can render a
+ * confirm dialog, completing the navigation on confirm. Shared by every editor
+ * (timeline, event, period, story, character, and the category manager shell).
  *
- * Two surfaces are covered:
- *  - **Hard navigation** (reload / tab close / external link): a `beforeunload`
- *    listener triggers the browser's native confirmation while `isDirty`.
- *  - **In-app navigation** the caller controls (Cancel/breadcrumbs, or — in the
- *    category manager — switching tree nodes and "New category"): call
- *    `requestNavigate(href)` instead of `router.push`. When dirty it defers the
- *    push and exposes `isConfirmOpen` so the caller can render a confirm dialog;
- *    on confirm it completes the navigation.
- *
- * NOTE: the App Router has no stable API to intercept arbitrary in-app
- * navigation (e.g. clicking a sidebar link), so only the surfaces routed
- * through `requestNavigate` are guarded in-app; `beforeunload` is the backstop
- * for everything else.
+ * The other two surfaces are covered elsewhere by `useRegisterUnsavedChanges`
+ * (`lib/use-register-unsaved-changes.ts`), which every editor also calls:
+ *  - **App-shell navigation** (sidebar, quick-create, breadcrumbs) — intercepted
+ *    globally via `ShellLink`'s `onNavigate` + one app-level discard dialog.
+ *  - **Hard navigation** (reload / tab close / external link) — the `beforeunload`
+ *    backstop now lives in that hook so hard-nav coverage is in one place.
  */
 export function useUnsavedChangesGuard(isDirty: boolean) {
   const router = useRouter();
   const [pendingHref, setPendingHref] = React.useState<string | null>(null);
-
-  React.useEffect(() => {
-    if (!isDirty) return;
-    const handler = (event: BeforeUnloadEvent) => {
-      event.preventDefault();
-      // Required for Chrome to show the native prompt.
-      event.returnValue = "";
-    };
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, [isDirty]);
 
   const requestNavigate = React.useCallback(
     (href: string) => {

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -8,13 +8,19 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
-    include: ["app/**/*.test.{ts,tsx}"],
+    include: [
+      "app/**/*.test.{ts,tsx}",
+      "lib/**/*.test.{ts,tsx}",
+      "components/**/*.test.{ts,tsx}",
+    ],
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],
       // Scope to files that have tests (ADR-0026: no coverage theater on
       // untested app boilerplate). Expand this list as app test coverage grows.
       include: [
+        "lib/use-register-unsaved-changes.ts",
+        "components/shell-link.tsx",
         "app/**/_components/media/attach-media-dialog.tsx",
         "app/**/_components/media/media-library.tsx",
         "app/**/_components/media/media-section.tsx",

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,44 +36,45 @@ model); the next new ADR is the next free number (`0029` onward), per the
 
 ## Index
 
-| #                                                          | Title                                                                           | Status           | Supersedes / Superseded by                 |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
-| [0001](adr-0001-supabase-backend-platform.md)              | Supabase as the backend platform                                                | Accepted (retro) | —                                          |
-| [0002](adr-0002-pnpm-turborepo-monorepo.md)                | pnpm + Turborepo monorepo                                                       | Accepted (retro) | —                                          |
-| [0003](adr-0003-nextjs-app-router-react19.md)              | Next.js 16 App Router + React 19, split apps                                    | Accepted (retro) | —                                          |
-| [0004](adr-0004-engineering-standards.md)                  | Engineering standards (strict TS, zero-warning, ESM)                            | Accepted (retro) | —                                          |
-| [0005](adr-0005-hybrid-temporal-system.md)                 | Hybrid temporal system (JSONB + generated sort columns)                         | Accepted (retro) | —                                          |
-| [0006](adr-0006-fractal-timeline-detail-timeline.md)       | Fractal timeline via forward `detail_timeline_id`                               | Accepted (retro) | supersedes prior `parent_event_id`† (#180) |
-| [0007](adr-0007-seven-character-types.md)                  | Seven character types + type-specific columns                                   | Accepted (retro) | —                                          |
-| [0008](adr-0008-character-relationships-directed-pairs.md) | Character relationships as directed pairs                                       | Accepted (retro) | amended by 0009                            |
-| [0009](adr-0009-relationship-sub-role-taxonomy.md)         | Relationship sub-role taxonomy (`relationship_role`)                            | Accepted (retro) | amends 0008 (#119)                         |
-| [0010](adr-0010-junction-table-conventions.md)             | Junction tables: composite PK, no surrogate id/user_id                          | Accepted (retro) | —                                          |
-| [0011](adr-0011-publication-model.md)                      | Publication model: `published` boolean + `published_at`                         | Accepted (retro) | —                                          |
-| [0012](adr-0012-postgrest-crud-thin-service-layer.md)      | PostgREST for all CRUD + thin TS service layer                                  | Accepted (retro) | —                                          |
-| [0013](adr-0013-db-functions-read-only.md)                 | DB functions reserved for complex read-only queries                             | Accepted (retro) | —                                          |
-| [0014](adr-0014-rls-single-source-of-authorization.md)     | RLS as the single source of authorization                                       | Accepted (retro) | —                                          |
-| [0015](adr-0015-rls-and-function-hardening.md)             | RLS + function hardening (DEFINER, search_path, perf)                           | Accepted (retro) | —                                          |
-| [0016](adr-0016-storage-buckets-graduated-access.md)       | Storage buckets with graduated access control                                   | Accepted (retro) | —                                          |
-| [0017](adr-0017-auth-bootstrap-supporting-tables.md)       | Auth bootstrap (profile trigger, is_admin) + supporting                         | Accepted (retro) | —                                          |
-| [0018](adr-0018-curated-content-library.md)                | Curated content library (admin-owned + import)                                  | Accepted (retro) | —                                          |
-| [0019](adr-0019-services-package.md)                       | `@repo/services` package (clients, schemas, modules)                            | Accepted (retro) | —                                          |
-| [0020](adr-0020-ui-package-shadcn-tailwind.md)             | `@repo/ui` on shadcn/ui + Tailwind 4                                            | Accepted (retro) | —                                          |
-| [0021](adr-0021-tanstack-query-zustand.md)                 | TanStack Query (server) + Zustand (client) state                                | Accepted (retro) | —                                          |
-| [0022](adr-0022-design-tokens-dual-source.md)              | Design tokens dual TS/CSS source + OKLCH + lucide                               | Accepted (retro) | —                                          |
-| [0023](adr-0023-dark-mode-only-fidelity-2.md)              | Dark-mode-only for fidelity-2 (light mode deferred)                             | Accepted (retro) | —                                          |
-| [0024](adr-0024-accessibility-first-visual-language.md)    | Accessibility-first visual language                                             | Accepted (retro) | —                                          |
-| [0025](adr-0025-shared-mediapicker-bespoke-tree.md)        | `MediaPicker` shared primitive; bespoke `Tree` only                             | Accepted (retro) | —                                          |
-| [0026](adr-0026-testing-strategy.md)                       | Testing strategy: pgTAP + Vitest 80% + Storybook                                | Accepted (retro) | —                                          |
-| [0027](adr-0027-upstream-spec-bug-protocol.md)             | Upstream-spec-bug + PRD-reconciliation protocol                                 | Accepted (retro) | —                                          |
-| [0028](adr-0028-period-span-overlay-and-hierarchy-axes.md) | Period span-overlays; period/category hierarchy axes                            | Accepted         | —                                          |
-| [0029](adr-0029-public-reader-route-scheme.md)             | Public reader entity reference scheme (`/:username/:type/:slug`)                | Accepted         | —                                          |
-| [0030](adr-0030-public-reader-app-placement.md)            | Public reader lives in dedicated `apps/reader` Next.js app                      | Accepted         | Amends 0003                                |
-| [0031](adr-0031-public-reader-design-divergence.md)        | Public reader design divergence (shared tokens, divergent motion + composition) | Accepted         | —                                          |
-| [0032](adr-0032-public-reader-motion-tokens.md)            | Public reader motion-token scale (durations, easing, reduced-motion contract)   | Accepted         | —                                          |
-| [0033](adr-0033-reader-shell-composites-in-ui-package.md)  | Reader shell composites live in `@repo/ui` (`reader-*`); apps/reader holds glue | Accepted         | —                                          |
-| [0034](adr-0034-api-role-table-grants.md)                  | Explicit table GRANTs for API roles (anon read, authenticated DML, svc all)     | Accepted         | —                                          |
-| [0035](adr-0035-list-filter-rail-placement.md)             | List-page filter rail on the right (nav → content → filters)                    | Accepted         | —                                          |
-| [0036](adr-0036-e2e-testing-strategy.md)                   | E2E strategy: Playwright, local-first, off the PR gate; smoke deferred          | Accepted         | —                                          |
+| #                                                          | Title                                                                            | Status           | Supersedes / Superseded by                 |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
+| [0001](adr-0001-supabase-backend-platform.md)              | Supabase as the backend platform                                                 | Accepted (retro) | —                                          |
+| [0002](adr-0002-pnpm-turborepo-monorepo.md)                | pnpm + Turborepo monorepo                                                        | Accepted (retro) | —                                          |
+| [0003](adr-0003-nextjs-app-router-react19.md)              | Next.js 16 App Router + React 19, split apps                                     | Accepted (retro) | —                                          |
+| [0004](adr-0004-engineering-standards.md)                  | Engineering standards (strict TS, zero-warning, ESM)                             | Accepted (retro) | —                                          |
+| [0005](adr-0005-hybrid-temporal-system.md)                 | Hybrid temporal system (JSONB + generated sort columns)                          | Accepted (retro) | —                                          |
+| [0006](adr-0006-fractal-timeline-detail-timeline.md)       | Fractal timeline via forward `detail_timeline_id`                                | Accepted (retro) | supersedes prior `parent_event_id`† (#180) |
+| [0007](adr-0007-seven-character-types.md)                  | Seven character types + type-specific columns                                    | Accepted (retro) | —                                          |
+| [0008](adr-0008-character-relationships-directed-pairs.md) | Character relationships as directed pairs                                        | Accepted (retro) | amended by 0009                            |
+| [0009](adr-0009-relationship-sub-role-taxonomy.md)         | Relationship sub-role taxonomy (`relationship_role`)                             | Accepted (retro) | amends 0008 (#119)                         |
+| [0010](adr-0010-junction-table-conventions.md)             | Junction tables: composite PK, no surrogate id/user_id                           | Accepted (retro) | —                                          |
+| [0011](adr-0011-publication-model.md)                      | Publication model: `published` boolean + `published_at`                          | Accepted (retro) | —                                          |
+| [0012](adr-0012-postgrest-crud-thin-service-layer.md)      | PostgREST for all CRUD + thin TS service layer                                   | Accepted (retro) | —                                          |
+| [0013](adr-0013-db-functions-read-only.md)                 | DB functions reserved for complex read-only queries                              | Accepted (retro) | —                                          |
+| [0014](adr-0014-rls-single-source-of-authorization.md)     | RLS as the single source of authorization                                        | Accepted (retro) | —                                          |
+| [0015](adr-0015-rls-and-function-hardening.md)             | RLS + function hardening (DEFINER, search_path, perf)                            | Accepted (retro) | —                                          |
+| [0016](adr-0016-storage-buckets-graduated-access.md)       | Storage buckets with graduated access control                                    | Accepted (retro) | —                                          |
+| [0017](adr-0017-auth-bootstrap-supporting-tables.md)       | Auth bootstrap (profile trigger, is_admin) + supporting                          | Accepted (retro) | —                                          |
+| [0018](adr-0018-curated-content-library.md)                | Curated content library (admin-owned + import)                                   | Accepted (retro) | —                                          |
+| [0019](adr-0019-services-package.md)                       | `@repo/services` package (clients, schemas, modules)                             | Accepted (retro) | —                                          |
+| [0020](adr-0020-ui-package-shadcn-tailwind.md)             | `@repo/ui` on shadcn/ui + Tailwind 4                                             | Accepted (retro) | —                                          |
+| [0021](adr-0021-tanstack-query-zustand.md)                 | TanStack Query (server) + Zustand (client) state                                 | Accepted (retro) | —                                          |
+| [0022](adr-0022-design-tokens-dual-source.md)              | Design tokens dual TS/CSS source + OKLCH + lucide                                | Accepted (retro) | —                                          |
+| [0023](adr-0023-dark-mode-only-fidelity-2.md)              | Dark-mode-only for fidelity-2 (light mode deferred)                              | Accepted (retro) | —                                          |
+| [0024](adr-0024-accessibility-first-visual-language.md)    | Accessibility-first visual language                                              | Accepted (retro) | —                                          |
+| [0025](adr-0025-shared-mediapicker-bespoke-tree.md)        | `MediaPicker` shared primitive; bespoke `Tree` only                              | Accepted (retro) | —                                          |
+| [0026](adr-0026-testing-strategy.md)                       | Testing strategy: pgTAP + Vitest 80% + Storybook                                 | Accepted (retro) | —                                          |
+| [0027](adr-0027-upstream-spec-bug-protocol.md)             | Upstream-spec-bug + PRD-reconciliation protocol                                  | Accepted (retro) | —                                          |
+| [0028](adr-0028-period-span-overlay-and-hierarchy-axes.md) | Period span-overlays; period/category hierarchy axes                             | Accepted         | —                                          |
+| [0029](adr-0029-public-reader-route-scheme.md)             | Public reader entity reference scheme (`/:username/:type/:slug`)                 | Accepted         | —                                          |
+| [0030](adr-0030-public-reader-app-placement.md)            | Public reader lives in dedicated `apps/reader` Next.js app                       | Accepted         | Amends 0003                                |
+| [0031](adr-0031-public-reader-design-divergence.md)        | Public reader design divergence (shared tokens, divergent motion + composition)  | Accepted         | —                                          |
+| [0032](adr-0032-public-reader-motion-tokens.md)            | Public reader motion-token scale (durations, easing, reduced-motion contract)    | Accepted         | —                                          |
+| [0033](adr-0033-reader-shell-composites-in-ui-package.md)  | Reader shell composites live in `@repo/ui` (`reader-*`); apps/reader holds glue  | Accepted         | —                                          |
+| [0034](adr-0034-api-role-table-grants.md)                  | Explicit table GRANTs for API roles (anon read, authenticated DML, svc all)      | Accepted         | —                                          |
+| [0035](adr-0035-list-filter-rail-placement.md)             | List-page filter rail on the right (nav → content → filters)                     | Accepted         | —                                          |
+| [0036](adr-0036-e2e-testing-strategy.md)                   | E2E strategy: Playwright, local-first, off the PR gate; smoke deferred           | Accepted         | —                                          |
+| [0037](adr-0037-global-unsaved-changes-shell-guard.md)     | Global unsaved-changes guard for app-shell nav (`onNavigate` + Zustand registry) | Accepted         | —                                          |
 
 † ADR `0006` supersedes the original event-to-event `parent_event_id` nesting
 approach, which was never given its own ADR; it is documented inside `0006` as

--- a/docs/adr/adr-0037-global-unsaved-changes-shell-guard.md
+++ b/docs/adr/adr-0037-global-unsaved-changes-shell-guard.md
@@ -1,0 +1,128 @@
+---
+title: "ADR-0037: Global unsaved-changes guard for app-shell navigation"
+status: "Accepted"
+date: "2026-07-10"
+authors: "Admin app team"
+tags: ["architecture", "decision", "frontend", "state-management"]
+supersedes: ""
+superseded_by: ""
+amends: ""
+amended_by: ""
+---
+
+# ADR-0037: Global unsaved-changes guard for app-shell navigation
+
+## Status
+
+**Accepted**
+
+## Context
+
+Every admin editor (timeline, event, period, story, character, and the category
+inspector) warns before losing unsaved edits — but the shared
+`useUnsavedChangesGuard` (`apps/admin/lib/use-unsaved-changes-guard.ts`) only
+intercepts navigations a caller explicitly routes through `requestNavigate(...)`,
+plus a `beforeunload` backstop for hard navigation. That covers the editor's own
+Cancel/breadcrumb controls and the category manager's tree-node / "New category"
+navigations (ADR-context #370), but **not** navigation through the app shell:
+the sidebar, the topbar quick-create menu, and the header breadcrumbs. Those
+render `<Link>`s whose clicks never pass through `requestNavigate`, so unsaved
+edits were silently discarded across _every_ editor.
+
+The App Router historically had no supported API to intercept arbitrary in-app
+navigation, which is why the original guard punted on shell links. Two facts make
+this now tractable: (1) every shell nav surface renders through a single injected
+`LinkComponent` (`ShellLink`), so there is one choke point; and (2) Next 16's
+`<Link onNavigate>` fires on client-side navigation and can `preventDefault()` it —
+an official API, no monkeypatching `router.push`.
+
+## Decision
+
+Intercept shell navigation via `<Link onNavigate>`, backed by a global Zustand
+"is any editor dirty?" registry, resolved by a single app-level discard dialog.
+
+- **Global dirty registry** in `useUiStore` (`packages/ui/src/stores/ui-store.ts`):
+  `dirtyEditors: Set<string>` with `setEditorDirty(id, dirty)`, plus
+  `pendingNavigation: string | null` with `requestShellNavigate` /
+  `cancelShellNavigate` / `confirmShellNavigate`. Both fields are transient and
+  excluded from persistence. Keyed by a stable `useId` so overlapping mounts /
+  route transitions ref-count rather than clobber each other's flag.
+- **Shared registration hook** `useRegisterUnsavedChanges(isDirty)`
+  (`apps/admin/lib/use-register-unsaved-changes.ts`) syncs an editor's dirty
+  state into the registry and clears it on unmount. It also owns the
+  `beforeunload` backstop, so hard-navigation coverage lives in one place. Every
+  editor calls it: the five form-clients pass `form.formState.isDirty`; the
+  category manager shell passes the `isDirty` it already receives from the
+  inspector via `editor-guard-context`.
+- **`ShellLink` interception**: reads `dirtyEditors.size > 0` from the store and
+  adds `onNavigate={(e) => { if (dirty) { e.preventDefault(); requestShellNavigate(href); } }}`.
+  Self-contained in the app-layer adapter — `packages/ui/src/components/shell.tsx`
+  is untouched.
+- **One app-level discard dialog** in `ProtectedShell`, driven by
+  `pendingNavigation`: _Keep editing_ cancels; _Discard_ clears the registry and
+  performs `router.push(pendingNavigation)`. The push happens in the event
+  handler, never inside a state updater (see NEG-002).
+
+The local `useUnsavedChangesGuard` is **retained** for the surfaces `onNavigate`
+can't see: in-editor Cancel/breadcrumb controls and the category manager's
+tree-node / "New category" navigations (those are `router.push`, not `<Link>`).
+The two mechanisms are complementary; the single global dialog and the per-editor
+local dialogs never both fire for one click.
+
+## Consequences
+
+### Positive
+
+- **POS-001**: Closes the shell-navigation hole for all editors at once, at a
+  single choke point, with no per-editor duplication.
+- **POS-002**: Uses an official Next API (`onNavigate`) rather than monkeypatching
+  the router or the DOM — robust across Next internal changes.
+- **POS-003**: The dirty registry is a reusable global-state primitive; new nav
+  surfaces are covered for free as long as they route through `ShellLink`.
+
+### Negative
+
+- **NEG-001**: Browser back/forward (popstate) remains **unguarded** —
+  `onNavigate` does not fire for it and the App Router still has no supported
+  popstate-blocking API; `beforeunload` doesn't cover SPA popstate either. A
+  `history.pushState` sentinel hack is possible but fragile and out of scope.
+  Accepted limitation.
+- **NEG-002**: The confirm path must `router.push` in the event handler, not in a
+  Zustand updater (an updater runs during render; navigating there triggers a
+  Router update mid-render — the regression fixed in 83c95e3). Encoded as a
+  convention, guarded by the e2e console-error assertion.
+
+## Alternatives Considered
+
+### B — Monkeypatch `router.push` / global click interception on `document`
+
+- **ALT-001**: **Description**: Wrap the router or capture link clicks at the
+  document level to detect navigation.
+- **ALT-002**: **Rejection Reason**: Fragile, fights the framework, breaks on
+  Next internals. Rejected in favour of the official `onNavigate` API.
+
+### C — Per-editor duplication of shell-link handling
+
+- **ALT-003**: **Description**: Each editor handles shell links itself.
+- **ALT-004**: **Rejection Reason**: Doesn't centralize; every new nav surface
+  reopens the gap. Rejected.
+
+## Implementation Notes
+
+- **IMP-001**: `setEditorDirty` rebuilds the `Set` on each change so the reference
+  changes and Zustand subscribers re-render.
+- **IMP-002**: Coverage after this change — sidebar, quick-create, breadcrumbs,
+  in-editor Cancel/breadcrumb, category tree-node / New category, and
+  reload/tab-close are all guarded; only popstate is not.
+- **IMP-003**: Verified by unit tests (registry reducer, registration hook,
+  `ShellLink`) and an e2e spec that makes an editor dirty, clicks a sidebar link,
+  and asserts the dialog plus the "no push during render" console-error regression.
+
+## References
+
+- **REF-001**: #371 (this decision), #370 (per-editor guard + category editor guard).
+- **REF-002**: `apps/admin/lib/use-unsaved-changes-guard.ts`,
+  `apps/admin/lib/use-register-unsaved-changes.ts`,
+  `packages/ui/src/stores/ui-store.ts`, `apps/admin/components/shell-link.tsx`.
+- **REF-003**: ADR-0021 (TanStack Query + Zustand state split); commit 83c95e3
+  (render-phase `setState` fix).

--- a/docs/adr/adr-0037-global-unsaved-changes-shell-guard.md
+++ b/docs/adr/adr-0037-global-unsaved-changes-shell-guard.md
@@ -61,7 +61,7 @@ Intercept shell navigation via `<Link onNavigate>`, backed by a global Zustand
 - **One app-level discard dialog** in `ProtectedShell`, driven by
   `pendingNavigation`: _Keep editing_ cancels; _Discard_ clears the registry and
   performs `router.push(pendingNavigation)`. The push happens in the event
-  handler, never inside a state updater (see NEG-002).
+  handler, never inside a state updater (see NEG-003).
 
 The local `useUnsavedChangesGuard` is **retained** for the surfaces `onNavigate`
 can't see: in-editor Cancel/breadcrumb controls and the category manager's
@@ -82,12 +82,46 @@ local dialogs never both fire for one click.
 
 ### Negative
 
-- **NEG-001**: Browser back/forward (popstate) remains **unguarded** —
-  `onNavigate` does not fire for it and the App Router still has no supported
-  popstate-blocking API; `beforeunload` doesn't cover SPA popstate either. A
-  `history.pushState` sentinel hack is possible but fragile and out of scope.
-  Accepted limitation.
-- **NEG-002**: The confirm path must `router.push` in the event handler, not in a
+- **NEG-001**: Browser back/forward (popstate) remains **unguarded** — accepted
+  limitation, confirmed by a real attempted fix and rollback, not just a
+  theoretical gap. `onNavigate` does not fire for `popstate`, and the App
+  Router exposes no supported popstate-blocking API, so the only known
+  technique is a `history.pushState` "sentinel" entry: push a dummy entry
+  while dirty, so the first Back press pops it instead of leaving, giving a
+  chance to show a confirm dialog. **This was implemented, tested against Next
+  16.2.10 (Turbopack), and reverted** after it reproducibly broke Next's own
+  client-side navigation: with the sentinel armed (any editor merely dirty —
+  no Back press needed), a normal Save-and-redirect stopped completing. Network
+  evidence showed the save mutation succeeding (`POST .../categories` → 201)
+  and Next fetching the destination route's RSC payload (200), but the
+  `router.push()` call itself never committed — the URL and `history.length`
+  stayed unchanged. Reproduced 3× deterministically on a freshly restarted,
+  fully warm dev server (ruling out compile-time/HMR races), with and without
+  merging the sentinel into the existing `history.state` object rather than
+  replacing it (Next stores its own internal router bookkeeping — route cache,
+  scroll restoration — in `history.state`; even a careful merge didn't avoid
+  the corruption). Root cause not fully diagnosed beyond that: Next's App
+  Router evidently keeps additional navigation bookkeeping that a
+  same-frame `window.history.pushState()` call desyncs, regardless of care
+  taken with the `state` payload. **This is a routing-internals conflict, not
+  an edge case in our own code** — no variant of directly calling the History
+  API from application code was found safe against this Next version. A future
+  attempt should first verify against the Next version in use at that time,
+  since this depends on undocumented App Router internals that can change
+  across releases.
+- **NEG-002**: Reload, tab close, and browser close are **not** part of the
+  NEG-001 gap — they're covered by the existing `beforeunload` backstop
+  (`useRegisterUnsavedChanges`), confirmed working: the native dialog fires and
+  reliably blocks the reload when declined. `beforeunload` fires on all three
+  (they're the same underlying browser event) and doesn't touch the History
+  API, so it's unaffected by the NEG-001 finding. Two browser-level caveats
+  apply regardless of our implementation: the dialog's text can't be
+  customized (always the browser's generic message), and Chrome requires
+  "sticky user activation" (a prior real interaction with the page) for the
+  dialog to fire at all — a page where the user never clicked/typed before
+  attempting to close it may not show it. Neither is something application
+  code can work around.
+- **NEG-003**: The confirm path must `router.push` in the event handler, not in a
   Zustand updater (an updater runs during render; navigating there triggers a
   Router update mid-render — the regression fixed in 83c95e3). Encoded as a
   convention, guarded by the e2e console-error assertion.
@@ -107,16 +141,61 @@ local dialogs never both fire for one click.
 - **ALT-004**: **Rejection Reason**: Doesn't centralize; every new nav surface
   reopens the gap. Rejected.
 
+### D — `history.pushState` sentinel entry for popstate (attempted, reverted)
+
+- **ALT-005**: **Description**: While any editor is dirty, push one extra
+  history entry at the current URL (merging into, not replacing, Next's
+  existing `history.state`). The first Back press pops the sentinel — same URL,
+  so Next's router has nothing to reconcile — which is the chance to show the
+  same discard dialog before a second, real Back is let through. Implemented as
+  `apps/admin/lib/use-popstate-guard.ts`, mounted once in `ProtectedShell`,
+  reusing the existing dirty registry and dialog.
+- **ALT-006**: **Rejection Reason**: Confirmed broken against Next 16.2.10 —
+  see NEG-001 for the reproducible evidence (a normal Save-and-redirect stops
+  completing the moment the sentinel is armed, independent of any Back press).
+  Not a theoretical fragility judgment; an observed regression. Reverted in
+  full before merge; no trace remains in shipped code.
+
+### E — Popstate `confirm()` + monkeypatched `router.push` (proposed externally, not attempted)
+
+- **ALT-007**: **Description**: A commonly-suggested pattern — on `popstate`,
+  call blocking `window.confirm()` and, if declined, call
+  `history.pushState(null, "", location.href)` to "undo" the Back; separately,
+  reassign `router.push` on the object returned by `useRouter()` to gate
+  programmatic navigation behind the same `confirm()`.
+- **ALT-008**: **Rejection Reason**: Two independent problems, neither novel to
+  this ADR. First, its `router.push` override is Alternative B (ALT-001/002)
+  restated — reassigning a method on a hook-returned object doesn't reliably
+  intercept navigation Next itself triggers internally (e.g. via `<Link>`,
+  form actions, `router.refresh()`), and mutating that object at all is
+  unsupported by the App Router's public API. Second, its popstate handler
+  calls `history.pushState(null, "", url)` — replacing `history.state` with
+  `null` outright rather than merging it — which is strictly more destructive
+  to Next's internal bookkeeping than the merged-state variant already
+  disproven in ALT-006, and would be expected to reproduce the same failure
+  (or worse). Its own documented caveats (a visible URL "flicker," and no
+  guaranteed ordering between its listener and Next's internal popstate
+  listener) are the same listener-ordering race NEG-001 already identified.
+  Not attempted, given ALT-006's direct evidence that the underlying technique
+  — an application calling the History API directly alongside Next's App
+  Router — doesn't hold up.
+
 ## Implementation Notes
 
-- **IMP-001**: `setEditorDirty` rebuilds the `Set` on each change so the reference
-  changes and Zustand subscribers re-render.
+- **IMP-001**: `setEditorDirty` reads the `set()` updater's own `state`
+  argument (not the outer `get()`) to build the new `Set`, and no-ops —
+  skipping the rebuild and the subscriber notification — when the requested
+  flag already matches, so idempotent calls are free.
 - **IMP-002**: Coverage after this change — sidebar, quick-create, breadcrumbs,
   in-editor Cancel/breadcrumb, category tree-node / New category, and
-  reload/tab-close are all guarded; only popstate is not.
+  reload/tab-close/browser-close are all guarded; only popstate (Back/Forward)
+  is not, and is expected to remain so (see NEG-001/ALT-006, NEG-002).
 - **IMP-003**: Verified by unit tests (registry reducer, registration hook,
   `ShellLink`) and an e2e spec that makes an editor dirty, clicks a sidebar link,
   and asserts the dialog plus the "no push during render" console-error regression.
+  The `beforeunload` reload/close path was separately confirmed via a live
+  Playwright run observing the native dialog fire and block the reload (see
+  NEG-002).
 
 ## References
 

--- a/packages/ui/src/stores/ui-store.test.ts
+++ b/packages/ui/src/stores/ui-store.test.ts
@@ -9,6 +9,8 @@ beforeEach(() => {
     activeModal: null,
     modalData: {},
     toasts: [],
+    dirtyEditors: new Set<string>(),
+    pendingNavigation: null,
   });
 });
 
@@ -177,6 +179,67 @@ describe("removeToast", () => {
   });
 });
 
+describe("setEditorDirty", () => {
+  it("registers a dirty editor by id", () => {
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    expect(useUiStore.getState().dirtyEditors.has("editor-a")).toBe(true);
+  });
+
+  it("ref-counts across editors — clearing one keeps others dirty", () => {
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    useUiStore.getState().setEditorDirty("editor-b", true);
+    expect(useUiStore.getState().dirtyEditors.size).toBe(2);
+
+    useUiStore.getState().setEditorDirty("editor-a", false);
+    const { dirtyEditors } = useUiStore.getState();
+    expect(dirtyEditors.has("editor-a")).toBe(false);
+    expect(dirtyEditors.has("editor-b")).toBe(true);
+    expect(dirtyEditors.size).toBe(1);
+  });
+
+  it("clearing the last dirty editor empties the set", () => {
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    useUiStore.getState().setEditorDirty("editor-a", false);
+    expect(useUiStore.getState().dirtyEditors.size).toBe(0);
+  });
+
+  it("produces a new Set reference so subscribers re-render", () => {
+    const before = useUiStore.getState().dirtyEditors;
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    expect(useUiStore.getState().dirtyEditors).not.toBe(before);
+  });
+
+  it("registering the same id twice is idempotent", () => {
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    expect(useUiStore.getState().dirtyEditors.size).toBe(1);
+  });
+});
+
+describe("shell navigation guard", () => {
+  it("requestShellNavigate stashes the pending href", () => {
+    useUiStore.getState().requestShellNavigate("/characters");
+    expect(useUiStore.getState().pendingNavigation).toBe("/characters");
+  });
+
+  it("cancelShellNavigate clears the pending href without touching dirty flags", () => {
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    useUiStore.getState().requestShellNavigate("/characters");
+    useUiStore.getState().cancelShellNavigate();
+    expect(useUiStore.getState().pendingNavigation).toBeNull();
+    expect(useUiStore.getState().dirtyEditors.has("editor-a")).toBe(true);
+  });
+
+  it("confirmShellNavigate clears both the pending href and all dirty flags", () => {
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    useUiStore.getState().setEditorDirty("editor-b", true);
+    useUiStore.getState().requestShellNavigate("/timelines");
+    useUiStore.getState().confirmShellNavigate();
+    expect(useUiStore.getState().pendingNavigation).toBeNull();
+    expect(useUiStore.getState().dirtyEditors.size).toBe(0);
+  });
+});
+
 describe("persist partialize", () => {
   it("only persists sidebarOpen and sidebarWidth", () => {
     useUiStore.getState().setSidebarWidth(360);
@@ -185,6 +248,8 @@ describe("persist partialize", () => {
     useUiStore
       .getState()
       .addToast({ id: "t-1", message: "hi", variant: "default" });
+    useUiStore.getState().setEditorDirty("editor-a", true);
+    useUiStore.getState().requestShellNavigate("/dashboard");
 
     const stored = useUiStore.persist
       .getOptions()
@@ -195,6 +260,8 @@ describe("persist partialize", () => {
     expect(stored).not.toHaveProperty("activeModal");
     expect(stored).not.toHaveProperty("modalData");
     expect(stored).not.toHaveProperty("toasts");
+    expect(stored).not.toHaveProperty("dirtyEditors");
+    expect(stored).not.toHaveProperty("pendingNavigation");
   });
 });
 
@@ -207,6 +274,8 @@ describe("UiState type completeness", () => {
       "activeModal",
       "modalData",
       "toasts",
+      "dirtyEditors",
+      "pendingNavigation",
     ];
     requiredKeys.forEach((key) => {
       expect(state).toHaveProperty(key);

--- a/packages/ui/src/stores/ui-store.ts
+++ b/packages/ui/src/stores/ui-store.ts
@@ -100,18 +100,23 @@ export const useUiStore = create<UiStore>()(
             "removeToast",
           ),
 
-        setEditorDirty: (id, dirty) =>
+        setEditorDirty: (id, dirty) => {
+          // No-op when the flag already matches: skips the Set rebuild and
+          // avoids notifying subscribers for an idempotent call.
+          if (get().dirtyEditors.has(id) === dirty) return;
           set(
-            () => {
-              // Rebuild the Set so the reference changes and subscribers re-render.
-              const next = new Set(get().dirtyEditors);
+            (state) => {
+              // Rebuild from the updater's `state` (not the outer `get()`) so the
+              // Set is derived from the snapshot `set` is actually applying.
+              const next = new Set(state.dirtyEditors);
               if (dirty) next.add(id);
               else next.delete(id);
               return { dirtyEditors: next };
             },
             false,
             "setEditorDirty",
-          ),
+          );
+        },
 
         requestShellNavigate: (href) =>
           set({ pendingNavigation: href }, false, "requestShellNavigate"),

--- a/packages/ui/src/stores/ui-store.ts
+++ b/packages/ui/src/stores/ui-store.ts
@@ -23,6 +23,14 @@ export interface UiState {
   modalData: Record<string, unknown>;
   /** Ordered queue of toast notifications. */
   toasts: Toast[];
+  /**
+   * Ids of mounted editors that currently have unsaved changes. Ref-counted so
+   * overlapping mounts / route transitions can't clobber each other's flag; any
+   * shell navigation is guarded while this is non-empty. Transient — never persisted.
+   */
+  dirtyEditors: Set<string>;
+  /** Href of a shell navigation deferred by the unsaved-changes guard, or null. */
+  pendingNavigation: string | null;
 }
 
 export interface UiActions {
@@ -38,6 +46,18 @@ export interface UiActions {
   addToast: (toast: Toast) => void;
   /** Remove a toast from the queue by id. */
   removeToast: (id: string) => void;
+  /** Register (or clear) an editor's dirty state by its stable id. */
+  setEditorDirty: (id: string, dirty: boolean) => void;
+  /** Defer a shell navigation, opening the app-level discard dialog. */
+  requestShellNavigate: (href: string) => void;
+  /** Dismiss the discard dialog and abandon the deferred navigation. */
+  cancelShellNavigate: () => void;
+  /**
+   * Accept the deferred navigation: clears all dirty flags and the pending href.
+   * Does NOT `router.push` — the caller performs the push in its event handler so
+   * navigation never happens inside a state updater (would run mid-render).
+   */
+  confirmShellNavigate: () => void;
 }
 
 export type UiStore = UiState & UiActions;
@@ -48,6 +68,8 @@ const INITIAL_STATE: UiState = {
   activeModal: null,
   modalData: {},
   toasts: [],
+  dirtyEditors: new Set<string>(),
+  pendingNavigation: null,
 };
 
 export const useUiStore = create<UiStore>()(
@@ -76,6 +98,32 @@ export const useUiStore = create<UiStore>()(
             { toasts: get().toasts.filter((t) => t.id !== id) },
             false,
             "removeToast",
+          ),
+
+        setEditorDirty: (id, dirty) =>
+          set(
+            () => {
+              // Rebuild the Set so the reference changes and subscribers re-render.
+              const next = new Set(get().dirtyEditors);
+              if (dirty) next.add(id);
+              else next.delete(id);
+              return { dirtyEditors: next };
+            },
+            false,
+            "setEditorDirty",
+          ),
+
+        requestShellNavigate: (href) =>
+          set({ pendingNavigation: href }, false, "requestShellNavigate"),
+
+        cancelShellNavigate: () =>
+          set({ pendingNavigation: null }, false, "cancelShellNavigate"),
+
+        confirmShellNavigate: () =>
+          set(
+            { pendingNavigation: null, dirtyEditors: new Set<string>() },
+            false,
+            "confirmShellNavigate",
           ),
       }),
       {


### PR DESCRIPTION
## What & why

Closes #371.

Every admin editor already warned before losing unsaved edits — but only for surfaces it controlled: its Cancel/breadcrumb buttons (via `requestNavigate`) and hard navigation (reload / tab close via `beforeunload`). Navigating away through the **app shell** — the sidebar, the topbar quick-create menu, or the header breadcrumbs — silently discarded edits in *every* editor, because those `<Link>` clicks never passed through the local `useUnsavedChangesGuard`.

This closes the hole centrally (approach A from the issue).

## Approach

Intercept shell navigation via Next 16 `<Link onNavigate>`, backed by a global Zustand "is any editor dirty?" registry, resolved by one app-level discard dialog. The per-editor `useUnsavedChangesGuard` is **retained** for the non-`<Link>` surfaces it already covered; the two mechanisms are complementary and never both fire for one click.

- **Global dirty registry** — `ui-store.ts`: `dirtyEditors: Set<string>` (ref-counted by `useId`) + `pendingNavigation`, with `setEditorDirty` / `requestShellNavigate` / `cancelShellNavigate` / `confirmShellNavigate`. Both fields are transient (excluded from `partialize`).
- **`useRegisterUnsavedChanges` hook** (new) — syncs each editor's `isDirty` into the registry, clears on unmount, and owns the `beforeunload` backstop (moved out of the local guard, so hard-nav coverage lives in one place). All six editors call it.
- **`ShellLink` interception** — `onNavigate` calls `preventDefault()` + `requestShellNavigate(href)` only when dirty. `packages/ui` untouched.
- **One app-level dialog** in `ProtectedShell`, driven by `pendingNavigation`. *Discard* pushes in the handler, never inside a state updater (the 83c95e3 render-phase rule).

## Coverage after this change

| Navigation surface | Before | After |
| --- | --- | --- |
| Reload / tab close | ✅ | ✅ |
| In-editor Cancel / breadcrumb | ✅ | ✅ |
| Category tree-node / New category | ✅ | ✅ |
| **Sidebar nav** | ❌ | ✅ |
| **Topbar quick-create** | ❌ | ✅ |
| **Header breadcrumbs** | ❌ | ✅ |
| Browser back/forward (popstate) | ❌ | ❌ (accepted limitation) |

**Residual limitation:** `onNavigate` doesn't fire for browser back/forward and the App Router still has no supported popstate-blocking API. Documented as accepted in [ADR-0037](docs/adr/adr-0037-global-unsaved-changes-shell-guard.md).

## Tests

- **Unit** — ui-store registry reducer (ref-counting, transitions, partialize; 100%); `useRegisterUnsavedChanges` (mount/unmount/ref-count/beforeunload); `ShellLink` (`preventDefault` + defer only when dirty).
- **e2e** — `category-crud.spec.ts`: dirty an editor, click a **sidebar** link → assert the discard dialog; *Keep editing* preserves the edit, *Discard* lands on the target route; reuses the "no push during render" console-error regression guard. Ran green locally.
- Full suite green: format · check-types · lint · test:coverage · build.

## ADR

[ADR-0037](docs/adr/adr-0037-global-unsaved-changes-shell-guard.md) added and indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)