### PR TITLE
test(admin): characters list-page shell e2e (loading/empty/error/filter/bulk) (#355)

### DIFF
--- a/apps/admin/e2e/authenticated/characters-list.spec.ts
+++ b/apps/admin/e2e/authenticated/characters-list.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupCharactersList,
+  seedCharactersList,
+  type CharactersListFixture,
+} from "../support/characters-list-fixture";
+import {
+  expectFilteredHeader,
+  mockListEmpty,
+  mockListError,
+  mockListLoading,
+  searchList,
+  toggleFilterCheckbox,
+} from "../support/list-helpers";
+
+/**
+ * Characters list-page shell — the same loading / empty / error / filtered /
+ * bulk coverage the events (#378) and timelines (#379) lists got, applied to
+ * the characters list. Third entity in the per-list rollout under #355; reuses
+ * the shared `list-helpers.ts` (the characters FilterRail is all checkboxes).
+ *
+ * Runs under the `authenticated` project (starts signed in). A per-suite,
+ * self-cleaning fixture seeds a small varied set of characters owned by the
+ * test user; the real-data tests isolate those rows by searching the seeded
+ * stamp (the shared DB is non-deterministic — we never assert on global
+ * counts). The three states a real, non-empty DB won't produce on cue
+ * (loading/error/empty) are forced with route interception scoped to the
+ * `characters` read (which also covers the facet-count queries — harmless,
+ * since the list's own state is driven by useCharactersPage alone).
+ *
+ * Serial so the fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("characters list-page shell", () => {
+  let fx: CharactersListFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    fx = await seedCharactersList(userId);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupCharactersList(fx.stamp);
+    }
+  });
+
+  /** Land on the characters list filtered (via search) to exactly the seeded rows. */
+  async function gotoSeeded(page: Page): Promise<void> {
+    await page.goto("/characters");
+    await searchList(page, String(fx.stamp));
+    await page.waitForURL(/[?&]q=/);
+    await expect(page.getByText(fx.characters[0]!.name)).toBeVisible();
+  }
+
+  test("populated: renders seeded rows with sort + pagination controls", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    for (const c of fx.characters) {
+      await expect(page.getByText(c.name)).toBeVisible();
+    }
+    await expect(
+      page.getByRole("button", { name: "Previous page" }),
+    ).toBeVisible();
+    await expect(page.locator("#character-sort-select")).toBeVisible();
+  });
+
+  test("filters: type checkbox narrows results and flags the header", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    await toggleFilterCheckbox(page, "type", "human");
+    await page.waitForURL(/type=human/);
+    await expectFilteredHeader(page);
+
+    // The two `human` seeded rows remain; the animal and mythological ones
+    // drop out.
+    await expect(page.getByText(fx.characters[0]!.name)).toBeVisible();
+    await expect(page.getByText(fx.characters[3]!.name)).toBeVisible();
+    await expect(page.getByText(fx.characters[1]!.name)).toHaveCount(0);
+    await expect(page.getByText(fx.characters[2]!.name)).toHaveCount(0);
+  });
+
+  test("filters: Clear all resets the query", async ({ page }) => {
+    await page.goto(`/characters?q=${fx.stamp}&type=human`);
+    await expectFilteredHeader(page);
+
+    await page.getByRole("button", { name: "Clear all" }).click();
+    await page.waitForURL(/\/characters\??$/);
+    await expect(page.getByText(/·\s*filtered/)).toHaveCount(0);
+  });
+
+  test("filtered-empty: a no-match search shows the empty message", async ({
+    page,
+  }) => {
+    await page.goto("/characters?q=zzznomatchqqq");
+
+    await expect(
+      page.getByText("No characters match these filters."),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear filters" }).click();
+    await page.waitForURL(/\/characters\??$/);
+    await expect(
+      page.getByText("No characters match these filters."),
+    ).toHaveCount(0);
+  });
+
+  test("bulk: select all seeded rows and publish them", async ({ page }) => {
+    await gotoSeeded(page);
+
+    await page.getByRole("checkbox", { name: "Select all" }).click();
+
+    const bar = page.getByRole("region", { name: "Bulk actions" });
+    await expect(bar).toBeVisible();
+    await expect(bar.getByText("4 selected")).toBeVisible();
+
+    await bar.getByRole("button", { name: "Publish", exact: true }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(/Publish 4 characters\?/)).toBeVisible();
+    await dialog.getByRole("button", { name: "Publish", exact: true }).click();
+
+    // All four seeded rows now read as published. Scope the count to the table
+    // body rows: the "Published" column header <th>, the filter-rail "Published"
+    // checkbox (in the <aside>), and the "Published 4 characters." success toast
+    // all live outside <tbody>.
+    await expect(
+      page.locator("tbody").getByText("Published", { exact: true }),
+    ).toHaveCount(4);
+  });
+
+  test("loading: the loading state shows while the query is in flight", async ({
+    page,
+  }) => {
+    const unroute = await mockListLoading(page, "characters", 3000);
+    await page.goto("/characters");
+
+    await expect(page.getByText("Loading…")).toBeVisible();
+    await expect(page.getByText("Loading…")).toBeHidden({ timeout: 15_000 });
+
+    await unroute();
+  });
+
+  test("error: a failed load shows the inline error and Retry recovers", async ({
+    page,
+  }) => {
+    const unroute = await mockListError(page, "characters");
+    await page.goto("/characters");
+
+    // Target the error alert by its text — Next's route announcer is also
+    // role="alert", so a bare getByRole("alert") is ambiguous.
+    const errorAlert = page
+      .getByRole("alert")
+      .filter({ hasText: "Failed to load characters." });
+    await expect(errorAlert).toBeVisible();
+
+    // Drop the mock, then Retry refetches against the real backend and recovers.
+    await unroute();
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByText("Failed to load characters.")).toBeHidden();
+  });
+
+  test("true-empty: an empty list shows the 'No characters yet' state", async ({
+    page,
+  }) => {
+    const unroute = await mockListEmpty(page, "characters");
+    await page.goto("/characters");
+
+    await expect(page.getByText(/No characters yet\./)).toBeVisible();
+
+    await unroute();
+  });
+});

