### PR TITLE
test(admin): periods list-page shell e2e (loading/empty/error/filter/bulk) (#355)

### DIFF
--- a/apps/admin/e2e/authenticated/periods-list.spec.ts
+++ b/apps/admin/e2e/authenticated/periods-list.spec.ts
@@ -1,0 +1,171 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupPeriodsList,
+  seedPeriodsList,
+  type PeriodsListFixture,
+} from "../support/periods-list-fixture";
+import {
+  mockListEmpty,
+  mockListError,
+  mockListLoading,
+  searchList,
+  toggleFilterCheckbox,
+} from "../support/list-helpers";
+
+/**
+ * Periods list-page shell — the same loading / empty / error / filtered / bulk
+ * coverage the events (#378), timelines (#379), and characters (#380) lists
+ * got, applied to the periods list. Fourth entity in the per-list rollout
+ * under #355.
+ *
+ * Periods is the outlier: its search + filters + sort are all **client-side
+ * local state** (no URL params, no server pagination). It fetches the full set
+ * (`pageSize: 100`) and filters in memory. So this spec diverges from the
+ * URL-driven template in three ways:
+ *   - no `waitForURL` after search / filter — the filtering is synchronous
+ *     local state, so we assert on row visibility directly;
+ *   - the filtered header reads `"N of M shown"`, not `"· filtered"` (so the
+ *     shared `expectFilteredHeader` helper doesn't apply);
+ *   - there is no pagination footer to assert.
+ * The route-mock + checkbox helpers still apply unchanged.
+ *
+ * The bulk action drives publish (`publishPeriod` has no precondition). Serial
+ * so the self-cleaning fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("periods list-page shell", () => {
+  let fx: PeriodsListFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    fx = await seedPeriodsList(userId);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupPeriodsList(fx.stamp);
+    }
+  });
+
+  /** Land on the periods list and client-side-search down to the seeded rows. */
+  async function gotoSeeded(page: Page): Promise<void> {
+    await page.goto("/periods");
+    await searchList(page, String(fx.stamp));
+    await expect(page.getByText(fx.periods[0]!.title)).toBeVisible();
+  }
+
+  test("populated: renders seeded rows with a sort control", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    for (const p of fx.periods) {
+      await expect(page.getByText(p.title)).toBeVisible();
+    }
+    // Client-side list: a sort control, but no server pagination footer.
+    await expect(page.locator("#period-sort-select")).toBeVisible();
+  });
+
+  test("filters: significance checkbox narrows results and flags the header", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    await toggleFilterCheckbox(page, "significance", "high");
+
+    // The two `high` seeded rows remain; the medium and low ones drop out.
+    await expect(page.getByText(fx.periods[0]!.title)).toBeVisible();
+    await expect(page.getByText(fx.periods[1]!.title)).toBeVisible();
+    await expect(page.getByText(fx.periods[2]!.title)).toHaveCount(0);
+    await expect(page.getByText(fx.periods[3]!.title)).toHaveCount(0);
+    // Periods' filtered-count header variant ("N of M shown").
+    await expect(page.getByText(/\d+ of \d+ shown/)).toBeVisible();
+
+    // Clear all resets search + filters (client-side): the filtered header goes
+    // away and a previously-hidden seeded row comes back.
+    await page.getByRole("button", { name: "Clear all" }).click();
+    await expect(page.getByText(/\d+ of \d+ shown/)).toHaveCount(0);
+    await expect(page.getByText(fx.periods[2]!.title)).toBeVisible();
+  });
+
+  test("filtered-empty: a no-match search shows the empty message", async ({
+    page,
+  }) => {
+    await page.goto("/periods");
+    await searchList(page, "zzznomatchqqq");
+
+    await expect(
+      page.getByText("No periods match these filters."),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear filters" }).click();
+    await expect(page.getByText("No periods match these filters.")).toHaveCount(
+      0,
+    );
+  });
+
+  test("bulk: select all seeded rows and publish them", async ({ page }) => {
+    await gotoSeeded(page);
+
+    await page.getByRole("checkbox", { name: "Select all" }).click();
+
+    const bar = page.getByRole("region", { name: "Bulk actions" });
+    await expect(bar).toBeVisible();
+    await expect(bar.getByText("4 selected")).toBeVisible();
+
+    await bar.getByRole("button", { name: "Publish", exact: true }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(/Publish 4 periods\?/)).toBeVisible();
+    await dialog.getByRole("button", { name: "Publish", exact: true }).click();
+
+    // All four seeded rows now read as published. Scope the count to <tbody> so
+    // the "Published 4 periods." success toast (outside the table) doesn't count.
+    await expect(
+      page.locator("tbody").getByText("Published", { exact: true }),
+    ).toHaveCount(4);
+  });
+
+  test("loading: the loading state shows while the query is in flight", async ({
+    page,
+  }) => {
+    const unroute = await mockListLoading(page, "periods", 3000);
+    await page.goto("/periods");
+
+    await expect(page.getByText("Loading…")).toBeVisible();
+    await expect(page.getByText("Loading…")).toBeHidden({ timeout: 15_000 });
+
+    await unroute();
+  });
+
+  test("error: a failed load shows the inline error and Retry recovers", async ({
+    page,
+  }) => {
+    const unroute = await mockListError(page, "periods");
+    await page.goto("/periods");
+
+    // Target the error alert by its text — Next's route announcer is also
+    // role="alert", so a bare getByRole("alert") is ambiguous.
+    const errorAlert = page
+      .getByRole("alert")
+      .filter({ hasText: "Failed to load periods." });
+    await expect(errorAlert).toBeVisible();
+
+    // Drop the mock, then Retry refetches against the real backend and recovers.
+    await unroute();
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByText("Failed to load periods.")).toBeHidden();
+  });
+
+  test("true-empty: an empty list shows the 'No periods yet' state", async ({
+    page,
+  }) => {
+    const unroute = await mockListEmpty(page, "periods");
+    await page.goto("/periods");
+
+    await expect(page.getByText(/No periods yet\./)).toBeVisible();
+
+    await unroute();
+  });
+});

