### PR TITLE
test(admin): stories list-page shell e2e (loading/empty/error/filter/bulk) (#355)

### DIFF
--- a/apps/admin/e2e/authenticated/stories-list.spec.ts
+++ b/apps/admin/e2e/authenticated/stories-list.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupStoriesList,
+  seedStoriesList,
+  type StoriesListFixture,
+} from "../support/stories-list-fixture";
+import {
+  expectFilteredHeader,
+  mockListEmpty,
+  mockListError,
+  mockListLoading,
+  searchList,
+  toggleFilterCheckbox,
+} from "../support/list-helpers";
+
+/**
+ * Stories list-page shell — the states and shared surfaces every entity list is
+ * built from (loading / hard-error / true-empty / filtered-empty, the
+ * FilterRail, and the BulkActionBar), exercised on the stories list. The 7 CRUD
+ * spines only drive the detail happy path; this fills the untested list surface.
+ *
+ * Stories is URL-driven (like events/timelines/characters): search/filter/sort
+ * live in the query string, so the real-data tests wait on the URL after driving
+ * the shared filter UI. Runs under the `authenticated` project (starts signed
+ * in). A per-suite fixture seeds a small, varied, self-cleaning set of stories
+ * owned by the test user; the real-data tests isolate those rows by searching
+ * the seeded stamp (the shared DB is non-deterministic — we never assert on
+ * global counts). Loading/error/empty are forced with route interception scoped
+ * to the `stories` read only.
+ *
+ * Serial so the fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("stories list-page shell", () => {
+  let fx: StoriesListFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    fx = await seedStoriesList(userId);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupStoriesList(fx.stamp);
+    }
+  });
+
+  /** Land on the stories list filtered (via search) to exactly the seeded rows. */
+  async function gotoSeeded(page: Page): Promise<void> {
+    await page.goto("/stories");
+    await searchList(page, String(fx.stamp));
+    await page.waitForURL(/[?&]q=/);
+    await expect(page.getByText(fx.stories[0]!.title)).toBeVisible();
+  }
+
+  test("populated: renders seeded rows with sort + pagination controls", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    for (const s of fx.stories) {
+      await expect(page.getByText(s.title)).toBeVisible();
+    }
+    await expect(
+      page.getByRole("button", { name: "Previous page" }),
+    ).toBeVisible();
+    await expect(page.locator("#story-sort-select")).toBeVisible();
+  });
+
+  test("filters: narrator checkbox narrows results and flags the header", async ({
+    page,
+  }) => {
+    await gotoSeeded(page);
+
+    await toggleFilterCheckbox(page, "narrator", "third_person");
+    await page.waitForURL(/narrator=third_person/);
+    await expectFilteredHeader(page);
+
+    // The two third_person seeded rows remain; the two omniscient ones drop out.
+    await expect(page.getByText(fx.stories[0]!.title)).toBeVisible();
+    await expect(page.getByText(fx.stories[1]!.title)).toBeVisible();
+    await expect(page.getByText(fx.stories[2]!.title)).toHaveCount(0);
+    await expect(page.getByText(fx.stories[3]!.title)).toHaveCount(0);
+  });
+
+  test("filters: Clear all resets the query", async ({ page }) => {
+    await page.goto(`/stories?q=${fx.stamp}&narrator=third_person`);
+    await expectFilteredHeader(page);
+
+    await page.getByRole("button", { name: "Clear all" }).click();
+    await page.waitForURL(/\/stories\??$/);
+    await expect(page.getByText(/·\s*filtered/)).toHaveCount(0);
+  });
+
+  test("filtered-empty: a no-match search shows the empty message", async ({
+    page,
+  }) => {
+    await page.goto("/stories?q=zzznomatchqqq");
+
+    await expect(
+      page.getByText("No stories match these filters."),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear filters" }).click();
+    await page.waitForURL(/\/stories\??$/);
+    await expect(page.getByText("No stories match these filters.")).toHaveCount(
+      0,
+    );
+  });
+
+  test("bulk: select all seeded rows and publish them", async ({ page }) => {
+    await gotoSeeded(page);
+
+    await page.getByRole("checkbox", { name: "Select all" }).click();
+
+    const bar = page.getByRole("region", { name: "Bulk actions" });
+    await expect(bar).toBeVisible();
+    await expect(bar.getByText("4 selected")).toBeVisible();
+
+    await bar.getByRole("button", { name: "Publish", exact: true }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Publish", exact: true }).click();
+
+    // All four seeded rows now read as published. Scope the count to the table
+    // BODY: the stories status column header is literally "Published" (a <th>),
+    // and the filter-rail "Published" checkbox + the success toast also carry
+    // the word — only <tbody> holds exactly the four row badges.
+    await expect(
+      page.locator("tbody").getByText("Published", { exact: true }),
+    ).toHaveCount(4);
+  });
+
+  test("loading: the loading state shows while the query is in flight", async ({
+    page,
+  }) => {
+    const unroute = await mockListLoading(page, "stories", 3000);
+    await page.goto("/stories");
+
+    await expect(page.getByText("Loading…")).toBeVisible();
+    await expect(page.getByText("Loading…")).toBeHidden({ timeout: 15_000 });
+
+    await unroute();
+  });
+
+  test("error: a failed load shows the inline error and Retry recovers", async ({
+    page,
+  }) => {
+    const unroute = await mockListError(page, "stories");
+    await page.goto("/stories");
+
+    // Target the error alert by its text — Next's route announcer is also
+    // role="alert", so a bare getByRole("alert") is ambiguous.
+    const errorAlert = page
+      .getByRole("alert")
+      .filter({ hasText: "Failed to load stories." });
+    await expect(errorAlert).toBeVisible();
+
+    // Drop the mock, then Retry refetches against the real backend and recovers.
+    await unroute();
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByText("Failed to load stories.")).toBeHidden();
+  });
+
+  test("true-empty: an empty list shows the 'No stories yet' state", async ({
+    page,
+  }) => {
+    const unroute = await mockListEmpty(page, "stories");
+    await page.goto("/stories");
+
+    await expect(page.getByText(/No stories yet\./)).toBeVisible();
+
+    await unroute();
+  });
+});

