### PR TITLE
chore(admin): one local e2e retry to absorb dev-server load flakes

### DIFF
--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -43,7 +43,12 @@ export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  // Specs run against the Next dev server (`pnpm run dev`), which compiles
+  // routes on demand — under peak parallel load a mutation can transiently fail
+  // (e.g. a CRUD spine's save). One local retry absorbs that single-shot dev-
+  // server flake, matching the intent of the CI retry policy; `trace:
+  // "on-first-retry"` still captures a trace when the first attempt fails.
+  retries: process.env.CI ? 2 : 1,
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
 


### PR DESCRIPTION
## What

Set Playwright **local** retries to `1` (`retries: process.env.CI ? 2 : 1`). CI already retries 2×; local runs retried 0×.

## Why

Running the full authenticated e2e suite occasionally fails a **pre-existing CRUD spine** (observed on `period-crud`) with `"Couldn't save this <entity>"` — the edit **save mutation transiently failing**. Evidence it's dev-server load flake, not a logic bug:

- `period-crud` **passes** in isolation, alongside `periods-list` under 4 workers, and on a full-suite **re-run** (56/56).
- It surfaced only once, under peak **8-worker** load.
- The suite runs against the Next **dev server** (`pnpm run dev`), which compiles routes on demand — a mutation under peak concurrent load can transiently fail.
- Every CRUD spine (event/story/timeline/character/category/period) shares the same save pattern and is equally exposed — this is **not** specific to any spec, and specifically not to the recently-added list-shell specs (whose extra parallel load just made the latent flake marginally more likely to surface).

## The fix

One local auto-retry absorbs the single-shot dev-server flake, matching the intent of the existing CI retry policy. `trace: "on-first-retry"` (already set) still captures a trace whenever a first attempt fails, so genuinely broken tests stay diagnosable rather than silently masked.

## Verification

- `pnpm exec playwright test --list` loads the config cleanly (49 tests).
- Full suite green (56/56) on re-run; `check-types` ✓ · `format:check` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)