### PR TITLE
test(admin): events list-page shell e2e (loading/empty/error/filter/bulk) (#355)

### DIFF
--- a/apps/admin/e2e/authenticated/events-list.spec.ts
+++ b/apps/admin/e2e/authenticated/events-list.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupEventsList,
+  seedEventsList,
+  type EventsListFixture,
+} from "../support/events-list-fixture";
+import {
+  expectFilteredHeader,
+  mockListEmpty,
+  mockListError,
+  mockListLoading,
+  searchList,
+  toggleFilterCheckbox,
+} from "../support/list-helpers";
+
+/**
+ * Events list-page shell — the states and shared surfaces every entity list is
+ * built from, exercised here on the richest one (events). The 7 CRUD spines
+ * only drive the detail happy path; this fills the untested list surface:
+ * loading / hard-error / true-empty / filtered-empty, the FilterRail, and the
+ * BulkActionBar.
+ *
+ * Runs under the `authenticated` project (starts signed in). A per-suite
+ * fixture seeds a small, varied, self-cleaning set of events owned by the test
+ * user; the real-data tests isolate those rows by searching the seeded stamp
+ * (the shared DB is non-deterministic — we never assert on global counts). The
+ * three states a real, non-empty DB won't produce on cue (loading/error/empty)
+ * are forced with route interception scoped to the `events` read only.
+ *
+ * Serial so the fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("events list-page shell", () => {
+  let fx: EventsListFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    fx = await seedEventsList(userId);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupEventsList(fx.stamp);
+    }
+  });
+
+  /** Land on the events list filtered (via search) to exactly the seeded rows. */
+  async function gotoSeeded(page: Page): Promise<void> {
+    await page.goto("/events");
+    await searchList(page, String(fx.stamp));
+    await page.waitForURL(/[?&]q=/);
+    await expect(page.getByText(fx.events[0]!.title)).toBeVisible();
+  }
+
+  test("populated: renders seeded rows with sort + pagination controls", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    for (const e of fx.events) {
+      await expect(page.getByText(e.title)).toBeVisible();
+    }
+    await expect(
+      page.getByRole("button", { name: "Previous page" }),
+    ).toBeVisible();
+    await expect(page.locator("#event-sort-select")).toBeVisible();
+  });
+
+  test("filters: era checkbox narrows results and flags the header", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    await toggleFilterCheckbox(page, "era", "CE");
+    await page.waitForURL(/era=CE/);
+    await expectFilteredHeader(page);
+
+    // The two CE seeded rows remain; the BCE and MYA ones drop out.
+    await expect(page.getByText(fx.events[0]!.title)).toBeVisible();
+    await expect(page.getByText(fx.events[1]!.title)).toBeVisible();
+    await expect(page.getByText(fx.events[2]!.title)).toHaveCount(0);
+    await expect(page.getByText(fx.events[3]!.title)).toHaveCount(0);
+  });
+
+  test("filters: Clear all resets the query", async ({ page }) => {
+    await page.goto(`/events?q=${fx.stamp}&era=CE`);
+    await expectFilteredHeader(page);
+
+    await page.getByRole("button", { name: "Clear all" }).click();
+    await page.waitForURL(/\/events\??$/);
+    await expect(page.getByText(/·\s*filtered/)).toHaveCount(0);
+  });
+
+  test("filtered-empty: a no-match search shows the empty message", async ({
+    page,
+  }) => {
+    await page.goto("/events?q=zzznomatchqqq");
+
+    await expect(
+      page.getByText("No events match these filters."),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear filters" }).click();
+    await page.waitForURL(/\/events\??$/);
+    await expect(page.getByText("No events match these filters.")).toHaveCount(
+      0,
+    );
+  });
+
+  test("bulk: select all seeded rows and publish them", async ({ page }) => {
+    await gotoSeeded(page);
+
+    await page.getByRole("checkbox", { name: "Select all" }).click();
+
+    const bar = page.getByRole("region", { name: "Bulk actions" });
+    await expect(bar).toBeVisible();
+    await expect(bar.getByText("4 selected")).toBeVisible();
+
+    await bar.getByRole("button", { name: "Publish", exact: true }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(/Publish 4 events\?/)).toBeVisible();
+    await dialog.getByRole("button", { name: "Publish", exact: true }).click();
+
+    // All four seeded rows now read as published. Scope the count to the table
+    // rows: the filter-rail "Published" checkbox (in the <aside>) and the
+    // "Published 4 events." success toast both live outside it.
+    await expect(
+      page.getByRole("table").getByText("Published", { exact: true }),
+    ).toHaveCount(4);
+  });
+
+  test("loading: the loading state shows while the query is in flight", async ({
+    page,
+  }) => {
+    const unroute = await mockListLoading(page, "events", 3000);
+    await page.goto("/events");
+
+    await expect(page.getByText("Loading…")).toBeVisible();
+    await expect(page.getByText("Loading…")).toBeHidden({ timeout: 15_000 });
+
+    await unroute();
+  });
+
+  test("error: a failed load shows the inline error and Retry recovers", async ({
+    page,
+  }) => {
+    const unroute = await mockListError(page, "events");
+    await page.goto("/events");
+
+    // Target the error alert by its text — Next's route announcer is also
+    // role="alert", so a bare getByRole("alert") is ambiguous.
+    const errorAlert = page
+      .getByRole("alert")
+      .filter({ hasText: "Failed to load events." });
+    await expect(errorAlert).toBeVisible();
+
+    // Drop the mock, then Retry refetches against the real backend and recovers.
+    await unroute();
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByText("Failed to load events.")).toBeHidden();
+  });
+
+  test("true-empty: an empty list shows the 'No events yet' state", async ({
+    page,
+  }) => {
+    const unroute = await mockListEmpty(page, "events");
+    await page.goto("/events");
+
+    await expect(page.getByText(/No events yet\./)).toBeVisible();
+
+    await unroute();
+  });
+});