--- a/apps/admin/e2e/support/stories-list-fixture.ts
+++ b/apps/admin/e2e/support/stories-list-fixture.ts
@@ -1,0 +1,91 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * A single seeded story, with the attributes the list-shell spec filters on.
+ */
+export interface SeededStory {
+  slug: string;
+  title: string;
+  narratorType: string;
+  published: boolean;
+}
+
+export interface StoriesListFixture {
+  /** Timestamp shared by every seeded title — the spec searches on it to
+   * isolate its own rows from the shared authenticated DB. */
+  stamp: number;
+  /** Title prefix common to all seeded stories (`E2E List <stamp>`). Typing
+   * this into the list search returns exactly the seeded set. */
+  titlePrefix: string;
+  stories: SeededStory[];
+}
+
+/**
+ * Seed a small, deterministic set of stories owned by `userId`, with varied
+ * attributes so the list-shell spec can exercise the filters against real rows:
+ * distinct `narrator_type` (Narrator checkbox — two `third_person` and two
+ * `omniscient` so a narrator=third_person filter leaves a clean 2-of-4 subset).
+ *
+ * `first_person` is deliberately avoided — the story data contract requires a
+ * `perspective_character_id` for first-person narratives (see `storySchema`),
+ * which would drag a seeded character into the fixture; the narrator filter is
+ * exercised just as well with the other two values.
+ *
+ * All rows are seeded draft so the bulk test can drive publish (`publishStory`
+ * has no precondition, unlike `publishTimeline`). The stories list is URL-driven
+ * (like events), so isolation is a full-text search on the shared timestamp
+ * baked into every title. Pair with {@link cleanupStoriesList} in an `afterAll`
+ * (the #355 teardown note).
+ */
+export async function seedStoriesList(
+  userId: string,
+): Promise<StoriesListFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+  const titlePrefix = `E2E List ${stamp}`;
+
+  // Kept under one page (PAGE_SIZE = 20) so a stamp search never paginates.
+  const specs: Omit<SeededStory, "slug" | "title" | "published">[] = [
+    { narratorType: "third_person" },
+    { narratorType: "third_person" },
+    { narratorType: "omniscient" },
+    { narratorType: "omniscient" },
+  ];
+
+  const stories: SeededStory[] = specs.map((s, i) => ({
+    ...s,
+    published: false,
+    slug: `e2e-list-story-${i}-${stamp}`,
+    title: `${titlePrefix} — ${s.narratorType} ${i}`,
+  }));
+
+  const { error } = await admin.from("stories").insert(
+    stories.map((s) => ({
+      user_id: userId,
+      slug: s.slug,
+      title: s.title,
+      narrator_type: s.narratorType,
+      published: s.published,
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, titlePrefix, stories };
+}
+
+/**
+ * Delete every story seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupStoriesList(stamp: number): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("stories")
+    .delete()
+    .ilike("slug", `e2e-list-story-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}


### PR DESCRIPTION
## What

Adds list-page-shell e2e coverage for the **stories** list — the states and shared surfaces the 7 CRUD spines never exercise: **loading, hard-error, true-empty, filtered-empty, the FilterRail, and the BulkActionBar**. Fifth of seven entity lists under #355 (events #378, timelines #379, characters #380, periods #381 already merged).

## Shape

Stories is **URL-driven** (like events/timelines/characters — `useSearchParams`/`updateParams`), so the real-data tests `waitForURL` after driving the shared filter UI and the header uses the `· filtered` variant. Reuses `apps/admin/e2e/support/list-helpers.ts` unchanged.

The 8-test shell (serial):
- populated rows + sort/pagination controls
- narrator filter round-trip (`narrator=third_person` → 2-of-4) + filtered header
- Clear all resets the query
- filtered-empty message + Clear filters
- bulk select-all → publish
- loading / error+Retry / true-empty (route interception scoped to `stories`)

## Stories-specific notes

- **`publishStory` has no precondition** (unlike `publishTimeline`, which needs a linked event) — so the fixture seeds drafts and the bulk test publishes.
- **Status column header is literally "Published"** — the post-bulk badge count is scoped to `<tbody>` (the `<th>`, filter-rail checkbox, and toast all carry the word), same as the characters gotcha.
- Sort select is `#story-sort-select`; the narrowing filter group is `narrator` (stories have no era).
- Self-cleaning fixture (`cleanupStoriesList(stamp)` in `afterAll`): four stories (two `third_person`, two `omniscient`) under a shared timestamp stamp; the stamp search isolates them from the shared authed DB. `first_person` is avoided since the data contract requires a perspective character.

## Verification

- `pnpm exec playwright test authenticated/stories-list.spec.ts --project=authenticated` → **9 passed** (incl. setup), green on first run.
- Teardown verified: 0 `e2e-list-story-%` rows remain after the run.
- `format:check`, `pnpm --filter admin run lint`, `pnpm run check-types` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)