### PR TITLE
test(admin): categories manager shell e2e (loading/empty/error) (#355)

### DIFF
--- a/apps/admin/e2e/authenticated/categories-list.spec.ts
+++ b/apps/admin/e2e/authenticated/categories-list.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupCategoriesList,
+  seedCategoriesList,
+  type CategoriesListFixture,
+} from "../support/categories-list-fixture";
+import {
+  mockListEmpty,
+  mockListError,
+  mockListLoading,
+} from "../support/list-helpers";
+
+/**
+ * Categories manager shell — the states the category CRUD spine
+ * (category-crud.spec.ts) never reaches: **loading, hard-error, and
+ * true-empty**. Same intent as the other entity list-shell specs under #355,
+ * but categories is the outlier: a two-pane tree + inspector manager, not a
+ * list/detail surface. It has NO search / FilterRail / BulkActionBar /
+ * pagination, so the shared filter + bulk surfaces don't apply — the shell here
+ * is the tree pane's three query states plus its populated header.
+ *
+ * The three states a real, non-empty DB won't produce on cue are forced with
+ * route interception scoped to the tree read (`categories`). The category
+ * usage-count query hits a different resource (`event_categories`), so the mock
+ * leaves it untouched — the tree pane's state is driven by the tree query alone.
+ * A per-suite fixture seeds two root categories (self-cleaning) for the
+ * populated assertion; the manager header counts ALL of the user's categories,
+ * so the spec matches the summary line's shape and the seeded nodes' titles
+ * rather than an exact (non-deterministic) global count.
+ *
+ * Serial so the fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("categories manager shell", () => {
+  let fx: CategoriesListFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    fx = await seedCategoriesList(userId);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupCategoriesList(fx.stamp);
+    }
+  });
+
+  test("populated: the tree renders the seeded roots and the header summary", async ({
+    page,
+  }) => {
+    await page.goto("/categories");
+
+    // Both seeded roots appear as top-level tree items (they have no parent).
+    for (const c of fx.categories) {
+      await expect(
+        page.getByRole("treeitem").filter({ hasText: c.title }),
+      ).toBeVisible();
+    }
+
+    // The header summary line renders once the tree loads. Assert its shape
+    // ("N categories · M roots"), never an exact count — the shared DB holds
+    // an unknown number of other categories.
+    await expect(page.getByText(/categor(y|ies) · \d+ root/)).toBeVisible();
+  });
+
+  test("loading: the skeleton shows while the tree query is in flight", async ({
+    page,
+  }) => {
+    const unroute = await mockListLoading(page, "categories", 3000);
+    await page.goto("/categories");
+
+    // The tree pane renders animate-pulse skeleton rows while pending; they
+    // clear once the (delayed) response resolves and the tree renders.
+    const skeleton = page.locator("main .animate-pulse");
+    await expect(skeleton.first()).toBeVisible();
+    await expect(skeleton).toHaveCount(0, { timeout: 15_000 });
+
+    await unroute();
+  });
+
+  test("error: a failed load shows the inline alert and Retry recovers", async ({
+    page,
+  }) => {
+    const unroute = await mockListError(page, "categories");
+    await page.goto("/categories");
+
+    // Target the alert by its title text — Next's route announcer is also
+    // role="alert". The `.` tolerates the title's curly apostrophe encoding.
+    await expect(page.getByText(/Couldn.t load categories/)).toBeVisible();
+
+    // Drop the mock, then Retry refetches against the real backend and recovers.
+    await unroute();
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByText(/Couldn.t load categories/)).toBeHidden();
+  });
+
+  test("true-empty: an empty tree shows the 'No categories yet' state", async ({
+    page,
+  }) => {
+    const unroute = await mockListEmpty(page, "categories");
+    await page.goto("/categories");
+
+    await expect(page.getByText("No categories yet")).toBeVisible();
+
+    await unroute();
+  });
+});

--- a/apps/admin/e2e/support/categories-list-fixture.ts
+++ b/apps/admin/e2e/support/categories-list-fixture.ts
@@ -1,0 +1,79 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * A single seeded category (kept flat — the manager shell only needs a couple
+ * of visible root nodes to render its populated state; hierarchy/reparenting is
+ * covered by the category CRUD spine, category-crud.spec.ts).
+ */
+export interface SeededCategory {
+  slug: string;
+  title: string;
+}
+
+export interface CategoriesListFixture {
+  /** Timestamp shared by every seeded title/slug — isolates this run's rows
+   * (and the cleanup) from the shared authenticated DB. */
+  stamp: number;
+  categories: SeededCategory[];
+}
+
+/**
+ * Seed a small set of root categories owned by `userId` so the manager-shell
+ * spec can assert its populated state (the tree renders, the header summary
+ * line appears). Two roots is enough — the category manager has no
+ * filter/bulk/pagination surface (it is a tree + inspector, not a list/detail),
+ * so unlike the other entity list fixtures this one carries no filterable
+ * attributes; the untested shell states (loading / hard-error / true-empty) are
+ * forced with route interception rather than data.
+ *
+ * The manager header counts ALL of the user's categories, so the spec never
+ * asserts an exact count (the shared DB is non-deterministic) — it matches the
+ * summary line's shape and asserts the seeded nodes are visible by their
+ * stamped titles. Pair with {@link cleanupCategoriesList} in an `afterAll` (the
+ * #355 teardown note).
+ */
+export async function seedCategoriesList(
+  userId: string,
+): Promise<CategoriesListFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+
+  const categories: SeededCategory[] = [
+    {
+      slug: `e2e-list-category-a-${stamp}`,
+      title: `E2E List ${stamp} — Root A`,
+    },
+    {
+      slug: `e2e-list-category-b-${stamp}`,
+      title: `E2E List ${stamp} — Root B`,
+    },
+  ];
+
+  const { error } = await admin.from("categories").insert(
+    categories.map((c) => ({
+      user_id: userId,
+      slug: c.slug,
+      title: c.title,
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, categories };
+}
+
+/**
+ * Delete every category seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupCategoriesList(stamp: number): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("categories")
+    .delete()
+    .ilike("slug", `e2e-list-category-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}

--- a/apps/admin/e2e/support/test-user.ts
+++ b/apps/admin/e2e/support/test-user.ts
@@ -56,14 +56,27 @@ export async function seedTestUser(): Promise<string> {
     }
   }
 
-  // Already existed — look the account up so we can return its id.
-  const { data: list, error: listError } = await admin.auth.admin.listUsers();
-  if (listError) {
-    throw listError;
+  // Already existed — page through the admin user list to find it. listUsers
+  // paginates (default 50 users/page) and the admin API has no getByEmail, so a
+  // single unpaged call silently misses the account once the shared local auth
+  // table exceeds one page (it accumulates a user per auth-flow run). Page until
+  // the account is found or a short page signals the end.
+  const perPage = 1000;
+  for (let page = 1; ; page++) {
+    const { data: list, error: listError } = await admin.auth.admin.listUsers({
+      page,
+      perPage,
+    });
+    if (listError) {
+      throw listError;
+    }
+    const existing = list.users.find((u) => u.email === TEST_USER.email);
+    if (existing) {
+      return existing.id;
+    }
+    if (list.users.length < perPage) {
+      break;
+    }
   }
-  const existing = list.users.find((u) => u.email === TEST_USER.email);
-  if (!existing) {
-    throw new Error(`Test user ${TEST_USER.email} not found after createUser`);
-  }
-  return existing.id;
+  throw new Error(`Test user ${TEST_USER.email} not found after createUser`);
 }


### PR DESCRIPTION
## What

Adds shell-state e2e coverage for the **categories** manager — the states the category CRUD spine ([category-crud.spec.ts](apps/admin/e2e/authenticated/category-crud.spec.ts)) never reaches: **loading, hard-error+Retry, and true-empty**. Sixth of seven entity lists under #355 (events #378, timelines #379, characters #380, periods #381, stories #383 already merged).

Also includes a **required shared-infra fix** (separate commit) that was blocking the entire authenticated suite — see below.

## Shape — categories is the outlier

Categories isn't a list/detail surface; it's a two-pane **tree + inspector manager** (wireframe 24), so it has **no search / FilterRail / BulkActionBar / pagination**. The "shell" here is the tree pane's three query states plus its populated header — no filter/bulk round-trips to test. The 4-test spec (serial):

- **populated** — the seeded roots render as tree items + the header summary line (`N categories · M roots`, shape-matched, never an exact count).
- **loading** — the skeleton rows show while the tree query is in flight.
- **error** — the inline "Couldn't load categories" alert + Retry recovers.
- **true-empty** — the "No categories yet" state.

The three forced states use route interception scoped to the tree read (`categories`). `getCategoryUsageCounts` hits a different resource (`event_categories`), so the mock leaves it untouched and the tree pane's state is driven by the tree query alone. A self-cleaning fixture seeds two root categories; the header counts **all** of the user's categories, so the spec matches the seeded titles + the summary line's shape rather than a non-deterministic global count.

## Required infra fix: `seedTestUser` paged lookup

`seedTestUser` (shared by **every** authenticated spec) looks the test account up via a single unpaged `admin.listUsers()` when `createUser` reports it already exists. `listUsers` paginates at 50 users/page and the admin API has no `getByEmail`, so once the shared local auth table exceeds one page (it gains a user per auth-flow run) the lookup silently misses the account and throws `"not found after createUser"` — failing the e2e setup and all dependent specs. This surfaced now because the local table crossed 50 rows (54). Fixed by paging through `listUsers` until the account is found. Without this, the authenticated suite can't run against a warm local DB.

## Verification

- `playwright test authenticated/categories-list.spec.ts --project=authenticated` → **5 passed** (incl. setup).
- **Full authenticated suite → 58 passed** (confirms the `test-user.ts` fix doesn't regress the other specs and unblocks them).
- Teardown verified: 0 `e2e-list-category-%` rows remain.
- `format:check`, `pnpm --filter admin run lint`, `pnpm run check-types` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)