### PR TITLE
test(admin): timelines list-page shell e2e (loading/empty/error/filter/bulk) (#355)

### DIFF
--- a/apps/admin/e2e/authenticated/timelines-list.spec.ts
+++ b/apps/admin/e2e/authenticated/timelines-list.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupTimelinesList,
+  seedTimelinesList,
+  type TimelinesListFixture,
+} from "../support/timelines-list-fixture";
+import {
+  expectFilteredHeader,
+  mockListEmpty,
+  mockListError,
+  mockListLoading,
+  searchList,
+  toggleFilterCheckbox,
+} from "../support/list-helpers";
+
+/**
+ * Timelines list-page shell — the same loading / empty / error / filtered /
+ * bulk coverage the events list got (#378), applied to the timelines list.
+ * Second entity in the per-list rollout under #355; reuses the shared
+ * `list-helpers.ts` (the timelines FilterRail is all checkboxes).
+ *
+ * Runs under the `authenticated` project (starts signed in). A per-suite,
+ * self-cleaning fixture seeds a small varied set of timelines owned by the test
+ * user; the real-data tests isolate those rows by searching the seeded stamp
+ * (the shared DB is non-deterministic — we never assert on global counts). The
+ * three states a real, non-empty DB won't produce on cue (loading/error/empty)
+ * are forced with route interception scoped to the `timelines` read only.
+ *
+ * The bulk action drives **unpublish** rather than publish: publishing a
+ * timeline is gated on it having a linked event (#212), so a bulk publish of
+ * eventless seeded rows would fail the precondition.
+ *
+ * Serial so the fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("timelines list-page shell", () => {
+  let fx: TimelinesListFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    fx = await seedTimelinesList(userId);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupTimelinesList(fx.stamp);
+    }
+  });
+
+  /** Land on the timelines list filtered (via search) to exactly the seeded rows. */
+  async function gotoSeeded(page: Page): Promise<void> {
+    await page.goto("/timelines");
+    await searchList(page, String(fx.stamp));
+    await page.waitForURL(/[?&]q=/);
+    await expect(page.getByText(fx.timelines[0]!.title)).toBeVisible();
+  }
+
+  test("populated: renders seeded rows with sort + pagination controls", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    for (const t of fx.timelines) {
+      await expect(page.getByText(t.title)).toBeVisible();
+    }
+    await expect(
+      page.getByRole("button", { name: "Previous page" }),
+    ).toBeVisible();
+    await expect(page.locator("#sort-select")).toBeVisible();
+  });
+
+  test("filters: type checkbox narrows results and flags the header", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    await toggleFilterCheckbox(page, "type", "general");
+    await page.waitForURL(/type=general/);
+    await expectFilteredHeader(page);
+
+    // The two `general` seeded rows remain; the biographical and comparative
+    // ones drop out.
+    await expect(page.getByText(fx.timelines[0]!.title)).toBeVisible();
+    await expect(page.getByText(fx.timelines[3]!.title)).toBeVisible();
+    await expect(page.getByText(fx.timelines[1]!.title)).toHaveCount(0);
+    await expect(page.getByText(fx.timelines[2]!.title)).toHaveCount(0);
+  });
+
+  test("filters: Clear all resets the query", async ({ page }) => {
+    await page.goto(`/timelines?q=${fx.stamp}&type=general`);
+    await expectFilteredHeader(page);
+
+    await page.getByRole("button", { name: "Clear all" }).click();
+    await page.waitForURL(/\/timelines\??$/);
+    await expect(page.getByText(/·\s*filtered/)).toHaveCount(0);
+  });
+
+  test("filtered-empty: a no-match search shows the empty message", async ({
+    page,
+  }) => {
+    await page.goto("/timelines?q=zzznomatchqqq");
+
+    await expect(
+      page.getByText("No timelines match these filters."),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear filters" }).click();
+    await page.waitForURL(/\/timelines\??$/);
+    await expect(
+      page.getByText("No timelines match these filters."),
+    ).toHaveCount(0);
+  });
+
+  test("bulk: select all seeded rows and unpublish them", async ({ page }) => {
+    await gotoSeeded(page);
+
+    await page.getByRole("checkbox", { name: "Select all" }).click();
+
+    const bar = page.getByRole("region", { name: "Bulk actions" });
+    await expect(bar).toBeVisible();
+    await expect(bar.getByText("4 selected")).toBeVisible();
+
+    await bar.getByRole("button", { name: "Unpublish", exact: true }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(/Unpublish 4 timelines\?/)).toBeVisible();
+    await dialog
+      .getByRole("button", { name: "Unpublish", exact: true })
+      .click();
+
+    // All four seeded rows now read as drafts. Scope the count to the table
+    // rows: the filter-rail "Draft" checkbox (in the <aside>) and the
+    // "Unpublished 4 timelines." success toast both live outside it.
+    await expect(
+      page.getByRole("table").getByText("Draft", { exact: true }),
+    ).toHaveCount(4);
+  });
+
+  test("loading: the loading state shows while the query is in flight", async ({
+    page,
+  }) => {
+    const unroute = await mockListLoading(page, "timelines", 3000);
+    await page.goto("/timelines");
+
+    await expect(page.getByText("Loading…")).toBeVisible();
+    await expect(page.getByText("Loading…")).toBeHidden({ timeout: 15_000 });
+
+    await unroute();
+  });
+
+  test("error: a failed load shows the inline error and Retry recovers", async ({
+    page,
+  }) => {
+    const unroute = await mockListError(page, "timelines");
+    await page.goto("/timelines");
+
+    // Target the error alert by its text — Next's route announcer is also
+    // role="alert", so a bare getByRole("alert") is ambiguous.
+    const errorAlert = page
+      .getByRole("alert")
+      .filter({ hasText: "Failed to load timelines." });
+    await expect(errorAlert).toBeVisible();
+
+    // Drop the mock, then Retry refetches against the real backend and recovers.
+    await unroute();
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByText("Failed to load timelines.")).toBeHidden();
+  });
+
+  test("true-empty: an empty list shows the 'No timelines yet' state", async ({
+    page,
+  }) => {
+    const unroute = await mockListEmpty(page, "timelines");
+    await page.goto("/timelines");
+
+    await expect(page.getByText(/No timelines yet\./)).toBeVisible();
+
+    await unroute();
+  });
+});