--- a/apps/admin/e2e/support/events-list-fixture.ts
+++ b/apps/admin/e2e/support/events-list-fixture.ts
@@ -1,0 +1,112 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * A single seeded event, with the attributes the list-shell spec filters on.
+ */
+export interface SeededEvent {
+  slug: string;
+  title: string;
+  eventType: string;
+  era: string;
+  importance: number;
+  published: boolean;
+}
+
+export interface EventsListFixture {
+  /** Timestamp shared by every seeded title — the spec searches on it to
+   * isolate its own rows from the shared authenticated DB. */
+  stamp: number;
+  /** Title prefix common to all seeded events (`E2E List <stamp>`). Typing
+   * this into the list search returns exactly the seeded set. */
+  titlePrefix: string;
+  events: SeededEvent[];
+}
+
+/**
+ * Seed a small, deterministic set of events owned by `userId`, with varied
+ * attributes so the list-shell spec can exercise every filter group against
+ * real rows: distinct `event_type` (Type checkbox), `era` (Era checkbox), a
+ * spread of `importance` (Importance range), and a published/draft mix (Status
+ * checkbox + bulk publish/unpublish).
+ *
+ * Every title carries a shared timestamp so the spec can `search` the list down
+ * to exactly these rows — the shared authenticated DB accumulates events from
+ * other specs, so the suite never asserts on global counts (#355). Unlike the
+ * older fixtures this one is **self-cleaning**: pair it with
+ * {@link cleanupEventsList} in an `afterAll` (see the #355 teardown note).
+ */
+export async function seedEventsList(
+  userId: string,
+): Promise<EventsListFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+  const titlePrefix = `E2E List ${stamp}`;
+
+  // One row per (type, era, importance, published) combination the spec drives.
+  // Kept under one page (PAGE_SIZE = 20) so a stamp search never paginates.
+  const specs: Omit<SeededEvent, "slug" | "title">[] = [
+    { eventType: "milestone", era: "CE", importance: 9, published: true },
+    { eventType: "discovery", era: "CE", importance: 5, published: false },
+    { eventType: "conflict", era: "BCE", importance: 2, published: false },
+    { eventType: "milestone", era: "MYA", importance: 7, published: false },
+  ];
+
+  const events: SeededEvent[] = specs.map((s, i) => ({
+    ...s,
+    slug: `e2e-list-event-${i}-${stamp}`,
+    title: `${titlePrefix} — ${s.eventType} ${i}`,
+  }));
+
+  const { error } = await admin.from("events").insert(
+    events.map((e) => ({
+      user_id: userId,
+      slug: e.slug,
+      title: e.title,
+      event_type: e.eventType,
+      importance: e.importance,
+      published: e.published,
+      temporal_data: temporalForEra(e.era),
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, titlePrefix, events };
+}
+
+/**
+ * Delete every event seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupEventsList(stamp: number): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("events")
+    .delete()
+    .ilike("slug", `e2e-list-event-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}
+
+/**
+ * A minimal temporal_data payload for a given era. Every era uses `year` (the
+ * temporal schema forbids sub-year fields for prehistoric eras but still keys
+ * off `year`, and the `sort_order_years` generated column computes from it);
+ * the era filter itself only reads `temporal_data->>era`.
+ */
+function temporalForEra(era: string): Record<string, unknown> {
+  switch (era) {
+    case "BCE":
+      return { era: "BCE", year: 500 };
+    case "KYA":
+      return { era: "KYA", year: 10 };
+    case "MYA":
+      return { era: "MYA", year: 5 };
+    case "BYA":
+      return { era: "BYA", year: 1 };
+    default:
+      return { era: "CE", year: 2000 };
+  }
+}

--- a/apps/admin/e2e/support/list-helpers.ts
+++ b/apps/admin/e2e/support/list-helpers.ts
@@ -1,0 +1,105 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Shared helpers for the entity list-page specs (the list "shell": loading /
+ * empty / error / filtered states, the FilterRail, and bulk actions). They
+ * cover the two things a list spec keeps needing: driving the shared filter
+ * UI, and forcing the query states that a real, non-empty local DB won't
+ * produce on cue (loading / hard-error / true-empty) via route interception.
+ *
+ * The mock helpers target a single PostgREST resource GET (e.g. `events`), so
+ * the page's *other* backend reads — the timelines filter dropdown, the auth
+ * user lookup — still hit the real server and the page renders normally.
+ */
+
+/** Matches the paginated list read: GET `<supabase>/rest/v1/<resource>?…`. */
+function resourceRoute(resource: string): RegExp {
+  return new RegExp(`/rest/v1/${resource}\\?`);
+}
+
+/**
+ * Fail every list read for `resource` with a 500, so the list renders its
+ * inline error + Retry. Returns an unroute fn — call it before clicking Retry
+ * so the refetch reaches the real backend and the list recovers.
+ */
+export async function mockListError(
+  page: Page,
+  resource: string,
+): Promise<() => Promise<void>> {
+  const route = resourceRoute(resource);
+  await page.route(route, (r) =>
+    r.request().method() === "GET"
+      ? r.fulfill({ status: 500, contentType: "application/json", body: "{}" })
+      : r.continue(),
+  );
+  return () => page.unroute(route);
+}
+
+/**
+ * Return an empty page for `resource`: an empty JSON array plus a zero-total
+ * `content-range` header, so supabase-js parses a total of 0 (drives the
+ * true-empty state, since no filter is applied). Returns an unroute fn.
+ */
+export async function mockListEmpty(
+  page: Page,
+  resource: string,
+): Promise<() => Promise<void>> {
+  const route = resourceRoute(resource);
+  await page.route(route, (r) =>
+    r.request().method() === "GET"
+      ? r.fulfill({
+          status: 200,
+          contentType: "application/json",
+          headers: { "content-range": "*/0" },
+          body: "[]",
+        })
+      : r.continue(),
+  );
+  return () => page.unroute(route);
+}
+
+/**
+ * Delay every list read for `resource` by `ms` before letting it through, so
+ * the transient loading state (skeleton + "Loading…") stays observable long
+ * enough to assert. Returns an unroute fn.
+ */
+export async function mockListLoading(
+  page: Page,
+  resource: string,
+  ms = 2000,
+): Promise<() => Promise<void>> {
+  const route = resourceRoute(resource);
+  await page.route(route, async (r) => {
+    if (r.request().method() !== "GET") return r.continue();
+    await new Promise((resolve) => setTimeout(resolve, ms));
+    await r.continue();
+  });
+  return () => page.unroute(route);
+}
+
+/**
+ * Type `text` into a list's search box (role `searchbox`). The list debounces
+ * search → URL by 300ms, so callers should await the resulting `?q=` change
+ * (e.g. `page.waitForURL`) before asserting.
+ */
+export async function searchList(page: Page, text: string): Promise<void> {
+  await page.getByRole("searchbox").fill(text);
+}
+
+/**
+ * Toggle a FilterRail checkbox by its group id + option value. The rail renders
+ * each checkbox with `id="${groupId}-${value}"` (filter-rail.tsx), e.g.
+ * `era-CE`, `type-milestone`, `publication-published`.
+ */
+export async function toggleFilterCheckbox(
+  page: Page,
+  groupId: string,
+  value: string,
+): Promise<void> {
+  await page.locator(`#${groupId}-${value}`).click();
+}
+
+/** Assert the list header switched to its active-filter variant ("… · filtered"). */
+export async function expectFilteredHeader(page: Page): Promise<void> {
+  await expect(page.getByText(/·\s*filtered/)).toBeVisible();
+}


### PR DESCRIPTION
## What

Adds full e2e coverage of the **list-page shell** on the **events** entity (the anchor for this pattern) — the highest-exposure surface the suite still left untested. The 7 CRUD spines only drive create → view → edit → delete; the list states and shared surfaces had **zero** e2e coverage.

Part of #355 (Playwright e2e roadmap, Phase 9). e2e stays **off** the CI gate per [ADR-0036](docs/adr/adr-0036-e2e-testing-strategy.md).

## Coverage (8 tests, all green)

| Test | State / surface |
|---|---|
| populated | seeded rows render + sort/pagination controls |
| filters: era checkbox | narrows results, updates URL, `· filtered` header |
| filters: Clear all | resets query to `/events` |
| filtered-empty | "No events match these filters." + Clear filters |
| bulk | select-all → publish → confirm dialog → 4 status badges flip |
| loading | `Loading…` while in flight |
| error | inline alert + Retry recovers |
| true-empty | "No events yet." |

## How

- **`events-list-fixture.ts`** — seeds 4 varied events (distinct type/era/importance, published/draft mix) owned by the test user, every title carrying a shared stamp so tests isolate their rows via search rather than asserting on the non-deterministic shared DB. **Self-cleaning** (`cleanupEventsList` in `afterAll`) — starts paying down the #355 fixture-teardown debt.
- **`list-helpers.ts`** — reusable across future entity list specs: `mockListError` / `mockListEmpty` / `mockListLoading` (route interception scoped to a single resource read, so the timelines-dropdown and auth reads still hit the real backend), plus `searchList`, `toggleFilterCheckbox`, `expectFilteredHeader`.
- Real-data states use seeded rows; the three states a live, non-empty DB won't produce on cue (loading / hard-error / true-empty) are forced with **route interception** — a new but sanctioned technique for the suite.

## Verification

- `pnpm exec playwright test authenticated/events-list.spec.ts --project=authenticated` → **9/9 green** (incl. setup)
- Teardown verified: `SELECT count(*) FROM events WHERE slug LIKE 'e2e-list-event-%'` → `0`
- `format:check` ✓ · `lint` (max-warnings 0) ✓ · `check-types` ✓

## Follow-up

Same treatment (loading/empty/error/filter/bulk) for each remaining entity list, reusing `list-helpers.ts` — **next: timelines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)