### PR TITLE
fix(services): draft filter must match nullable published rows (#331)

### DIFF
--- a/packages/services/src/modules/character-service.test.ts
+++ b/packages/services/src/modules/character-service.test.ts
@@ -204,12 +204,12 @@ describe("getCharacters", () => {
     expect(builder.eq).toHaveBeenCalledWith("published", true);
   });
 
-  it("applies published=false filter", async () => {
+  it("applies published=false as `not published is true` (matches NULL drafts) (#331)", async () => {
     const client = makeClient({ fromResult: { data: [], error: null } });
     await getCharacters(client, { published: false });
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
-    expect(builder.eq).toHaveBeenCalledWith("published", false);
+    expect(builder.not).toHaveBeenCalledWith("published", "is", true);
   });
 
   it("selects an inner has-media embed when hasMedia=true", async () => {

--- a/packages/services/src/modules/character-service.ts
+++ b/packages/services/src/modules/character-service.ts
@@ -213,7 +213,13 @@ export async function getCharacters(
     query = query.eq("user_id", userId);
   }
   if (published !== undefined) {
-    query = query.eq("published", published);
+    // "draft" (published === false) must also match NULL rows — mirrors the
+    // getCharactersPage note below; `not.is.true` = published IS NOT TRUE
+    // (false OR NULL), matching the list badge that renders NULL as "Draft".
+    // See #331.
+    query = published
+      ? query.eq("published", true)
+      : query.not("published", "is", true);
   }
   if (hasMedia === false) {
     query = query.is("character_media", null);

--- a/packages/services/src/modules/event-service.test.ts
+++ b/packages/services/src/modules/event-service.test.ts
@@ -391,6 +391,16 @@ describe("getEventsPage", () => {
     expect(firstBuilder(client).eq).toHaveBeenCalledWith("published", true);
   });
 
+  it("applies published=false as `not published is true` (matches NULL drafts) (#331)", async () => {
+    const client = pageClient(0);
+    await getEventsPage(client, { published: false });
+    expect(firstBuilder(client).not).toHaveBeenCalledWith(
+      "published",
+      "is",
+      true,
+    );
+  });
+
   it("keeps events with participants via an !inner embed", async () => {
     const client = pageClient(0);
     await getEventsPage(client, { hasParticipants: true });

--- a/packages/services/src/modules/event-service.ts
+++ b/packages/services/src/modules/event-service.ts
@@ -300,7 +300,14 @@ export async function getEventsPage(
     query = query.eq("user_id", userId);
   }
   if (published !== undefined) {
-    query = query.eq("published", published);
+    // "draft" (published === false) must also match NULL rows: `published` is
+    // nullable (BOOLEAN DEFAULT false, no NOT NULL — migration 00001) and the
+    // list badge renders NULL as "Draft", so the filter has to too — otherwise
+    // a NULL row shows "Draft" yet vanishes under the Draft filter.
+    // `not.is.true` = published IS NOT TRUE (false OR NULL). See #331.
+    query = published
+      ? query.eq("published", true)
+      : query.not("published", "is", true);
   }
 
   // "has at least one" is handled by the `!inner` embed above. "has none" has no

--- a/packages/services/src/modules/timeline-service.test.ts
+++ b/packages/services/src/modules/timeline-service.test.ts
@@ -47,6 +47,7 @@ function makeBuilder(result: {
     upsert: vi.fn().mockReturnThis(),
     delete: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
     in: vi.fn().mockReturnThis(),
     ilike: vi.fn().mockReturnThis(),
     textSearch: vi.fn().mockReturnThis(),
@@ -323,14 +324,14 @@ describe("getTimelinesPage", () => {
     expect(builder.eq).toHaveBeenCalledWith("published", true);
   });
 
-  it("applies published=false filter", async () => {
+  it("applies published=false as `not published is true` (matches NULL drafts) (#331)", async () => {
     const client = makeClient({
       fromResult: { data: [], error: null, count: 0 },
     });
     await getTimelinesPage(client, { published: false });
     const builder = (client.from as ReturnType<typeof vi.fn>).mock.results[0]
       ?.value as ReturnType<typeof makeBuilder>;
-    expect(builder.eq).toHaveBeenCalledWith("published", false);
+    expect(builder.not).toHaveBeenCalledWith("published", "is", true);
   });
 
   it("sorts by title ascending", async () => {

--- a/packages/services/src/modules/timeline-service.ts
+++ b/packages/services/src/modules/timeline-service.ts
@@ -182,7 +182,14 @@ export async function getTimelinesPage(
   // Only filter by published when exactly one value is requested.
   // Omitting the predicate when both or neither are selected avoids a no-op filter.
   if (published !== undefined) {
-    query = query.eq("published", published);
+    // "draft" (published === false) must also match NULL rows: `published` is
+    // nullable (BOOLEAN DEFAULT false, no NOT NULL — migration 00001) and the
+    // list badge renders NULL as "Draft", so the filter has to too — otherwise
+    // a NULL row shows "Draft" yet vanishes under the Draft filter.
+    // `not.is.true` = published IS NOT TRUE (false OR NULL). See #331.
+    query = published
+      ? query.eq("published", true)
+      : query.not("published", "is", true);
   }
 
   if (userId !== undefined) {


### PR DESCRIPTION
## What & why

Closes #331. `published` is `BOOLEAN DEFAULT false` with **no NOT NULL constraint** (migration `00001_initial_schema.sql`), so the column is nullable and the admin list badges render `NULL` as **"Draft"**. But three list-query paths filtered drafts with `.eq("published", false)`, which in SQL does **not** match `NULL`. A `published IS NULL` row therefore displayed "Draft" in the table yet **disappeared when the user filtered to Draft**.

## The fix

Switch the draft branch from `.eq("published", false)` to `.not("published", "is", true)` (`published IS NOT TRUE` = `false OR NULL`) in the three remaining buggy list paths:

- **`getEventsPage`** (event-service)
- **`getTimelinesPage`** (timeline-service)
- **`getCharacters`** (character-service — the non-paginated getter named in the issue title)

This mirrors the pattern **already applied** to `getCharactersPage`, its facet counts, and the entire stories service in #55's review follow-up (commit `40903f2`) — the established convention for this repo. No migration: a `NOT NULL` change would contradict the already-committed query-level fix.

## Scope notes

- The **characters list page and its facet counts** were already fixed — this PR finishes the sibling paths the issue's "audit these too" note called out.
- **Events and timelines have no published/draft facet-count functions**, so only the *filter* half of the bug existed there; there was no count-half to fix.
- Reproduction requires a `published = NULL` row, only reachable via direct SQL / bulk import (the app's create/publish/unpublish flow always writes `true`/`false`).

## Tests

Following the existing `#331` convention (`expect(builder.not).toHaveBeenCalledWith("published", "is", true)`):
- Updated the `getCharacters` and `getTimelinesPage` `published=false` tests (they asserted the old `.eq(..., false)`).
- Added a `published=false` test to `getEventsPage` (it previously covered only `true`).
- Added the missing `not` method to the timeline test's mock builder — `getTimelinesPage` never called `.not` before.

## Verification
`format`, `check-types`, `lint`, `test:coverage`, and `build` all pass (310/310 across the three affected suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)