--- a/apps/admin/e2e/support/characters-list-fixture.ts
+++ b/apps/admin/e2e/support/characters-list-fixture.ts
@@ -1,0 +1,91 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * A single seeded character, with the attributes the list-shell spec filters on.
+ */
+export interface SeededCharacter {
+  slug: string;
+  name: string;
+  characterType: string;
+  significance: string;
+  published: boolean;
+}
+
+export interface CharactersListFixture {
+  /** Timestamp shared by every seeded name — the spec searches on it to
+   * isolate its own rows from the shared authenticated DB. */
+  stamp: number;
+  /** Name prefix common to all seeded characters (`E2E List <stamp>`). Typing
+   * this into the list search returns exactly the seeded set. */
+  namePrefix: string;
+  characters: SeededCharacter[];
+}
+
+/**
+ * Seed a small, deterministic set of characters owned by `userId`, with varied
+ * attributes so the list-shell spec can exercise the filters against real rows:
+ * distinct `character_type` (Type checkbox) and `significance` (Significance
+ * checkbox). All rows are seeded draft so the bulk test can drive publish
+ * (`publishCharacter` has no precondition).
+ *
+ * Every name carries a shared timestamp so the spec can `search` the list down
+ * to exactly these rows — the shared authenticated DB accumulates characters
+ * from other specs, so the suite never asserts on global counts (#355). Pair
+ * with {@link cleanupCharactersList} in an `afterAll` (the #355 teardown note).
+ */
+export async function seedCharactersList(
+  userId: string,
+): Promise<CharactersListFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+  const namePrefix = `E2E List ${stamp}`;
+
+  // One row per (type, significance) combination the spec drives. Two `human`
+  // rows so a type=human filter leaves a clean 2-of-4 subset. Kept under one
+  // page (PAGE_SIZE = 20) so a stamp search never paginates.
+  const specs: Omit<SeededCharacter, "slug" | "name" | "published">[] = [
+    { characterType: "human", significance: "critical" },
+    { characterType: "animal", significance: "high" },
+    { characterType: "mythological", significance: "medium" },
+    { characterType: "human", significance: "low" },
+  ];
+
+  const characters: SeededCharacter[] = specs.map((s, i) => ({
+    ...s,
+    published: false,
+    slug: `e2e-list-character-${i}-${stamp}`,
+    name: `${namePrefix} — ${s.characterType} ${i}`,
+  }));
+
+  const { error } = await admin.from("characters").insert(
+    characters.map((c, i) => ({
+      user_id: userId,
+      slug: c.slug,
+      name: c.name,
+      character_type: c.characterType,
+      significance: c.significance,
+      published: c.published,
+      birth_temporal: { era: "CE", year: 1900 + i },
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, namePrefix, characters };
+}
+
+/**
+ * Delete every character seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupCharactersList(stamp: number): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("characters")
+    .delete()
+    .ilike("slug", `e2e-list-character-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}


### PR DESCRIPTION
## What

Third entity in the list-page-shell e2e rollout under #355, mirroring events ([#378](https://github.com/shaes-farm/time-traveler/pull/378)) and timelines ([#379](https://github.com/shaes-farm/time-traveler/pull/379)) on the **characters** list: loading / true-empty / error / filtered-empty states, the FilterRail, and the BulkActionBar.

Reuses the shared `list-helpers.ts` **unchanged** (all-checkbox FilterRail). e2e stays **off** the CI gate per [ADR-0036](docs/adr/adr-0036-e2e-testing-strategy.md).

## Coverage (8 tests, all green)

| Test | State / surface |
|---|---|
| populated | seeded rows render + sort/pagination controls |
| filters: type checkbox | narrows results, updates URL, `· filtered` header |
| filters: Clear all | resets query to `/characters` |
| filtered-empty | "No characters match these filters." + Clear filters |
| bulk | select-all → **publish** → confirm dialog → 4 status badges flip to Published |
| loading | `Loading…` while in flight |
| error | inline alert + Retry recovers |
| true-empty | "No characters yet." |

## Entity-specific notes

- **Bulk publish** (not unpublish): `publishCharacter` has no linked-event precondition (timelines' #212 gate was the exception).
- The characters status **column header is literally "Published"** (events used "Status", timelines "Publication"), so the post-publish badge count is scoped to `<tbody>` to exclude the `<th>`.
- The route mock on the `characters` read also intercepts the filter-rail **facet-count** queries — harmless: the list's own loading/error/empty state is driven by `useCharactersPage` alone.

## How

- **`characters-list-fixture.ts`** — self-cleaning seeder: 4 varied characters (distinct `character_type` + `significance`, all draft), names stamped for search-based row isolation. `cleanupCharactersList` runs in `afterAll`. (Note the column differences from other entities: `name` not `title`, `birth_temporal` not `temporal_data`, required `character_type`.)
- **`characters-list.spec.ts`** — the 8-test shell, serial so the fixture seeds/tears down once.

## Verification

- `pnpm exec playwright test authenticated/characters-list.spec.ts --project=authenticated` → **9/9 green** (incl. setup)
- Teardown verified: `SELECT count(*) FROM characters WHERE slug LIKE 'e2e-list-character-%'` → `0`
- `format:check` ✓ · `lint` (max-warnings 0) ✓ · `check-types` ✓

## Follow-up

Same treatment for the remaining lists — **next: periods**, then stories / categories / media.

🤖 Generated with [Claude Code](https://claude.com/claude-code)