### PR TITLE
feat(reader): logarithmic axis tick generation (#66)

### DIFF
--- a/packages/ui/src/components/timeline/timeline-renderer.stories.tsx
+++ b/packages/ui/src/components/timeline/timeline-renderer.stories.tsx
@@ -126,6 +126,53 @@ const PERF_EVENTS: TimelineEventDatum[] = Array.from(
   },
 );
 
+/**
+ * A near-present set straddling the BCE/CE boundary — exercises the calendar
+ * (CE/BCE) tick labels and confirms no tick lands on the non-existent year zero.
+ */
+const RECENT_EVENTS: TimelineEventDatum[] = [
+  {
+    id: "rome",
+    label: "Rome founded",
+    sortYears: -753,
+    eventType: "milestone",
+    eraCode: "BCE",
+    displayValue: "753 BCE",
+  },
+  {
+    id: "caesar",
+    label: "Julius Caesar",
+    sortYears: -44,
+    eventType: "milestone",
+    eraCode: "BCE",
+    displayValue: "44 BCE",
+  },
+  {
+    id: "printing",
+    label: "Printing press",
+    sortYears: 1440,
+    eventType: "discovery",
+    eraCode: "CE",
+    displayValue: "1440 CE",
+  },
+  {
+    id: "moon",
+    label: "Moon landing",
+    sortYears: 1969,
+    eventType: "milestone",
+    eraCode: "CE",
+    displayValue: "1969 CE",
+  },
+  {
+    id: "today",
+    label: "Today",
+    sortYears: 2026,
+    eventType: "milestone",
+    eraCode: "CE",
+    displayValue: "2026 CE",
+  },
+];
+
 const meta = {
   title: "Components/TimelineRenderer",
   component: TimelineRenderer,
@@ -146,6 +193,22 @@ export const Logarithmic: Story = {};
 
 export const Linear: Story = {
   args: { scale: "linear" },
+};
+
+/**
+ * Full Big-Bang-to-today span at a wide, fixed width — the axis shows one era
+ * label per order of magnitude (BYA → MYA → KYA → CE), culled for legibility.
+ */
+export const AxisTicksWide: Story = {
+  args: { width: 1200 },
+};
+
+/**
+ * Recent era on a linear scale — calendar CE/BCE ticks straddle the boundary
+ * with no year-zero tick.
+ */
+export const RecentEraLinear: Story = {
+  args: { events: RECENT_EVENTS, scale: "linear", width: 1000 },
 };
 
 export const PerformanceBaseline: Story = {

--- a/packages/ui/src/components/timeline/timeline-renderer.test.tsx
+++ b/packages/ui/src/components/timeline/timeline-renderer.test.tsx
@@ -183,4 +183,56 @@ describe("TimelineRenderer", () => {
       globalThis.ResizeObserver = original;
     }
   });
+
+  it("renders era-labelled axis ticks", () => {
+    renderWithWidth();
+    const ticks = screen.getAllByTestId("timeline-tick");
+    expect(ticks.length).toBeGreaterThan(0);
+    // Ticks are decorative chrome, hidden from the a11y tree.
+    for (const t of ticks) expect(t).toHaveAttribute("aria-hidden");
+  });
+
+  it("shows more axis ticks as the axis widens", () => {
+    const { rerender } = render(
+      <TimelineRenderer events={EVENTS} width={320} />,
+    );
+    const narrow = screen.getAllByTestId("timeline-tick").length;
+    rerender(<TimelineRenderer events={EVENTS} width={1600} />);
+    const wide = screen.getAllByTestId("timeline-tick").length;
+    expect(wide).toBeGreaterThan(narrow);
+  });
+
+  it("labels axis ticks across the BCE/CE boundary", () => {
+    render(
+      <TimelineRenderer
+        width={1000}
+        scale="linear"
+        events={[
+          {
+            id: "a",
+            label: "Founding",
+            sortYears: -2000,
+            eventType: "milestone",
+            eraCode: "BCE",
+            displayValue: "2000 BCE",
+          },
+          {
+            id: "b",
+            label: "Now",
+            sortYears: 2000,
+            eventType: "milestone",
+            eraCode: "CE",
+            displayValue: "2000 CE",
+          },
+        ]}
+      />,
+    );
+    const labels = screen
+      .getAllByTestId("timeline-tick")
+      .map((t) => t.textContent ?? "");
+    expect(labels.some((l) => l.endsWith("BCE"))).toBe(true);
+    expect(labels.some((l) => l.endsWith(" CE"))).toBe(true);
+    // No tick at the non-existent year zero.
+    expect(labels.some((l) => l === "0 CE" || l === "0 BCE")).toBe(false);
+  });
 });

