### PR TITLE
fix(admin): clamp out-of-range page on list pages (#330)

### DIFF
--- a/apps/admin/app/(protected)/characters/_components/character-list-client.tsx
+++ b/apps/admin/app/(protected)/characters/_components/character-list-client.tsx
@@ -479,6 +479,21 @@ export function CharacterListClient() {
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
+  // Clamp an out-of-range page (e.g. a bulk delete shrank the result set below
+  // the current page, or a deep link points past the last page) back to the
+  // last valid page. Gated on !isPending so a legitimately deep-linked page
+  // isn't clamped before its data loads. Builds from window.location like
+  // updateParams (see #329) and mirrors handlePageChange's "page 1 → drop the
+  // param" convention.
+  React.useEffect(() => {
+    if (isPending || isError) return;
+    if (parsed.page <= totalPages) return;
+    const next = new URLSearchParams(window.location.search);
+    if (totalPages <= 1) next.delete("page");
+    else next.set("page", String(totalPages));
+    router.replace(`?${next.toString()}`, { scroll: false });
+  }, [isPending, isError, parsed.page, totalPages, router]);
+
   // Selection lives on the current page only; reset it whenever the query
   // (filters/sort/page) changes so stale ids never leak into a bulk action.
   const filterKey = searchParams.toString();

--- a/apps/admin/app/(protected)/events/_components/event-list-client.tsx
+++ b/apps/admin/app/(protected)/events/_components/event-list-client.tsx
@@ -552,6 +552,21 @@ export function EventListClient() {
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
+  // Clamp an out-of-range page (e.g. a bulk delete shrank the result set below
+  // the current page, or a deep link points past the last page) back to the
+  // last valid page. Gated on !isPending so a legitimately deep-linked page
+  // isn't clamped before its data loads. Builds from window.location like
+  // updateParams (see #329) and mirrors handlePageChange's "page 1 → drop the
+  // param" convention.
+  React.useEffect(() => {
+    if (isPending || isError) return;
+    if (parsed.page <= totalPages) return;
+    const next = new URLSearchParams(window.location.search);
+    if (totalPages <= 1) next.delete("page");
+    else next.set("page", String(totalPages));
+    router.replace(`?${next.toString()}`, { scroll: false });
+  }, [isPending, isError, parsed.page, totalPages, router]);
+
   // Selection lives on the current page only; reset it whenever the query
   // (filters/sort/page) changes so stale ids never leak into a bulk action.
   // Keyed on the stable URL string and done in render (not an effect), per the

--- a/apps/admin/app/(protected)/stories/_components/story-list-client.tsx
+++ b/apps/admin/app/(protected)/stories/_components/story-list-client.tsx
@@ -416,6 +416,21 @@ export function StoryListClient() {
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
+  // Clamp an out-of-range page (e.g. a bulk delete shrank the result set below
+  // the current page, or a deep link points past the last page) back to the
+  // last valid page. Gated on !isPending so a legitimately deep-linked page
+  // isn't clamped before its data loads. Builds from window.location like
+  // updateParams (see #329) and mirrors handlePageChange's "page 1 → drop the
+  // param" convention.
+  React.useEffect(() => {
+    if (isPending || isError) return;
+    if (parsed.page <= totalPages) return;
+    const next = new URLSearchParams(window.location.search);
+    if (totalPages <= 1) next.delete("page");
+    else next.set("page", String(totalPages));
+    router.replace(`?${next.toString()}`, { scroll: false });
+  }, [isPending, isError, parsed.page, totalPages, router]);
+
   // Selection lives on the current page only; reset whenever the query changes.
   const filterKey = searchParams.toString();
   const [prevFilterKey, setPrevFilterKey] = React.useState(filterKey);

--- a/apps/admin/app/(protected)/timelines/_components/timeline-list-client.tsx
+++ b/apps/admin/app/(protected)/timelines/_components/timeline-list-client.tsx
@@ -411,7 +411,22 @@ export function TimelineListClient() {
     [data],
   );
   const total = data?.total ?? 0;
-  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  // Clamp an out-of-range page (e.g. a bulk delete shrank the result set below
+  // the current page, or a deep link points past the last page) back to the
+  // last valid page. Gated on !isPending so a legitimately deep-linked page
+  // isn't clamped before its data loads. Builds from window.location like
+  // updateParams (see #329) and mirrors handlePageChange's "page 1 → drop the
+  // param" convention.
+  React.useEffect(() => {
+    if (isPending || isError) return;
+    if (page <= totalPages) return;
+    const next = new URLSearchParams(window.location.search);
+    if (totalPages <= 1) next.delete("page");
+    else next.set("page", String(totalPages));
+    router.replace(`?${next.toString()}`, { scroll: false });
+  }, [isPending, isError, page, totalPages, router]);
 
   // Reset selection whenever the query (filters/sort/page) changes. Keyed on the
   // stable URL string — `filters` is a fresh object each render, so comparing it

--- a/apps/admin/e2e/authenticated/characters-pagination.spec.ts
+++ b/apps/admin/e2e/authenticated/characters-pagination.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupCharactersPageOverflow,
+  seedCharactersPageOverflow,
+  PAGE_SIZE,
+  type CharactersPageOverflowFixture,
+} from "../support/characters-pagination-fixture";
+
+/**
+ * Characters list pagination clamp — regression coverage for #330 (a list page
+ * must not strand the user on an out-of-range page). Both entry paths are
+ * exercised on characters; the clamp itself is byte-identical across the four
+ * paginated list clients (characters/events/stories/timelines), so one entity's
+ * coverage guards the shared implementation. The list-shell specs already assert
+ * every list renders its pagination controls.
+ *
+ * Both scenarios reach the clamp through the same in-range response (from ==
+ * count → PostgREST 206 empty, not a 416 error), which is exactly the state
+ * `getCharactersPage` returns when the current page sits just past a shrunken
+ * result set. A deep link far beyond the end (from > count) instead 416s into
+ * the list's error state — a separate, pre-existing gap the clamp deliberately
+ * does not touch (it is gated on !isError so a transient error never yanks the
+ * user off their page).
+ *
+ * Runs under the `authenticated` project (starts signed in) against the real
+ * backend. Serial so each fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("characters list pagination clamp — deep link", () => {
+  let fx: CharactersPageOverflowFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    // Exactly one full page: a deep link to page 2 requests offset == count,
+    // the empty boundary that triggers the clamp without any mutation.
+    fx = await seedCharactersPageOverflow(userId, PAGE_SIZE);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupCharactersPageOverflow(fx.stamp);
+    }
+  });
+
+  test("landing on an empty page-past-the-end clamps to the last valid page", async ({
+    page,
+  }) => {
+    // 20 seeded rows fill page 1 exactly; page 2 is empty. Deep-linking there
+    // must auto-correct after the data loads (the clamp is gated on !isPending,
+    // so it fires once, not before the initial load resolves): page 1 is the
+    // last valid page, so the param is dropped entirely and the rows render
+    // instead of a blank table.
+    await page.goto(`/characters?page=2&q=${fx.stamp}`);
+    await page.waitForURL((url) => !url.searchParams.has("page"));
+    // The clamp does a second round-trip (empty page 2 → refetch page 1), so
+    // allow the shell's usual generous timeout for the rows to land.
+    await expect(page.getByText(fx.names[0]!)).toBeVisible({ timeout: 15_000 });
+  });
+});
+
+test.describe("characters list pagination clamp — bulk delete", () => {
+  let fx: CharactersPageOverflowFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    // One row past a full page so a single character sits alone on page 2;
+    // deleting it shrinks the set to one page.
+    fx = await seedCharactersPageOverflow(userId, PAGE_SIZE + 1);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupCharactersPageOverflow(fx.stamp);
+    }
+  });
+
+  test("deleting the last page's only row clamps off the now-empty page", async ({
+    page,
+  }) => {
+    // 21 seeded rows filtered by stamp → page 2 holds exactly one. Land there
+    // directly; page 2 is valid at this point, so nothing clamps yet.
+    await page.goto(`/characters?page=2&q=${fx.stamp}`);
+    await page.waitForURL(/[?&]page=2/);
+
+    // Exactly one row on page 2 → "Select all" selects just that row.
+    await page.getByRole("checkbox", { name: "Select all" }).click();
+    const bar = page.getByRole("region", { name: "Bulk actions" });
+    await expect(bar.getByText("1 selected")).toBeVisible();
+
+    // Delete → batched confirm dialog → confirm. (The bar button and the dialog
+    // button both read "Delete", so scope each to its container.)
+    await bar.getByRole("button", { name: "Delete", exact: true }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(/Delete 1 character\?/)).toBeVisible();
+    await dialog.getByRole("button", { name: "Delete", exact: true }).click();
+
+    // The delete drops total to 20 (one page). The clamp must move off page 2;
+    // page 1 is the last valid page, so the param is dropped and the remaining
+    // rows render instead of a blank table.
+    await page.waitForURL((url) => !url.searchParams.has("page"));
+    // The clamp does a second round-trip (empty page 2 → refetch page 1), so
+    // allow the shell's usual generous timeout for the rows to land.
+    await expect(page.getByText(fx.names[0]!)).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/apps/admin/e2e/authenticated/events-pagination.spec.ts
+++ b/apps/admin/e2e/authenticated/events-pagination.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupEventsPageOverflow,
+  seedEventsPageOverflow,
+  PAGE_SIZE,
+  type EventsPageOverflowFixture,
+} from "../support/events-pagination-fixture";
+
+/**
+ * Events list pagination clamp — regression coverage for #330 (a list page must
+ * not strand the user on an out-of-range page). The events list has no bulk
+ * delete (only publish/unpublish), so the reachable clamp trigger is a deep
+ * link to an empty page-past-the-end; the clamp itself is byte-identical across
+ * the four paginated list clients. See `characters-pagination.spec.ts` for the
+ * full-scenario (bulk-delete) coverage and the from == count / from > count
+ * explanation.
+ *
+ * Runs under the `authenticated` project (starts signed in). Serial so the
+ * fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("events list pagination clamp — deep link", () => {
+  let fx: EventsPageOverflowFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    // Exactly one full page: a deep link to page 2 requests offset == count,
+    // the empty boundary that triggers the clamp without any mutation.
+    fx = await seedEventsPageOverflow(userId, PAGE_SIZE);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupEventsPageOverflow(fx.stamp);
+    }
+  });
+
+  test("landing on an empty page-past-the-end clamps to the last valid page", async ({
+    page,
+  }) => {
+    // 20 seeded rows fill page 1 exactly; page 2 is empty. Deep-linking there
+    // must auto-correct after the data loads (the clamp is gated on !isPending):
+    // page 1 is the last valid page, so the param is dropped and the rows render
+    // instead of a blank table.
+    await page.goto(`/events?page=2&q=${fx.stamp}`);
+    await page.waitForURL((url) => !url.searchParams.has("page"));
+    // The clamp does a second round-trip (empty page 2 → refetch page 1), so
+    // allow the shell's usual generous timeout for the rows to land.
+    await expect(page.getByText(fx.titles[0]!)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/admin/e2e/authenticated/stories-pagination.spec.ts
+++ b/apps/admin/e2e/authenticated/stories-pagination.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupStoriesPageOverflow,
+  seedStoriesPageOverflow,
+  PAGE_SIZE,
+  type StoriesPageOverflowFixture,
+} from "../support/stories-pagination-fixture";
+
+/**
+ * Stories list pagination clamp — regression coverage for #330 (a list page
+ * must not strand the user on an out-of-range page). Covers the deep-link
+ * trigger (an empty page-past-the-end); the clamp itself is byte-identical
+ * across the four paginated list clients. See `characters-pagination.spec.ts`
+ * for the full-scenario (bulk-delete) coverage and the from == count / from >
+ * count explanation.
+ *
+ * Runs under the `authenticated` project (starts signed in). Serial so the
+ * fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("stories list pagination clamp — deep link", () => {
+  let fx: StoriesPageOverflowFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    // Exactly one full page: a deep link to page 2 requests offset == count,
+    // the empty boundary that triggers the clamp without any mutation.
+    fx = await seedStoriesPageOverflow(userId, PAGE_SIZE);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupStoriesPageOverflow(fx.stamp);
+    }
+  });
+
+  test("landing on an empty page-past-the-end clamps to the last valid page", async ({
+    page,
+  }) => {
+    // 20 seeded rows fill page 1 exactly; page 2 is empty. Deep-linking there
+    // must auto-correct after the data loads (the clamp is gated on !isPending):
+    // page 1 is the last valid page, so the param is dropped and the rows render
+    // instead of a blank table.
+    await page.goto(`/stories?page=2&q=${fx.stamp}`);
+    await page.waitForURL((url) => !url.searchParams.has("page"));
+    // The clamp does a second round-trip (empty page 2 → refetch page 1), so
+    // allow the shell's usual generous timeout for the rows to land.
+    await expect(page.getByText(fx.titles[0]!)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/admin/e2e/authenticated/timelines-pagination.spec.ts
+++ b/apps/admin/e2e/authenticated/timelines-pagination.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { seedTestUser } from "../support/test-user";
+import {
+  cleanupTimelinesPageOverflow,
+  seedTimelinesPageOverflow,
+  PAGE_SIZE,
+  type TimelinesPageOverflowFixture,
+} from "../support/timelines-pagination-fixture";
+
+/**
+ * Timelines list pagination clamp — regression coverage for #330 (a list page
+ * must not strand the user on an out-of-range page). The timelines list has no
+ * bulk delete (only publish/unpublish), so the reachable clamp trigger is a
+ * deep link to an empty page-past-the-end; the clamp itself is byte-identical
+ * across the four paginated list clients. See `characters-pagination.spec.ts`
+ * for the full-scenario (bulk-delete) coverage and the from == count / from >
+ * count explanation.
+ *
+ * Runs under the `authenticated` project (starts signed in). Serial so the
+ * fixture seeds once and tears down once.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("timelines list pagination clamp — deep link", () => {
+  let fx: TimelinesPageOverflowFixture;
+
+  test.beforeAll(async () => {
+    const userId = await seedTestUser();
+    // Exactly one full page: a deep link to page 2 requests offset == count,
+    // the empty boundary that triggers the clamp without any mutation.
+    fx = await seedTimelinesPageOverflow(userId, PAGE_SIZE);
+  });
+
+  test.afterAll(async () => {
+    if (fx) {
+      await cleanupTimelinesPageOverflow(fx.stamp);
+    }
+  });
+
+  test("landing on an empty page-past-the-end clamps to the last valid page", async ({
+    page,
+  }) => {
+    // 20 seeded rows fill page 1 exactly; page 2 is empty. Deep-linking there
+    // must auto-correct after the data loads (the clamp is gated on !isPending):
+    // page 1 is the last valid page, so the param is dropped and the rows render
+    // instead of a blank table.
+    await page.goto(`/timelines?page=2&q=${fx.stamp}`);
+    await page.waitForURL((url) => !url.searchParams.has("page"));
+    // The clamp does a second round-trip (empty page 2 → refetch page 1), so
+    // allow the shell's usual generous timeout for the rows to land.
+    await expect(page.getByText(fx.titles[0]!)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/admin/e2e/support/characters-pagination-fixture.ts
+++ b/apps/admin/e2e/support/characters-pagination-fixture.ts
@@ -1,0 +1,75 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * Fixture for the pagination-clamp regression (#330). Unlike the list-shell
+ * fixtures (which keep rows under one page on purpose), this seeds
+ * `PAGE_SIZE + 1` characters so exactly one row lands on page 2 — deleting it
+ * shrinks the result set to a single page and must clamp the URL off page 2.
+ */
+export interface CharactersPageOverflowFixture {
+  /** Timestamp shared by every seeded name/slug; the spec searches on it to
+   * isolate its own rows from the shared authenticated DB. */
+  stamp: number;
+  /** Name prefix common to all seeded characters (`E2E Pg <stamp>`). */
+  namePrefix: string;
+  /** Seeded names in insertion order. `names[0]` sorts first (page 1). */
+  names: string[];
+}
+
+// PAGE_SIZE is 20 in every list client. The two clamp scenarios need different
+// counts: a full page (20) so a deep link to page 2 lands on the from==count
+// empty boundary (PostgREST 206, not a 416), and one extra row (21) so a single
+// character sits alone on page 2 for the bulk-delete path. Keep in sync if the
+// list PAGE_SIZE ever changes.
+export const PAGE_SIZE = 20;
+
+/**
+ * Seed `count` draft characters owned by `userId`, all sharing a timestamped
+ * name/slug so the spec can search down to exactly this set (the shared
+ * authenticated DB is non-deterministic — never assert global counts, per
+ * #355). Pair with {@link cleanupCharactersPageOverflow} in an `afterAll`.
+ */
+export async function seedCharactersPageOverflow(
+  userId: string,
+  count: number,
+): Promise<CharactersPageOverflowFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+  const namePrefix = `E2E Pg ${stamp}`;
+
+  const names = Array.from({ length: count }, (_, i) => `${namePrefix} — ${i}`);
+
+  const { error } = await admin.from("characters").insert(
+    names.map((name, i) => ({
+      user_id: userId,
+      slug: `e2e-pg-character-${i}-${stamp}`,
+      name,
+      character_type: "human",
+      significance: "medium",
+      published: false,
+      birth_temporal: { era: "CE", year: 1000 + i },
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, namePrefix, names };
+}
+
+/**
+ * Delete every character seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupCharactersPageOverflow(
+  stamp: number,
+): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("characters")
+    .delete()
+    .ilike("slug", `e2e-pg-character-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}

--- a/apps/admin/e2e/support/events-pagination-fixture.ts
+++ b/apps/admin/e2e/support/events-pagination-fixture.ts
@@ -1,0 +1,73 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * Fixture for the events list pagination-clamp regression (#330). Unlike the
+ * list-shell fixture (which keeps rows under one page on purpose), this seeds a
+ * caller-chosen `count` so a deep link to the next page lands on the from ==
+ * count empty boundary (PostgREST 206) that triggers the clamp.
+ */
+export interface EventsPageOverflowFixture {
+  /** Timestamp shared by every seeded title/slug; the spec searches on it to
+   * isolate its own rows from the shared authenticated DB. */
+  stamp: number;
+  /** Title prefix common to all seeded events (`E2E Pg <stamp>`). */
+  titlePrefix: string;
+  /** Seeded titles in insertion order. */
+  titles: string[];
+}
+
+// PAGE_SIZE is 20 in every list client; a deep link to page 2 of an exactly-full
+// page requests offset == count, the empty boundary the clamp recovers from.
+export const PAGE_SIZE = 20;
+
+/**
+ * Seed `count` draft events owned by `userId`, all sharing a timestamped
+ * title/slug so the spec can search down to exactly this set (the shared
+ * authenticated DB is non-deterministic — never assert global counts, per
+ * #355). Pair with {@link cleanupEventsPageOverflow} in an `afterAll`.
+ */
+export async function seedEventsPageOverflow(
+  userId: string,
+  count: number,
+): Promise<EventsPageOverflowFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+  const titlePrefix = `E2E Pg ${stamp}`;
+
+  const titles = Array.from(
+    { length: count },
+    (_, i) => `${titlePrefix} — ${i}`,
+  );
+
+  const { error } = await admin.from("events").insert(
+    titles.map((title, i) => ({
+      user_id: userId,
+      slug: `e2e-pg-event-${i}-${stamp}`,
+      title,
+      event_type: "milestone",
+      importance: 5,
+      published: false,
+      temporal_data: { era: "CE", year: 2000 + i },
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, titlePrefix, titles };
+}
+
+/**
+ * Delete every event seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupEventsPageOverflow(stamp: number): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("events")
+    .delete()
+    .ilike("slug", `e2e-pg-event-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}

--- a/apps/admin/e2e/support/stories-pagination-fixture.ts
+++ b/apps/admin/e2e/support/stories-pagination-fixture.ts
@@ -1,0 +1,73 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * Fixture for the stories list pagination-clamp regression (#330). Unlike the
+ * list-shell fixture (which keeps rows under one page on purpose), this seeds a
+ * caller-chosen `count` so a deep link to the next page lands on the from ==
+ * count empty boundary (PostgREST 206) that triggers the clamp.
+ */
+export interface StoriesPageOverflowFixture {
+  /** Timestamp shared by every seeded title/slug; the spec searches on it to
+   * isolate its own rows from the shared authenticated DB. */
+  stamp: number;
+  /** Title prefix common to all seeded stories (`E2E Pg <stamp>`). */
+  titlePrefix: string;
+  /** Seeded titles in insertion order. */
+  titles: string[];
+}
+
+// PAGE_SIZE is 20 in every list client; a deep link to page 2 of an exactly-full
+// page requests offset == count, the empty boundary the clamp recovers from.
+export const PAGE_SIZE = 20;
+
+/**
+ * Seed `count` draft stories owned by `userId`, all sharing a timestamped
+ * title/slug so the spec can search down to exactly this set (the shared
+ * authenticated DB is non-deterministic — never assert global counts, per
+ * #355). `third_person` narrator avoids the first-person perspective-character
+ * precondition (see the list-shell fixture note). Pair with
+ * {@link cleanupStoriesPageOverflow} in an `afterAll`.
+ */
+export async function seedStoriesPageOverflow(
+  userId: string,
+  count: number,
+): Promise<StoriesPageOverflowFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+  const titlePrefix = `E2E Pg ${stamp}`;
+
+  const titles = Array.from(
+    { length: count },
+    (_, i) => `${titlePrefix} — ${i}`,
+  );
+
+  const { error } = await admin.from("stories").insert(
+    titles.map((title, i) => ({
+      user_id: userId,
+      slug: `e2e-pg-story-${i}-${stamp}`,
+      title,
+      narrator_type: "third_person",
+      published: false,
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, titlePrefix, titles };
+}
+
+/**
+ * Delete every story seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupStoriesPageOverflow(stamp: number): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("stories")
+    .delete()
+    .ilike("slug", `e2e-pg-story-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}

--- a/apps/admin/e2e/support/timelines-pagination-fixture.ts
+++ b/apps/admin/e2e/support/timelines-pagination-fixture.ts
@@ -1,0 +1,75 @@
+import { createServiceRoleClient } from "./supabase-admin";
+
+/**
+ * Fixture for the timelines list pagination-clamp regression (#330). Unlike the
+ * list-shell fixture (which keeps rows under one page on purpose), this seeds a
+ * caller-chosen `count` so a deep link to the next page lands on the from ==
+ * count empty boundary (PostgREST 206) that triggers the clamp.
+ */
+export interface TimelinesPageOverflowFixture {
+  /** Timestamp shared by every seeded title/slug; the spec searches on it to
+   * isolate its own rows from the shared authenticated DB. */
+  stamp: number;
+  /** Title prefix common to all seeded timelines (`E2E Pg <stamp>`). */
+  titlePrefix: string;
+  /** Seeded titles in insertion order. */
+  titles: string[];
+}
+
+// PAGE_SIZE is 20 in every list client; a deep link to page 2 of an exactly-full
+// page requests offset == count, the empty boundary the clamp recovers from.
+export const PAGE_SIZE = 20;
+
+/**
+ * Seed `count` draft timelines owned by `userId`, all sharing a timestamped
+ * title/slug so the spec can search down to exactly this set (the shared
+ * authenticated DB is non-deterministic — never assert global counts, per
+ * #355). Pair with {@link cleanupTimelinesPageOverflow} in an `afterAll`.
+ */
+export async function seedTimelinesPageOverflow(
+  userId: string,
+  count: number,
+): Promise<TimelinesPageOverflowFixture> {
+  const admin = createServiceRoleClient();
+  const stamp = Date.now();
+  const titlePrefix = `E2E Pg ${stamp}`;
+
+  const titles = Array.from(
+    { length: count },
+    (_, i) => `${titlePrefix} — ${i}`,
+  );
+
+  const { error } = await admin.from("timelines").insert(
+    titles.map((title, i) => ({
+      user_id: userId,
+      slug: `e2e-pg-timeline-${i}-${stamp}`,
+      title,
+      timeline_type: "general",
+      visibility: "private",
+      published: false,
+      temporal_data: { era: "CE", year: 2000 + i },
+    })),
+  );
+  if (error) {
+    throw error;
+  }
+
+  return { stamp, titlePrefix, titles };
+}
+
+/**
+ * Delete every timeline seeded under `stamp` (matched by the timestamp in the
+ * slug). Idempotent; call from `afterAll` so a run leaves the shared DB clean.
+ */
+export async function cleanupTimelinesPageOverflow(
+  stamp: number,
+): Promise<void> {
+  const admin = createServiceRoleClient();
+  const { error } = await admin
+    .from("timelines")
+    .delete()
+    .ilike("slug", `e2e-pg-timeline-%-${stamp}`);
+  if (error) {
+    throw error;
+  }
+}


### PR DESCRIPTION
## What & why

Closes #330. The four paginated admin list clients (characters, events, stories, timelines) never re-checked the URL `page` against the freshly-computed `totalPages`. When the result set shrank below the current page — e.g. a **bulk delete** emptied the last page — the query refetched with the stale `page`, PostgREST returned an empty range while `total` stayed > 0, so none of the empty-state branches fired. The user was **stranded on a blank table** with a non-zero header count and a disabled Next button, recoverable only by manually clicking Prev/page 1.

## The fix

A page-clamp `useEffect` added to each of the four `*-list-client.tsx` components. When `page > totalPages` after data loads, it rewrites the URL to the last valid page (dropping `?page=` when that's page 1).

Key design points:
- **An effect, not the render-phase state-sync idiom** the files use elsewhere — `router.replace` can't run during render.
- **Gated on `!isPending`** so a legitimately deep-linked page (e.g. `?page=2` of a real 2-page set) isn't clamped to page 1 before its data loads.
- **Gated on `!isError`** so a transient error never yanks the user off their page (on error `data` is undefined → `totalPages` collapses to 1).
- Deps are all primitives + the stable `router`, so `react-hooks/exhaustive-deps` stays clean under the zero-warnings policy — no `eslint-disable`.
- No infinite loop: after the clamp, `page === totalPages`, so the guard short-circuits.
- Also normalized the `timelines` `totalPages` to the `Math.max(1, …)` guard the other three already had.

## Tests

A dedicated Playwright pagination spec per entity (authenticated project), each with its own overflow fixture. Every clamp is reachable only through the `from == count` empty boundary (PostgREST **206**), so:
- **Deep-link tests** (all four) seed exactly one full page (20 rows) and navigate to page 2 → clamp drops the param.
- **characters** additionally covers the full **bulk-delete** scenario (21 rows → delete the lone page-2 row → clamp), the originally-reported trigger. events/timelines have no bulk delete (publish/unpublish only), so deep-link is their reachable trigger; the clamp code is identical across all four.

Post-clamp assertions use the shell's 15s timeout to absorb the clamp's extra round-trip (empty page 2 → refetch page 1). All pagination specs pass; the 33 existing list-shell specs stay green.

> Note: e2e is excluded from CI and the pre-push `test:coverage` hook — these specs were run manually against local Supabase (`pnpm test:e2e --project=authenticated`).

## Follow-up

Deep-linking **far** past the end (`from > count` → PostgREST **416** → error state instead of clamping) is a separate, pre-existing gap the clamp deliberately does not touch (clamping on generic errors would be unsafe). Tracked in #388.

## Verification
`format`, `check-types`, `lint`, `build`, and `test:coverage` all pass. Pagination specs + list-shell specs verified against local Supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)