--- a/apps/admin/e2e/support/periods-list-fixture.ts
+++ b/apps/admin/e2e/support/periods-list-fixture.ts
@@ -1,0 +1,108 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * A single seeded period, with the attributes the list-shell spec filters on.
+ */
+export interface SeededPeriod {
+  slug: string;
+  title: string;
+  significance: string;
+  era: string;
+  published: boolean;
+}
+
+export interface PeriodsListFixture {
+  /** Timestamp shared by every seeded title — the spec searches on it to
+   * isolate its own rows from the shared authenticated DB. */
+  stamp: number;
+  /** Title prefix common to all seeded periods (`E2E List <stamp>`). Typing
+   * this into the list search returns exactly the seeded set. */
+  titlePrefix: string;
+  periods: SeededPeriod[];
+}
+
+/**
+ * Seed a small, deterministic set of periods owned by `userId`, with varied
+ * attributes so the list-shell spec can exercise the filters against real rows:
+ * distinct `significance` (Significance checkbox) and `era` (Era checkbox). Two
+ * `high`-significance rows so a significance=high filter leaves a clean 2-of-4
+ * subset. All rows are seeded draft so the bulk test can drive publish
+ * (`publishPeriod` has no precondition).
+ *
+ * The periods list filters entirely client-side over the full fetched set (no
+ * server search / URL params), so isolation is a client-side title substring
+ * match on the shared timestamp. Pair with {@link cleanupPeriodsList} in an
+ * `afterAll` (the #355 teardown note).
+ */
+export async function seedPeriodsList(
+  userId: string,
+): Promise<PeriodsListFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+  const titlePrefix = `E2E List ${stamp}`;
+
+  const specs: Omit<SeededPeriod, "slug" | "title" | "published">[] = [
+    { significance: "high", era: "CE" },
+    { significance: "high", era: "MYA" },
+    { significance: "medium", era: "BCE" },
+    { significance: "low", era: "CE" },
+  ];
+
+  const periods: SeededPeriod[] = specs.map((s, i) => ({
+    ...s,
+    published: false,
+    slug: `e2e-list-period-${i}-${stamp}`,
+    title: `${titlePrefix} — ${s.significance} ${i}`,
+  }));
+
+  const { error } = await admin.from("periods").insert(
+    periods.map((p) => ({
+      user_id: userId,
+      slug: p.slug,
+      title: p.title,
+      significance: p.significance,
+      published: p.published,
+      temporal_data: temporalForEra(p.era),
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, titlePrefix, periods };
+}
+
+/**
+ * Delete every period seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupPeriodsList(stamp: number): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("periods")
+    .delete()
+    .ilike("slug", `e2e-list-period-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}
+
+/**
+ * A minimal temporal_data payload for a given era. Every era uses `year` (the
+ * temporal schema forbids sub-year fields for prehistoric eras but still keys
+ * off `year`, and the `sort_order_start` generated column computes from it).
+ */
+function temporalForEra(era: string): Record<string, unknown> {
+  switch (era) {
+    case "BCE":
+      return { era: "BCE", year: 500 };
+    case "KYA":
+      return { era: "KYA", year: 10 };
+    case "MYA":
+      return { era: "MYA", year: 5 };
+    case "BYA":
+      return { era: "BYA", year: 1 };
+    default:
+      return { era: "CE", year: 2000 };
+  }
+}


### PR DESCRIPTION
## What

Fourth entity in the list-page-shell e2e rollout under #355, mirroring events ([#378](https://github.com/shaes-farm/time-traveler/pull/378)), timelines ([#379](https://github.com/shaes-farm/time-traveler/pull/379)), and characters ([#380](https://github.com/shaes-farm/time-traveler/pull/380)) on the **periods** list: loading / true-empty / error / filtered-empty states, the FilterRail, and the BulkActionBar.

e2e stays **off** the CI gate per [ADR-0036](docs/adr/adr-0036-e2e-testing-strategy.md).

## Periods is the outlier — client-side filtering

Unlike every other entity list (URL-driven, server-filtered, server-paginated), the periods list fetches the full set (`pageSize: 100`) and does **search / filter / sort entirely in client-side local state**. The spec adapts:

- **No `waitForURL`** after search/filter — filtering is synchronous local state, so it asserts on row visibility directly.
- **Filtered header reads `"N of M shown"`**, not `"· filtered"` — so the shared `expectFilteredHeader` helper doesn't apply; a periods-specific `/\d+ of \d+ shown/` assertion is used.
- **No pagination footer** to assert (only a sort control).

The route-mock helpers (`mockList*`) and `toggleFilterCheckbox` / `searchList` still apply unchanged.

## Coverage (7 tests, all green)

| Test | State / surface |
|---|---|
| populated | seeded rows render + sort control (no pagination) |
| filters: significance checkbox | narrows results, `N of M shown` header, then **Clear all** resets |
| filtered-empty | "No periods match these filters." + Clear filters |
| bulk | select-all → **publish** → confirm dialog → 4 status badges flip to Published |
| loading | `Loading…` while in flight |
| error | inline alert + Retry recovers |
| true-empty | "No periods yet." |

(The filter round-trip and Clear all are folded into one test here, since both are client-side — 7 tests vs the 8 in the URL-driven specs.)

## How

- **`periods-list-fixture.ts`** — self-cleaning seeder: 4 varied periods (distinct `significance` + `era`, two `high` for a clean 2-of-4 filter split, all draft), titles stamped for client-side search isolation. `cleanupPeriodsList` runs in `afterAll`.
- **`periods-list.spec.ts`** — the shell, serial so the fixture seeds/tears down once. Bulk drives publish (`publishPeriod` has no precondition).

## Verification

- `pnpm exec playwright test authenticated/periods-list.spec.ts --project=authenticated` → **8/8 green** (incl. setup)
- Teardown verified: `SELECT count(*) FROM periods WHERE slug LIKE 'e2e-list-period-%'` → `0`
- `format:check` ✓ · `lint` (max-warnings 0) ✓ · `check-types` ✓

## Follow-up

Two lists remain — **next: stories**, then categories (a tree/inspector surface, not a standard list) and media.

🤖 Generated with [Claude Code](https://claude.com/claude-code)