--- a/packages/ui/src/components/timeline/timeline-renderer.tsx
+++ b/packages/ui/src/components/timeline/timeline-renderer.tsx
@@ -130,6 +130,9 @@ export const TimelineRenderer = ({
     });
   }, [scale, domain, width, presentYear]);
 
+  // Era-aware axis ticks — structural chrome, recomputed with the scale.
+  const ticks = useMemo(() => timeScale?.ticks() ?? [], [timeScale]);
+
   const setActive = useCallback(
     (id: string | null) => {
       setActiveId(id);
@@ -173,6 +176,26 @@ export const TimelineRenderer = ({
             className="stroke-border"
             strokeWidth={1}
           />
+
+          {/* Axis ticks + era labels — decorative chrome (the SR help text
+              already describes the axis), so hidden from the a11y tree. */}
+          {ticks.map((tick) => (
+            <g
+              key={`tick-${tick.sortYears}`}
+              data-testid="timeline-tick"
+              transform={`translate(${tick.px}, ${axisY})`}
+              aria-hidden
+            >
+              <line y1={0} y2={6} className="stroke-border" strokeWidth={1} />
+              <text
+                y={18}
+                textAnchor="middle"
+                className="fill-foreground-subtle font-mono text-[10px]"
+              >
+                {tick.label}
+              </text>
+            </g>
+          ))}
 
           {events.map((event) => {
             const x = timeScale.position(event.sortYears);

--- a/packages/ui/src/components/timeline/timeline-scale.test.ts
+++ b/packages/ui/src/components/timeline/timeline-scale.test.ts
@@ -215,6 +215,26 @@ describe("createTimeScale — ticks (BCE/CE boundary + collision)", () => {
     expect(ticks[ticks.length - 1]!.label).toMatch(/ CE$/);
   });
 
+  it("rounds CE/BCE labels to whole years on a narrow linear domain", () => {
+    // d3-array's ticks() picks fractional "nice" steps (e.g. 2025.5) when the
+    // domain span is small relative to the tick count — labels must still
+    // read as whole calendar years.
+    const scale = createTimeScale({
+      mode: "linear",
+      domain: [2025, 2026],
+      range: RANGE,
+      presentYear: PRESENT,
+    });
+    const ticks = scale.ticks(2);
+
+    // Sanity: this domain/count actually produces a fractional candidate
+    // (2025.5) — otherwise the assertion below wouldn't exercise the bug.
+    expect(ticks.some((t) => !Number.isInteger(t.sortYears))).toBe(true);
+    for (const tick of ticks) {
+      expect(tick.label).toMatch(/^\d+ (CE|BCE)$/);
+    }
+  });
+
   it("culls colliding ticks down to the spacing floor", () => {
     const scale = createTimeScale({
       mode: "linear",

--- a/packages/ui/src/components/timeline/timeline-scale.test.ts
+++ b/packages/ui/src/components/timeline/timeline-scale.test.ts
@@ -130,3 +130,104 @@ describe("domainFromSortYears", () => {
     expect(max).toBe(DEFAULT_PRESENT_YEAR);
   });
 });
+
+describe("createTimeScale — ticks (log, whole history)", () => {
+  const scale = createTimeScale({
+    mode: "log",
+    domain: DOMAIN,
+    range: RANGE,
+    presentYear: PRESENT,
+  });
+
+  it("generates ascending, non-overlapping ticks across the domain", () => {
+    const ticks = scale.ticks();
+    expect(ticks.length).toBeGreaterThan(3);
+    for (let i = 1; i < ticks.length; i++) {
+      expect(ticks[i]!.px).toBeGreaterThan(ticks[i - 1]!.px);
+    }
+  });
+
+  it("labels ticks per era across the deep-time span", () => {
+    const labels = scale.ticks(20).map((t) => t.label);
+    expect(labels.some((l) => l.endsWith(" BYA"))).toBe(true);
+    expect(labels.some((l) => l.endsWith(" MYA"))).toBe(true);
+    expect(labels.some((l) => l.endsWith(" KYA"))).toBe(true);
+    // The recent edge lands in the calendar (CE) band, not a "years ago" era.
+    expect(labels.some((l) => l.endsWith(" CE"))).toBe(true);
+  });
+
+  it("keeps each tick's px consistent with position(sortYears)", () => {
+    for (const tick of scale.ticks()) {
+      expectNear(scale.position(tick.sortYears), tick.px, 1);
+    }
+  });
+
+  it("never emits a tick at the non-existent year zero", () => {
+    for (const tick of scale.ticks(40)) {
+      expect(tick.sortYears).not.toBe(0);
+      expect(tick.label).not.toMatch(/(^|\s)0\s(CE|BCE)$/);
+    }
+  });
+
+  it("honours a custom minimum spacing", () => {
+    const ticks = scale.ticks(40, 80);
+    for (let i = 1; i < ticks.length; i++) {
+      expect(ticks[i]!.px - ticks[i - 1]!.px).toBeGreaterThanOrEqual(80);
+    }
+  });
+
+  it("produces sensible sub-millennium ticks for a narrow near-present domain", () => {
+    const recent = createTimeScale({
+      mode: "log",
+      domain: [1000, PRESENT],
+      range: RANGE,
+      presentYear: PRESENT,
+    });
+    const labels = recent.ticks().map((t) => t.label);
+    expect(labels.length).toBeGreaterThan(0);
+    // Everything within the last millennium reads as a calendar CE year.
+    expect(labels.every((l) => l.endsWith(" CE"))).toBe(true);
+  });
+});
+
+describe("createTimeScale — ticks (BCE/CE boundary + collision)", () => {
+  it("crosses the BCE/CE boundary without a year-zero tick", () => {
+    const scale = createTimeScale({
+      mode: "linear",
+      domain: [-2000, 2000],
+      range: RANGE,
+      presentYear: PRESENT,
+    });
+    const ticks = scale.ticks();
+
+    // No tick sits at the non-existent year zero…
+    expect(ticks.every((t) => t.sortYears !== 0)).toBe(true);
+    // …and BCE/CE ticks order correctly on either side of the boundary.
+    for (let i = 1; i < ticks.length; i++) {
+      expect(ticks[i]!.sortYears).toBeGreaterThan(ticks[i - 1]!.sortYears);
+      expect(ticks[i]!.px).toBeGreaterThan(ticks[i - 1]!.px);
+    }
+    const labels = ticks.map((t) => t.label);
+    expect(labels.some((l) => l.endsWith(" BCE"))).toBe(true);
+    expect(labels.some((l) => l.endsWith(" CE"))).toBe(true);
+    // Oldest is BCE (left), newest is CE (right).
+    expect(ticks[0]!.label).toMatch(/ BCE$/);
+    expect(ticks[ticks.length - 1]!.label).toMatch(/ CE$/);
+  });
+
+  it("culls colliding ticks down to the spacing floor", () => {
+    const scale = createTimeScale({
+      mode: "linear",
+      domain: [-2000, 2000],
+      range: RANGE,
+      presentYear: PRESENT,
+    });
+    // Same candidate set, tighter vs. looser spacing.
+    const dense = scale.ticks(50, 1);
+    const sparse = scale.ticks(50, 300);
+    expect(sparse.length).toBeLessThan(dense.length);
+    for (let i = 1; i < sparse.length; i++) {
+      expect(sparse[i]!.px - sparse[i - 1]!.px).toBeGreaterThanOrEqual(300);
+    }
+  });
+});

--- a/packages/ui/src/components/timeline/timeline-scale.ts
+++ b/packages/ui/src/components/timeline/timeline-scale.ts
@@ -84,15 +84,15 @@ function trimScaled(n: number): string {
  * The KYA cutoff sits at 10,000 ybp so antiquity (e.g. 2560 BCE) labels as a
  * calendar year, matching how the seed data records those eras.
  *
- * There is no year zero (BCE year N → -N, CE year N → N), so a sort value of 0
- * is treated as 1 CE.
+ * There is no year zero (BCE year N → -N, CE year N → N), so a sort value that
+ * rounds to 0 is treated as 1 CE.
  */
 function formatTickLabel(sortYears: number, presentYear: number): string {
-  const year = sortYears === 0 ? 1 : sortYears;
-  const ybp = presentYear - year;
+  const ybp = presentYear - sortYears;
   if (ybp >= 1_000_000_000) return `${trimScaled(ybp / 1_000_000_000)} BYA`;
   if (ybp >= 1_000_000) return `${trimScaled(ybp / 1_000_000)} MYA`;
   if (ybp >= 10_000) return `${trimScaled(ybp / 1_000)} KYA`;
+  const year = Math.round(sortYears) || 1;
   return year > 0 ? `${year} CE` : `${-year} BCE`;
 }
 

--- a/packages/ui/src/components/timeline/timeline-scale.ts
+++ b/packages/ui/src/components/timeline/timeline-scale.ts
@@ -22,6 +22,12 @@ import type { TimelineScaleMode } from "./types";
 /** Fallback "present" year when the caller doesn't pin one (matches the strip). */
 export const DEFAULT_PRESENT_YEAR = 2026;
 
+/** Default spacing floor between axis ticks, in px, for readability. */
+export const MIN_TICK_SPACING_PX = 56;
+
+/** Approx. px budget per tick when a caller doesn't pass a target count. */
+const PX_PER_TICK = 120;
+
 export interface TimelineScaleOptions {
   mode: TimelineScaleMode;
   /** Temporal domain as `[minSortYears, maxSortYears]` (oldest, newest). */
@@ -32,17 +38,99 @@ export interface TimelineScaleOptions {
   presentYear?: number;
 }
 
+/**
+ * A generated axis tick: a labelled reference position along the timeline.
+ * `sortYears` is the mode-agnostic temporal coordinate, `px` is where it lands
+ * for the scale that produced it, and `label` is the era-aware display string.
+ */
+export interface AxisTick {
+  readonly sortYears: number;
+  readonly px: number;
+  readonly label: string;
+}
+
 export interface TimelineScale {
   readonly mode: TimelineScaleMode;
   /** Pixel position along the axis for a signed sortable-year value. */
   position(sortYears: number): number;
   /** Inverse of {@link position}: the sortable-year value at a pixel offset. */
   invert(px: number): number;
+  /**
+   * Readable, collision-free axis ticks across the current domain. Ticks land
+   * on human-friendly values (powers of ten and their 2/5 multiples in log
+   * mode), carry an era-aware label, and are culled so no two sit closer than
+   * `minSpacingPx`. `targetCount` defaults to a width-derived estimate.
+   */
+  ticks(targetCount?: number, minSpacingPx?: number): AxisTick[];
 }
 
 /** Years before `presentYear` for a signed sort-year value, clamped to ≥1. */
 function yearsBeforePresent(sortYears: number, presentYear: number): number {
   return Math.max(1, presentYear - sortYears);
+}
+
+/** One decimal, dropping a trailing ".0", with thousands grouping. */
+function trimScaled(n: number): string {
+  return Number(n.toFixed(1)).toLocaleString("en-US");
+}
+
+/**
+ * Era-aware label for an axis tick at a signed sortable-year value.
+ *
+ * Deep time reads as "<n> KYA/MYA/BYA", keyed off years-before-present — the
+ * same "years ago" framing as the landing strip's era bands (`computeLogBands`
+ * in `era-timeline-strip.tsx`) — while the recent band (within ~10k years of
+ * the present, and anything in the future) reads as a calendar "<year> CE/BCE".
+ * The KYA cutoff sits at 10,000 ybp so antiquity (e.g. 2560 BCE) labels as a
+ * calendar year, matching how the seed data records those eras.
+ *
+ * There is no year zero (BCE year N → -N, CE year N → N), so a sort value of 0
+ * is treated as 1 CE.
+ */
+function formatTickLabel(sortYears: number, presentYear: number): string {
+  const year = sortYears === 0 ? 1 : sortYears;
+  const ybp = presentYear - year;
+  if (ybp >= 1_000_000_000) return `${trimScaled(ybp / 1_000_000_000)} BYA`;
+  if (ybp >= 1_000_000) return `${trimScaled(ybp / 1_000_000)} MYA`;
+  if (ybp >= 10_000) return `${trimScaled(ybp / 1_000)} KYA`;
+  return year > 0 ? `${year} CE` : `${-year} BCE`;
+}
+
+/** Width-derived tick target when the caller doesn't pin one. */
+function defaultTickCount(leftPx: number, rightPx: number): number {
+  return Math.max(2, Math.round(Math.abs(rightPx - leftPx) / PX_PER_TICK));
+}
+
+/**
+ * Maps raw sort-year candidates to labelled, positioned ticks and culls them
+ * so no two sit closer than `minSpacingPx`. A single greedy left-to-right pass
+ * over px-sorted candidates handles both exact collisions (out-of-range values
+ * clamped to the same edge) and merely-too-close ticks. Raw ticks at the
+ * non-existent year zero are snapped to 1 CE before positioning.
+ */
+function assembleTicks(
+  rawSortYears: readonly number[],
+  presentYear: number,
+  position: (sortYears: number) => number,
+  minSpacingPx: number,
+): AxisTick[] {
+  const candidates = rawSortYears
+    .map((raw) => {
+      const sortYears = raw === 0 ? 1 : raw;
+      return {
+        sortYears,
+        px: position(sortYears),
+        label: formatTickLabel(sortYears, presentYear),
+      };
+    })
+    .sort((a, b) => a.px - b.px);
+
+  const kept: AxisTick[] = [];
+  for (const tick of candidates) {
+    const last = kept[kept.length - 1];
+    if (last == null || tick.px - last.px >= minSpacingPx) kept.push(tick);
+  }
+  return kept;
 }
 
 /**
@@ -73,14 +161,26 @@ export function createTimeScale(options: TimelineScaleOptions): TimelineScale {
       .range([leftPx, rightPx])
       .clamp(true);
 
+    const position = (sortYears: number): number => {
+      if (!Number.isFinite(sortYears)) return rightPx;
+      return scale(yearsBeforePresent(sortYears, presentYear));
+    };
+
     return {
       mode,
-      position(sortYears: number): number {
-        if (!Number.isFinite(sortYears)) return rightPx;
-        return scale(yearsBeforePresent(sortYears, presentYear));
-      },
+      position,
       invert(px: number): number {
         return presentYear - scale.invert(px);
+      },
+      ticks(
+        targetCount?: number,
+        minSpacingPx: number = MIN_TICK_SPACING_PX,
+      ): AxisTick[] {
+        const count = targetCount ?? defaultTickCount(leftPx, rightPx);
+        // d3 log ticks live in years-before-present space; map each back to a
+        // signed sort-year so labels and positions share one coordinate.
+        const rawSortYears = scale.ticks(count).map((ybp) => presentYear - ybp);
+        return assembleTicks(rawSortYears, presentYear, position, minSpacingPx);
       },
     };
   }
@@ -91,14 +191,29 @@ export function createTimeScale(options: TimelineScaleOptions): TimelineScale {
     .range([leftPx, rightPx])
     .clamp(true);
 
+  const position = (sortYears: number): number => {
+    if (!Number.isFinite(sortYears)) return rightPx;
+    return scale(sortYears);
+  };
+
   return {
     mode,
-    position(sortYears: number): number {
-      if (!Number.isFinite(sortYears)) return rightPx;
-      return scale(sortYears);
-    },
+    position,
     invert(px: number): number {
       return scale.invert(px);
+    },
+    ticks(
+      targetCount?: number,
+      minSpacingPx: number = MIN_TICK_SPACING_PX,
+    ): AxisTick[] {
+      const count = targetCount ?? defaultTickCount(leftPx, rightPx);
+      // Linear ticks are already in signed sort-year space.
+      return assembleTicks(
+        scale.ticks(count),
+        presentYear,
+        position,
+        minSpacingPx,
+      );
     },
   };
 }


### PR DESCRIPTION
## What & why

Closes #66. The #65 renderer foundation already shipped a `d3-scale`-backed log/linear positioning engine (`createTimeScale`/`domainFromSortYears`) that is deterministic and invertible — but the renderer drew only an axis **baseline**, with no ticks or labels. This PR adds readable, era-aware axis ticks and wires them in.

Stays inside [ADR-0039](docs/adr/adr-0039-reader-timeline-renderer-d3-strategy.md) (D3 submodules as pure math, React owns the SVG): ticks come from the underlying `d3-scale` object's own tick algorithm rendered as JSX — **no `d3-axis`, no new dependency, no new ADR**.

## Changes

- **`timeline-scale.ts`** — new `AxisTick` type + `ticks(targetCount?, minSpacingPx?)` on `TimelineScale`, implemented per-mode by reusing the scale objects already built (log ticks generated in years-before-present space, mapped back to signed sort-years so labels and positions share one coordinate). `formatTickLabel` derives era-aware labels (BYA/MYA/KYA keyed off ybp; calendar CE/BCE within the recent band, KYA cutoff at 10k ybp to match seed-data era usage).
- **BCE/CE boundary** — raw ticks at the non-existent year zero snap to 1 CE.
- **Collision strategy** — one greedy px-sorted pass drops any tick closer than `minSpacingPx` (default 56), handling both exact-edge collisions and mere crowding.
- **`timeline-renderer.tsx`** — an `aria-hidden` tick + label layer between the baseline and markers, styled as structural chrome (no era colour, so ticks never read as events).
- **Stories** — `AxisTicksWide` (full Big-Bang-to-today span) and `RecentEraLinear` (boundary crossing) for manual QA.

## Acceptance criteria (#66)

- [x] Log scale deterministic and invertible for supported ranges (from #65; unchanged)
- [x] Tick generation readable across large temporal spans
- [x] BCE/CE boundary behavior explicitly validated (no year-zero tick; ordered either side)
- [x] Collision strategy for identical/near temporal positions
- [x] No regression to base renderer stability (existing renderer tests unchanged and green)

## Tests

8 new scale cases (whole-history spread, era labels, px/position consistency, no year-zero, custom spacing, narrow near-present, BCE/CE ordering, collision culling) + 3 new renderer cases. Full timeline suite: **38 passing**. `timeline` dir coverage 99%+ (above the 80% gate).

Verification (CLAUDE.md order) all green locally: `format` → `check-types` → `lint` → `test:coverage` → `build`.

## Notes / follow-ups

- **#67 (linear toggle):** anchor preservation across the scale toggle (design risk R-66a) needs no new state — the temporal anchor is a mode-agnostic `sortYears` value both `position()` branches consume symmetrically. [Noted on #67](https://github.com/shaes-farm/time-traveler/issues/67#issuecomment-5076084496).
- Doc discrepancy (not fixed here): `system-design.md` §6.3 / PRD §6.20 describe log position as raw `sign * log10(|sortYears| + 1)`, but the shipped code uses years-before-present + `scaleLog` per ADR-0039's accepted rationale (native `.invert()`). Pre-existing, ratified divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)