### PR TITLE
fix(admin): make timeline detail list-view events clickable (#391)

### DIFF
--- a/apps/admin/app/(protected)/timelines/[id]/_components/timeline-detail-client.tsx
+++ b/apps/admin/app/(protected)/timelines/[id]/_components/timeline-detail-client.tsx
@@ -264,7 +264,7 @@ function EventRowItem({
       <div className="flex-1 min-w-0">
         <Link
           href={`/events/${event.slug}`}
-          className="text-sm font-medium truncate block after:absolute after:inset-0 after:rounded-md hover:underline focus-visible:underline focus-visible:outline-none"
+          className="text-sm font-medium truncate block after:absolute after:inset-0 after:rounded-md focus-visible:underline focus-visible:outline-none"
         >
           {event.title}
         </Link>

--- a/apps/admin/app/(protected)/timelines/[id]/_components/timeline-detail-client.tsx
+++ b/apps/admin/app/(protected)/timelines/[id]/_components/timeline-detail-client.tsx
@@ -227,9 +227,9 @@ function EventRowItem({
   onUnlink,
 }: EventRowProps) {
   return (
-    <div className="flex items-center gap-2 px-4 py-3 border border-border rounded-md bg-background hover:bg-muted/30 transition-colors">
+    <div className="relative flex items-center gap-2 px-4 py-3 border border-border rounded-md bg-background hover:bg-muted/30 transition-colors">
       {canEdit && (
-        <div className="flex flex-col gap-0.5 shrink-0">
+        <div className="relative z-10 flex flex-col gap-0.5 shrink-0">
           <button
             type="button"
             disabled={index === 0}
@@ -262,9 +262,12 @@ function EventRowItem({
       </div>
 
       <div className="flex-1 min-w-0">
-        <span className="text-sm font-medium truncate block">
+        <Link
+          href={`/events/${event.slug}`}
+          className="text-sm font-medium truncate block after:absolute after:inset-0 after:rounded-md hover:underline focus-visible:underline focus-visible:outline-none"
+        >
           {event.title}
-        </span>
+        </Link>
       </div>
 
       <div className="flex items-center gap-1.5 shrink-0">
@@ -299,7 +302,7 @@ function EventRowItem({
           <button
             type="button"
             onClick={() => onUnlink(event)}
-            className="ml-1 p-1 rounded text-muted-foreground hover:text-destructive"
+            className="relative z-10 ml-1 p-1 rounded text-muted-foreground hover:text-destructive"
             aria-label="Unlink event"
           >
             <X className="h-3.5 w-3.5" />

--- a/apps/admin/e2e/authenticated/fractal-drill-down.spec.ts
+++ b/apps/admin/e2e/authenticated/fractal-drill-down.spec.ts
@@ -57,4 +57,22 @@ test.describe("fractal drill-down", () => {
     await expandableItem.click();
     await page.waitForURL(`**/events/${fx.expandableEventSlug}`);
   });
+
+  test("List view: clicking an event row navigates to its event page (#391)", async ({
+    page,
+  }) => {
+    await page.goto(`/timelines/${fx.timelineId}`);
+
+    // The Events tab defaults to List view — no toggle needed.
+    const listButton = page
+      .getByRole("group", { name: "Events view" })
+      .getByRole("button", { name: "list" });
+    await expect(listButton).toHaveAttribute("aria-pressed", "true");
+
+    // Each list row exposes its title as a link to the event detail page.
+    const plainRowLink = page.getByRole("link", { name: fx.plainEventTitle });
+    await expect(plainRowLink).toBeVisible();
+    await plainRowLink.click();
+    await page.waitForURL(`**/events/${fx.plainEventSlug}`);
+  });
 });


### PR DESCRIPTION
## Summary

In the timeline detail page's **Events** tab, list-view rows were not clickable — you could see an event but not open it. Only **tree** view wired navigation to the event detail page, and list is the default view, so most users hit the dead rows first.

This makes the whole list row clickable using the **stretched-link overlay** pattern:
- The event title becomes a `next/link` to `/events/${slug}` with an `after:absolute after:inset-0` overlay stretching the hit area across the row.
- The move-up/down and unlink controls get `relative z-10` so they stay independently clickable above the overlay.

Result: full-row click **plus** real anchor semantics — keyboard focus + Enter, and cmd/ctrl-click to open in a new tab — without invalid nested-interactive HTML. Matches how tree view already navigates.

## Changes
- `apps/admin/.../timelines/[id]/_components/timeline-detail-client.tsx` — `EventRowItem` only.
- `apps/admin/e2e/authenticated/fractal-drill-down.spec.ts` — adds an e2e test covering list-view row navigation.

## Verification
- New e2e test passes; existing tree-view test still passes (no regression).
- `format` / `check-types` / `lint` / `build` all pass.

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)