### PR TITLE
chore: bump pending dependency updates

### DIFF
--- a/apps/reader/package.json
+++ b/apps/reader/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@repo/services": "workspace:^",
     "@repo/ui": "workspace:*",
-    "@tanstack/react-query": "^5.100.14",
+    "@tanstack/react-query": "^5.101.0",
     "next": "16.2.10",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.6.0",
     "jsdom": "^29.1.1",
-    "storybook": "^10.4.2",
+    "storybook": "^10.4.6",
     "tailwindcss": "^4.3.0",
     "typescript": "6.0.3",
     "vite": "^8.0.16",
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.4.0",
-    "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-alert-dialog": "^1.1.17",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.6",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,7 +303,7 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.76.1(react@19.2.7))
       '@radix-ui/react-alert-dialog':
-        specifier: ^1.1.15
+        specifier: ^1.1.17
         version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
@@ -439,7 +439,7 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@1.8.0)
       storybook:
-        specifier: ^10.4.2
+        specifier: ^10.4.6
         version: 10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwindcss:
         specifier: ^4.3.0
@@ -3717,8 +3717,8 @@ packages:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
     engines: {node: 20 || >=22}
 
-  lru-cache@11.5.1:
-    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -4176,19 +4176,19 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.4.6:
-    resolution: {integrity: sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==}
+  tldts-core@7.4.8:
+    resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
 
-  tldts@7.4.6:
-    resolution: {integrity: sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==}
+  tldts@7.4.8:
+    resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
     hasBin: true
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  tough-cookie@6.0.1:
-    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
 
   tr46@6.0.0:
@@ -7365,11 +7365,11 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.1
+      lru-cache: 11.5.2
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 6.0.1
+      tough-cookie: 6.0.2
       undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
@@ -7460,7 +7460,7 @@ snapshots:
 
   lru-cache@11.5.0: {}
 
-  lru-cache@11.5.1: {}
+  lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -7965,19 +7965,19 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tldts-core@7.4.6: {}
+  tldts-core@7.4.8: {}
 
-  tldts@7.4.6:
+  tldts@7.4.8:
     dependencies:
-      tldts-core: 7.4.6
+      tldts-core: 7.4.8
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
-  tough-cookie@6.0.1:
+  tough-cookie@6.0.2:
     dependencies:
-      tldts: 7.4.6
+      tldts: 7.4.8
 
   tr46@6.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,11 +15,9 @@ allowBuilds:
   sharp: true
 minimumReleaseAgeExclude:
   - js-yaml@4.1.1
-  - minimatch@3.1.3
-  - minimatch@3.1.4
+  - minimatch@3.1.3 || 3.1.4
   - ajv@6.14.0
-  - flatted@3.4.0
-  - flatted@3.4.2
+  - flatted@3.4.0 || 3.4.2
   - brace-expansion@1.1.13
   - postcss@8.5.10
   - esbuild@0.28.1


### PR DESCRIPTION
## What

Routine dependency bumps that were sitting uncommitted in the working tree, plus a follow-up `pnpm audit --fix update` pass.

**Direct bumps:**
- `@tanstack/react-query` `^5.100.14` → `^5.101.0` (`apps/reader`)
- `storybook` `^10.4.2` → `^10.4.6` (`packages/ui`)
- `@radix-ui/react-alert-dialog` `^1.1.15` → `^1.1.17` (`packages/ui`)
- `pnpm-workspace.yaml`: collapsed `minimumReleaseAgeExclude` version-range duplicates (`minimatch`, `flatted`) into single semver-range entries

**`pnpm audit --fix update` (transitive patch bumps):**
- `tough-cookie` `6.0.1` → `6.0.2`
- `tldts` / `tldts-core` `7.4.7` → `7.4.8`
- `lru-cache` `11.5.1` → `11.5.2`

No source changes — `pnpm-lock.yaml` + the two touched `package.json` files + `pnpm-workspace.yaml` only.

## Test plan

- [x] `pnpm install --frozen-lockfile` — lockfile consistent with package manifests
- [x] `pnpm run format` / `check-types` / `lint` / `test:coverage` / `build` — all green (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)