--- a/apps/admin/e2e/support/timelines-list-fixture.ts
+++ b/apps/admin/e2e/support/timelines-list-fixture.ts
@@ -1,0 +1,114 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * A single seeded timeline, with the attributes the list-shell spec filters on.
+ */
+export interface SeededTimeline {
+  slug: string;
+  title: string;
+  timelineType: string;
+  visibility: string;
+  era: string;
+  published: boolean;
+}
+
+export interface TimelinesListFixture {
+  /** Timestamp shared by every seeded title — the spec searches on it to
+   * isolate its own rows from the shared authenticated DB. */
+  stamp: number;
+  /** Title prefix common to all seeded timelines (`E2E List <stamp>`). Typing
+   * this into the list search returns exactly the seeded set. */
+  titlePrefix: string;
+  timelines: SeededTimeline[];
+}
+
+/**
+ * Seed a small, deterministic set of timelines owned by `userId`, with varied
+ * attributes so the list-shell spec can exercise the filters against real rows:
+ * distinct `timeline_type` (Type checkbox) and `visibility` (Visibility
+ * checkbox). Every row is seeded **published** so the bulk test can drive
+ * unpublish — publishing through the UI is gated on each timeline having a
+ * linked event (`publishTimeline`, #212), a precondition a service-role insert
+ * bypasses but the UI action would not.
+ *
+ * Every title carries a shared timestamp so the spec can `search` the list down
+ * to exactly these rows — the shared authenticated DB accumulates timelines
+ * from other specs, so the suite never asserts on global counts (#355). Pair
+ * with {@link cleanupTimelinesList} in an `afterAll` (the #355 teardown note).
+ */
+export async function seedTimelinesList(
+  userId: string,
+): Promise<TimelinesListFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+  const titlePrefix = `E2E List ${stamp}`;
+
+  // One row per (type, visibility, era) combination the spec drives. Two
+  // `general` rows so a type=general filter leaves a clean 2-of-4 subset.
+  // Kept under one page (PAGE_SIZE = 20) so a stamp search never paginates.
+  const specs: Omit<SeededTimeline, "slug" | "title" | "published">[] = [
+    { timelineType: "general", visibility: "public", era: "CE" },
+    { timelineType: "biographical", visibility: "private", era: "CE" },
+    { timelineType: "comparative", visibility: "shared", era: "BCE" },
+    { timelineType: "general", visibility: "private", era: "MYA" },
+  ];
+
+  const timelines: SeededTimeline[] = specs.map((s, i) => ({
+    ...s,
+    published: true,
+    slug: `e2e-list-timeline-${i}-${stamp}`,
+    title: `${titlePrefix} — ${s.timelineType} ${i}`,
+  }));
+
+  const { error } = await admin.from("timelines").insert(
+    timelines.map((t) => ({
+      user_id: userId,
+      slug: t.slug,
+      title: t.title,
+      timeline_type: t.timelineType,
+      visibility: t.visibility,
+      published: t.published,
+      temporal_data: temporalForEra(t.era),
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, titlePrefix, timelines };
+}
+
+/**
+ * Delete every timeline seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupTimelinesList(stamp: number): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("timelines")
+    .delete()
+    .ilike("slug", `e2e-list-timeline-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}
+
+/**
+ * A minimal temporal_data payload for a given era. Every era uses `year` (the
+ * temporal schema forbids sub-year fields for prehistoric eras but still keys
+ * off `year`, and the `sort_order_start` generated column computes from it).
+ */
+function temporalForEra(era: string): Record<string, unknown> {
+  switch (era) {
+    case "BCE":
+      return { era: "BCE", year: 500 };
+    case "KYA":
+      return { era: "KYA", year: 10 };
+    case "MYA":
+      return { era: "MYA", year: 5 };
+    case "BYA":
+      return { era: "BYA", year: 1 };
+    default:
+      return { era: "CE", year: 2000 };
+  }
+}


### PR DESCRIPTION
## What

Second entity in the list-page-shell e2e rollout under #355, mirroring the events coverage ([#378](https://github.com/shaes-farm/time-traveler/pull/378)) on the **timelines** list: loading / true-empty / error / filtered-empty states, the FilterRail, and the BulkActionBar.

Reuses the shared `list-helpers.ts` **unchanged** — the timelines FilterRail is all checkboxes, so `toggleFilterCheckbox` + the `mockList*` route helpers covered it as-is. e2e stays **off** the CI gate per [ADR-0036](docs/adr/adr-0036-e2e-testing-strategy.md).

## Coverage (8 tests, all green)

| Test | State / surface |
|---|---|
| populated | seeded rows render + sort/pagination controls |
| filters: type checkbox | narrows results, updates URL, `· filtered` header |
| filters: Clear all | resets query to `/timelines` |
| filtered-empty | "No timelines match these filters." + Clear filters |
| bulk | select-all → **unpublish** → confirm dialog → 4 status badges flip to Draft |
| loading | `Loading…` while in flight |
| error | inline alert + Retry recovers |
| true-empty | "No timelines yet." |

## Notable difference from events: bulk **unpublish**, not publish

Publishing a timeline is gated on it having at least one linked event (#212, enforced in `publishTimeline`), so a bulk *publish* of eventless seeded rows would hit the precondition and fail. Instead the fixture seeds rows **published** (a service-role insert bypasses the service-fn guard), and the bulk test drives **unpublish** — which has no precondition — flipping them to Draft.

## How

- **`timelines-list-fixture.ts`** — self-cleaning seeder: 4 varied timelines (distinct `timeline_type` + `visibility`, all published), titles stamped for search-based row isolation against the non-deterministic shared DB. `cleanupTimelinesList` runs in `afterAll`.
- **`timelines-list.spec.ts`** — the 8-test shell, serial so the fixture seeds/tears down once.

## Verification

- `pnpm exec playwright test authenticated/timelines-list.spec.ts --project=authenticated` → **9/9 green** (incl. setup)
- Teardown verified: `SELECT count(*) FROM timelines WHERE slug LIKE 'e2e-list-timeline-%'` → `0`
- `format:check` ✓ · `lint` (max-warnings 0) ✓ · `check-types` ✓

## Follow-up

Same treatment for the remaining entity lists — **next: characters**, then periods / stories / categories / media.

🤖 Generated with [Claude Code](https://claude.com/claude-code)