### PR TITLE
feat(reader): linear scale mode with log/linear toggle (#67)

### DIFF
--- a/packages/ui/src/components/timeline/compression-hint.test.tsx
+++ b/packages/ui/src/components/timeline/compression-hint.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { CompressionHint } from "./compression-hint";
+
+const LONG_SPAN: [number, number] = [-13.8e9, 2026];
+const SHORT_SPAN: [number, number] = [1900, 2026];
+const HINT_TEXT = "Events compressed — switch to logarithmic?";
+
+describe("CompressionHint", () => {
+  it("shows in linear mode on a long span", () => {
+    render(
+      <CompressionHint
+        mode="linear"
+        domain={LONG_SPAN}
+        onSwitchToLogarithmic={() => {}}
+      />,
+    );
+    expect(screen.getByText(HINT_TEXT)).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Switch to logarithmic" }),
+    ).toBeVisible();
+  });
+
+  it("stays hidden in logarithmic mode even on a long span", () => {
+    render(
+      <CompressionHint
+        mode="logarithmic"
+        domain={LONG_SPAN}
+        onSwitchToLogarithmic={() => {}}
+      />,
+    );
+    expect(screen.queryByText(HINT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("stays hidden in linear mode on a short span", () => {
+    render(
+      <CompressionHint
+        mode="linear"
+        domain={SHORT_SPAN}
+        onSwitchToLogarithmic={() => {}}
+      />,
+    );
+    expect(screen.queryByText(HINT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("invokes the switch handler when the suggestion is accepted", async () => {
+    const onSwitchToLogarithmic = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CompressionHint
+        mode="linear"
+        domain={LONG_SPAN}
+        onSwitchToLogarithmic={onSwitchToLogarithmic}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Switch to logarithmic" }),
+    );
+    expect(onSwitchToLogarithmic).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses without switching, and re-arms on a fresh toggle to linear", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <CompressionHint
+        mode="linear"
+        domain={LONG_SPAN}
+        onSwitchToLogarithmic={() => {}}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Dismiss compression hint" }),
+    );
+    expect(screen.queryByText(HINT_TEXT)).not.toBeInTheDocument();
+
+    // Toggling away and back to linear re-arms the hint.
+    rerender(
+      <CompressionHint
+        mode="logarithmic"
+        domain={LONG_SPAN}
+        onSwitchToLogarithmic={() => {}}
+      />,
+    );
+    rerender(
+      <CompressionHint
+        mode="linear"
+        domain={LONG_SPAN}
+        onSwitchToLogarithmic={() => {}}
+      />,
+    );
+    expect(screen.getByText(HINT_TEXT)).toBeVisible();
+  });
+});

--- a/packages/ui/src/components/timeline/compression-hint.tsx
+++ b/packages/ui/src/components/timeline/compression-hint.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+import { cn } from "@repo/ui/lib/utils";
+import { Button } from "@repo/ui/components/button";
+import type { ViewMode } from "@repo/ui/stores";
+import { isSpanCompressed } from "./scale-mode";
+
+/**
+ * CompressionHint — the non-blocking "linear self-trap" recovery hint (#67, V-07).
+ *
+ * When linear mode is applied to a long span (≥
+ * `LINEAR_COMPRESSION_THRESHOLD_YEARS`, see {@link isSpanCompressed}), events
+ * pile up illegibly and "user intent respected / no auto-switch" (spec §5.3)
+ * leaves silently toggling back as the only escape. This hint makes that
+ * recovery explicit without blocking anything: it suggests logarithmic and
+ * offers a one-click switch, and it is dismissible.
+ *
+ * It never nags: once dismissed it stays hidden for the current linear view, but
+ * re-arms on a fresh toggle (any `mode` change resets the dismissal), so a
+ * deliberate return to linear surfaces it again. Rendered in a polite `status`
+ * region so screen readers hear it without a focus grab.
+ */
+
+export interface CompressionHintProps {
+  /** Current scale mode; the hint only appears in linear. */
+  mode: ViewMode;
+  /** Temporal domain `[minSortYears, maxSortYears]` currently in view. */
+  domain: readonly [number, number];
+  /** Invoked when the reader accepts the suggestion to switch to logarithmic. */
+  onSwitchToLogarithmic: () => void;
+  className?: string;
+}
+
+export const CompressionHint = ({
+  mode,
+  domain,
+  onSwitchToLogarithmic,
+  className,
+}: CompressionHintProps) => {
+  const [dismissed, setDismissed] = useState(false);
+  const [prevMode, setPrevMode] = useState(mode);
+
+  // Re-arm on any mode change so a deliberate re-toggle to linear shows the hint
+  // again, while a within-linear dismissal stays dismissed. This is React's
+  // "reset state when a prop changes" render-phase pattern — no effect, no extra
+  // commit — so the reset is applied before the first paint of the new mode.
+  if (prevMode !== mode) {
+    setPrevMode(mode);
+    setDismissed(false);
+  }
+
+  if (dismissed || !isSpanCompressed(domain, mode)) return null;
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "ambient-presence flex items-center gap-3 rounded-md border border-border bg-surface px-3 py-2 text-sm text-foreground",
+        className,
+      )}
+    >
+      <span className="text-foreground-muted">
+        Events compressed — switch to logarithmic?
+      </span>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={onSwitchToLogarithmic}
+      >
+        Switch to logarithmic
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-label="Dismiss compression hint"
+        className="ml-auto px-2"
+        onClick={() => setDismissed(true)}
+      >
+        <X className="h-4 w-4" aria-hidden />
+      </Button>
+    </div>
+  );
+};

--- a/packages/ui/src/components/timeline/scale-mode-control.stories.tsx
+++ b/packages/ui/src/components/timeline/scale-mode-control.stories.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ViewMode } from "@repo/ui/stores";
+import { ScaleModeControl } from "./scale-mode-control";
+import { CompressionHint } from "./compression-hint";
+import { TimelineRenderer } from "./timeline-renderer";
+import { domainFromSortYears } from "./timeline-scale";
+import { toScaleMode } from "./scale-mode";
+import type { TimelineEventDatum } from "./types";
+
+/** Big-Bang-to-today exemplars — a cosmological span that linear mode compresses. */
+const DEEP_TIME_EVENTS: TimelineEventDatum[] = [
+  {
+    id: "big-bang",
+    label: "Big Bang",
+    sortYears: -13.8e9,
+    eventType: "milestone",
+    eraCode: "BYA",
+    displayValue: "13.8 BYA",
+  },
+  {
+    id: "first-life",
+    label: "First life",
+    sortYears: -3.5e9,
+    eventType: "milestone",
+    eraCode: "BYA",
+    displayValue: "3.5 BYA",
+  },
+  {
+    id: "cambrian",
+    label: "Cambrian explosion",
+    sortYears: -538e6,
+    eventType: "transformation",
+    eraCode: "MYA",
+    displayValue: "538 MYA",
+  },
+  {
+    id: "first-humans",
+    label: "First humans",
+    sortYears: -300e3,
+    eventType: "milestone",
+    eraCode: "KYA",
+    displayValue: "300 KYA",
+  },
+  {
+    id: "pyramid",
+    label: "Great Pyramid",
+    sortYears: -2560,
+    eventType: "creation",
+    eraCode: "BCE",
+    displayValue: "2560 BCE",
+  },
+  {
+    id: "moon",
+    label: "Moon landing",
+    sortYears: 1969,
+    eventType: "milestone",
+    eraCode: "CE",
+    displayValue: "1969 CE",
+  },
+  {
+    id: "today",
+    label: "Today",
+    sortYears: 2026,
+    eventType: "milestone",
+    eraCode: "CE",
+    displayValue: "2026 CE",
+  },
+];
+
+/** A recent (sub-megayear) span that never trips the compression hint. */
+const RECENT_EVENTS: TimelineEventDatum[] = [
+  {
+    id: "rome",
+    label: "Rome founded",
+    sortYears: -753,
+    eventType: "milestone",
+    eraCode: "BCE",
+    displayValue: "753 BCE",
+  },
+  {
+    id: "printing",
+    label: "Printing press",
+    sortYears: 1440,
+    eventType: "discovery",
+    eraCode: "CE",
+    displayValue: "1440 CE",
+  },
+  {
+    id: "moon",
+    label: "Moon landing",
+    sortYears: 1969,
+    eventType: "milestone",
+    eraCode: "CE",
+    displayValue: "1969 CE",
+  },
+  {
+    id: "today",
+    label: "Today",
+    sortYears: 2026,
+    eventType: "milestone",
+    eraCode: "CE",
+    displayValue: "2026 CE",
+  },
+];
+
+/**
+ * The composed toggle experience (#67): a {@link ScaleModeControl} driving the
+ * {@link TimelineRenderer}'s scale, with the {@link CompressionHint} surfacing
+ * when linear compresses a long span. State is local here; in the reader it is
+ * canonically the `?scale=` query (#261).
+ */
+function ScaleToggleDemo({ events }: { events: TimelineEventDatum[] }) {
+  const [mode, setMode] = useState<ViewMode>("logarithmic");
+  const domain = domainFromSortYears(events.map((e) => e.sortYears));
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ScaleModeControl value={mode} onValueChange={setMode} />
+      <CompressionHint
+        mode={mode}
+        domain={domain}
+        onSwitchToLogarithmic={() => setMode("logarithmic")}
+      />
+      <TimelineRenderer events={events} scale={toScaleMode(mode)} width={960} />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Components/ScaleModeControl",
+  component: ScaleModeControl,
+  parameters: { layout: "padded" },
+  args: {
+    value: "logarithmic",
+    onValueChange: () => {},
+  },
+  argTypes: {
+    value: { control: "inline-radio", options: ["logarithmic", "linear"] },
+  },
+} satisfies Meta<typeof ScaleModeControl>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The bare control, controlled by the Storybook `value` arg. */
+export const Control: Story = {
+  render: (args) => (
+    <ScaleModeControl
+      value={args.value}
+      onValueChange={() => {}}
+      ariaLabel={args.ariaLabel}
+    />
+  ),
+};
+
+/**
+ * Toggling linear on a Big-Bang-to-today span compresses geological events into
+ * the recent sliver and surfaces the V-07 hint; switching back to logarithmic
+ * (via the control or the hint) restores legibility. Selection/focus survive the
+ * swap because the anchor is the mode-agnostic `sortYears`.
+ */
+export const WithTimeline: Story = {
+  render: () => <ScaleToggleDemo events={DEEP_TIME_EVENTS} />,
+};
+
+/** A recent span: the control still toggles, but the compression hint never fires. */
+export const RecentSpanNoHint: Story = {
+  render: () => <ScaleToggleDemo events={RECENT_EVENTS} />,
+};

--- a/packages/ui/src/components/timeline/scale-mode-control.test.tsx
+++ b/packages/ui/src/components/timeline/scale-mode-control.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ScaleModeControl } from "./scale-mode-control";
+
+describe("ScaleModeControl", () => {
+  it("renders a radio group with both scale options", () => {
+    render(<ScaleModeControl value="logarithmic" onValueChange={() => {}} />);
+    expect(
+      screen.getByRole("radiogroup", { name: "Time scale" }),
+    ).toBeVisible();
+    expect(screen.getByRole("radio", { name: "Logarithmic" })).toBeVisible();
+    expect(screen.getByRole("radio", { name: "Linear" })).toBeVisible();
+  });
+
+  it("marks the active option with aria-checked (not aria-pressed)", () => {
+    render(<ScaleModeControl value="linear" onValueChange={() => {}} />);
+    const linear = screen.getByRole("radio", { name: "Linear" });
+    const log = screen.getByRole("radio", { name: "Logarithmic" });
+    expect(linear).toHaveAttribute("aria-checked", "true");
+    expect(log).toHaveAttribute("aria-checked", "false");
+    expect(linear).not.toHaveAttribute("aria-pressed");
+  });
+
+  it("exposes the plain-language helper text as each option's description", () => {
+    render(<ScaleModeControl value="logarithmic" onValueChange={() => {}} />);
+    expect(
+      screen.getByRole("radio", { name: "Logarithmic" }),
+    ).toHaveAccessibleDescription("Compressed for deep time");
+    expect(
+      screen.getByRole("radio", { name: "Linear" }),
+    ).toHaveAccessibleDescription("Even spacing");
+  });
+
+  it("fires onValueChange with the long-form mode on selection", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ScaleModeControl value="logarithmic" onValueChange={onValueChange} />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: "Linear" }));
+    expect(onValueChange).toHaveBeenCalledWith("linear");
+  });
+
+  it("is keyboard-reachable, landing focus on the checked option", async () => {
+    const user = userEvent.setup();
+    render(<ScaleModeControl value="linear" onValueChange={() => {}} />);
+
+    // A single Tab enters the roving-focus group at the checked option; arrow
+    // traversal between options is Radix's own (well-tested) behavior.
+    await user.tab();
+    expect(screen.getByRole("radio", { name: "Linear" })).toHaveFocus();
+  });
+
+  it("announces the active mode in a polite live region", () => {
+    const { rerender } = render(
+      <ScaleModeControl value="logarithmic" onValueChange={() => {}} />,
+    );
+    // The live region text tracks the current mode for immediate SR feedback.
+    expect(screen.getByText("Logarithmic scale")).toBeInTheDocument();
+
+    rerender(<ScaleModeControl value="linear" onValueChange={() => {}} />);
+    expect(screen.getByText("Linear scale")).toBeInTheDocument();
+  });
+
+  it("accepts a custom accessible group name", () => {
+    render(
+      <ScaleModeControl
+        value="logarithmic"
+        onValueChange={() => {}}
+        ariaLabel="Axis scale"
+      />,
+    );
+    expect(
+      screen.getByRole("radiogroup", { name: "Axis scale" }),
+    ).toBeVisible();
+  });
+});

--- a/packages/ui/src/components/timeline/scale-mode-control.tsx
+++ b/packages/ui/src/components/timeline/scale-mode-control.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useId } from "react";
+import { cn } from "@repo/ui/lib/utils";
+import { RadioGroup, RadioGroupItem } from "@repo/ui/components/radio-group";
+import type { ViewMode } from "@repo/ui/stores";
+
+/**
+ * ScaleModeControl — the log/linear scale toggle for the reader timeline (#67).
+ *
+ * Modelled as a **radio group**, not a toggle button: log and linear are
+ * mutually exclusive, so each option carries `aria-checked` (via the Radix
+ * primitive), never `aria-pressed`
+ * ([accessibility-spec §6], [mid-fidelity 03 §controls]). Labels are the precise
+ * domain terms "Logarithmic" / "Linear", each paired with plain-language helper
+ * text so a general reader can predict the effect (validation V-03).
+ *
+ * Controlled: the parent owns the {@link ViewMode} (canonically the `?scale=`
+ * query per interaction spec §5.1) and re-runs the renderer's position mapping
+ * on change — this control holds no mode state of its own. Preserving the
+ * `viewportCenter` temporal anchor across the swap needs no state here: the
+ * anchor is a mode-agnostic `sortYears` the scale consumes symmetrically
+ * (issue #67 comment, [implementation-risks R-66a]).
+ *
+ * A polite live region announces the new mode immediately, since toggling scale
+ * is a discrete, intentional action ([accessibility-spec §4.1]). The visible
+ * label uses `cross-fade` for the content swap; that class collapses to an
+ * instant redraw under `prefers-reduced-motion` (spec §10.3), so no bespoke
+ * reduced-motion handling is needed.
+ */
+
+interface ScaleOption {
+  readonly value: ViewMode;
+  readonly label: string;
+  readonly helper: string;
+}
+
+/** The two options, in reading order (logarithmic is the default/first). */
+const OPTIONS: readonly ScaleOption[] = [
+  {
+    value: "logarithmic",
+    label: "Logarithmic",
+    helper: "Compressed for deep time",
+  },
+  { value: "linear", label: "Linear", helper: "Even spacing" },
+];
+
+/** Immediate SR announcement text for a mode (accessibility-spec §4.1). */
+function announce(mode: ViewMode): string {
+  return mode === "linear" ? "Linear scale" : "Logarithmic scale";
+}
+
+export interface ScaleModeControlProps {
+  /** Currently selected mode (owned by the parent / `?scale=`). */
+  value: ViewMode;
+  /** Fired with the newly selected mode. */
+  onValueChange: (mode: ViewMode) => void;
+  /** Accessible group name. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+export const ScaleModeControl = ({
+  value,
+  onValueChange,
+  ariaLabel = "Time scale",
+  className,
+}: ScaleModeControlProps) => {
+  const groupId = useId();
+
+  return (
+    <div className={cn("flex flex-col gap-1", className)}>
+      <RadioGroup
+        value={value}
+        onValueChange={(next) => onValueChange(next as ViewMode)}
+        aria-label={ariaLabel}
+        className="flex gap-4 rounded-md bg-surface p-2"
+      >
+        {OPTIONS.map((option) => {
+          const itemId = `${groupId}-${option.value}`;
+          const helperId = `${itemId}-helper`;
+          return (
+            <div key={option.value} className="flex items-start gap-2">
+              <RadioGroupItem
+                id={itemId}
+                value={option.value}
+                aria-describedby={helperId}
+                className="mt-0.5"
+              />
+              {/* Only the title is inside the label, so the radio's accessible
+                  name is the term alone; the plain-language helper is wired as a
+                  description via `aria-describedby` (V-03). */}
+              <div className="flex flex-col">
+                <label
+                  htmlFor={itemId}
+                  className="cross-fade cursor-pointer select-none text-sm font-medium text-foreground"
+                >
+                  {option.label}
+                </label>
+                <span id={helperId} className="text-xs text-foreground-muted">
+                  {option.helper}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </RadioGroup>
+
+      {/* Immediate, discrete-action announcement of the active mode. */}
+      <div aria-live="polite" className="sr-only">
+        {announce(value)}
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/src/components/timeline/scale-mode.test.ts
+++ b/packages/ui/src/components/timeline/scale-mode.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceScaleParam,
+  DEFAULT_VIEW_MODE,
+  isSpanCompressed,
+  LINEAR_COMPRESSION_THRESHOLD_YEARS,
+  SCALE_QUERY_KEY,
+  toScaleMode,
+  toViewMode,
+} from "./scale-mode";
+
+describe("coerceScaleParam", () => {
+  it("selects linear only for the exact 'linear' value", () => {
+    expect(coerceScaleParam("linear")).toBe("linear");
+  });
+
+  it("keeps 'logarithmic' as logarithmic", () => {
+    expect(coerceScaleParam("logarithmic")).toBe("logarithmic");
+  });
+
+  it.each([null, undefined, "", "log", "Linear", "LINEAR", "foo", "0"])(
+    "coerces invalid input %p to the logarithmic default (spec §5.1)",
+    (value) => {
+      expect(coerceScaleParam(value as string | null | undefined)).toBe(
+        DEFAULT_VIEW_MODE,
+      );
+    },
+  );
+
+  it("has logarithmic as the default mode", () => {
+    expect(DEFAULT_VIEW_MODE).toBe("logarithmic");
+  });
+
+  it("exposes the canonical query key", () => {
+    expect(SCALE_QUERY_KEY).toBe("scale");
+  });
+});
+
+describe("view/scale mode adapters", () => {
+  it("maps ViewMode to the renderer's TimelineScaleMode", () => {
+    expect(toScaleMode("logarithmic")).toBe("log");
+    expect(toScaleMode("linear")).toBe("linear");
+  });
+
+  it("maps TimelineScaleMode back to ViewMode", () => {
+    expect(toViewMode("log")).toBe("logarithmic");
+    expect(toViewMode("linear")).toBe("linear");
+  });
+
+  it("round-trips both modes", () => {
+    expect(toViewMode(toScaleMode("logarithmic"))).toBe("logarithmic");
+    expect(toViewMode(toScaleMode("linear"))).toBe("linear");
+  });
+});
+
+describe("isSpanCompressed (V-07 threshold)", () => {
+  it("never trips in logarithmic mode, even on a cosmological span", () => {
+    expect(isSpanCompressed([-13.8e9, 2026], "logarithmic")).toBe(false);
+  });
+
+  it("trips in linear mode at or above the threshold", () => {
+    const min = 0;
+    expect(
+      isSpanCompressed([min, LINEAR_COMPRESSION_THRESHOLD_YEARS], "linear"),
+    ).toBe(true);
+    expect(isSpanCompressed([-13.8e9, 2026], "linear")).toBe(true);
+  });
+
+  it("does not trip in linear mode just below the threshold", () => {
+    expect(
+      isSpanCompressed([0, LINEAR_COMPRESSION_THRESHOLD_YEARS - 1], "linear"),
+    ).toBe(false);
+  });
+
+  it("uses absolute span, independent of endpoint order/sign", () => {
+    expect(isSpanCompressed([2026, -13.8e9], "linear")).toBe(true);
+  });
+
+  it("documents an explicit one-megayear threshold", () => {
+    expect(LINEAR_COMPRESSION_THRESHOLD_YEARS).toBe(1_000_000);
+  });
+});

--- a/packages/ui/src/components/timeline/scale-mode.ts
+++ b/packages/ui/src/components/timeline/scale-mode.ts
@@ -1,0 +1,76 @@
+import type { ViewMode } from "@repo/ui/stores";
+import type { TimelineScaleMode } from "./types";
+
+/**
+ * Scale-mode plumbing for the reader timeline toggle (#67).
+ *
+ * This module is the single source of the log/linear mode contract shared by the
+ * toggle UI, the URL query, and the renderer. It exists to centralise two things
+ * so SSR and client can never disagree ([implementation-risks R-67b]):
+ *
+ * 1. `?scale=` parsing + coercion (interaction spec §5.1).
+ * 2. The explicit "linear compresses a long span" threshold (validation V-07),
+ *    so the hint's trigger is a documented constant, not a magic number.
+ *
+ * ## Two mode vocabularies (deliberate divergence — flagged per CLAUDE.md)
+ *
+ * The timeline renderer speaks {@link TimelineScaleMode} (`"log" | "linear"`,
+ * `./types`) while both the URL query (`?scale=logarithmic|linear`, spec §5.1)
+ * and the persisted `navigation-store` speak {@link ViewMode}
+ * (`"logarithmic" | "linear"`). Neither predates the other cleanly and both are
+ * load-bearing (changing either breaks a shipped API or the store's tests), so
+ * rather than refactor we bridge them with {@link toScaleMode} / {@link toViewMode}.
+ * The URL + control layer is the long form; the renderer is the short form.
+ */
+
+/** URL query key carrying the persisted scale mode (interaction spec §5.1). */
+export const SCALE_QUERY_KEY = "scale";
+
+/** Default scale mode on timeline entry / for any invalid input (spec §5.1). */
+export const DEFAULT_VIEW_MODE: ViewMode = "logarithmic";
+
+/**
+ * Coerce a raw `?scale=` query value to a valid {@link ViewMode}. Only an exact
+ * `"linear"` selects linear; everything else — `"logarithmic"`, `null`,
+ * `undefined`, unknown strings, wrong casing, arrays flattened to a joined
+ * string — falls back to logarithmic (spec §5.1, R-67b). Centralising the rule
+ * here keeps the server-rendered and client-hydrated modes in agreement.
+ */
+export function coerceScaleParam(value: string | null | undefined): ViewMode {
+  return value === "linear" ? "linear" : DEFAULT_VIEW_MODE;
+}
+
+/** Bridge the long-form {@link ViewMode} to the renderer's {@link TimelineScaleMode}. */
+export function toScaleMode(view: ViewMode): TimelineScaleMode {
+  return view === "linear" ? "linear" : "log";
+}
+
+/** Bridge the renderer's {@link TimelineScaleMode} back to the long-form {@link ViewMode}. */
+export function toViewMode(mode: TimelineScaleMode): ViewMode {
+  return mode === "linear" ? "linear" : "logarithmic";
+}
+
+/**
+ * Domain span (in years) at or above which linear mode compresses events badly
+ * enough to warrant the V-07 hint. One megayear: past this, a linear axis packs
+ * all of deep time into a sliver while the recent era dominates the width, which
+ * is exactly the "illegible pile" the validation flagged. Logarithmic mode never
+ * trips the hint. Exposed so the threshold is explicit and testable
+ * (issue #67 AC: "suggestion logic threshold is explicit").
+ */
+export const LINEAR_COMPRESSION_THRESHOLD_YEARS = 1_000_000;
+
+/**
+ * Whether the current view should surface the "events compressed" hint: true
+ * only in linear mode when the domain spans at least
+ * {@link LINEAR_COMPRESSION_THRESHOLD_YEARS}. Non-blocking by design — the hint
+ * suggests logarithmic, it never forces a switch (spec §5.3, R-67a).
+ */
+export function isSpanCompressed(
+  domain: readonly [number, number],
+  mode: ViewMode,
+): boolean {
+  if (mode !== "linear") return false;
+  const [min, max] = domain;
+  return Math.abs(max - min) >= LINEAR_COMPRESSION_THRESHOLD_YEARS;
+}

--- a/packages/ui/src/components/timeline/timeline-renderer.tsx
+++ b/packages/ui/src/components/timeline/timeline-renderer.tsx
@@ -56,7 +56,11 @@ function eraFill(eraCode: string): string {
 export interface TimelineRendererProps {
   /** Events to plot. Marker positions derive from each event's `sortYears`. */
   events: readonly TimelineEventDatum[];
-  /** Axis scale — log (default) or linear. Toggle UI arrives in #67. */
+  /**
+   * Axis scale — log (default) or linear. The renderer is controlled: the
+   * `ScaleModeControl` toggle (#67) owns the mode and passes it here, re-running
+   * the position mapping without any renderer-side state.
+   */
   scale?: TimelineScaleMode;
   /** Year treated as "now" for the years-before-present log mapping. */
   presentYear?: number;


### PR DESCRIPTION
Closes #67.

Adds the user-facing scale layer on top of the mode-agnostic positioning math delivered by #66. The scale *math* already supported both modes (`createTimeScale` in `timeline-scale.ts`); this PR delivers the toggle control, URL-query mode plumbing, and the compression hint.

## What's included (all in `packages/ui/src/components/timeline/`)

- **`scale-mode.ts`** — the shared mode contract:
  - `coerceScaleParam()` + `SCALE_QUERY_KEY` — single `?scale=` coercion rule (invalid → logarithmic, [interaction spec §5.1](docs/design/public/05-interaction-specification.md) / R-67b) so SSR and client agree.
  - `toScaleMode` / `toViewMode` — bridge the two load-bearing vocabularies: `navigation-store`'s `"logarithmic"|"linear"` (and the URL) ↔ the renderer's `"log"|"linear"`. Flagged rather than refactored per CLAUDE.md, since changing either breaks a shipped API or the store's tests.
  - `LINEAR_COMPRESSION_THRESHOLD_YEARS = 1_000_000` + `isSpanCompressed()` — the **explicit** V-07 hint trigger (satisfies the AC "suggestion logic threshold is explicit").
- **`ScaleModeControl`** — a **radio group** (`aria-checked`, not `aria-pressed`, per [a11y-spec §6](docs/design/public/06-mid-fidelity/accessibility-spec.md)) with "Logarithmic"/"Linear" labels + plain-language helper text wired as `aria-describedby` descriptions (V-03), plus a polite live region announcing the active mode. Controlled — holds no mode state, so anchor preservation needs none (R-66a).
- **`CompressionHint`** — the non-blocking "Events compressed — switch to logarithmic?" recovery (V-07): appears only in linear on a ≥1 Myr span, dismissible, re-arms on a fresh toggle.
- Tests for all three + a Storybook demo composing the control, hint, and `TimelineRenderer`; JSDoc refresh on the renderer's `scale` prop.

## Scope boundaries

- Live `/explore` page mount + `useSearchParams`/`router` URL wiring stay with **#261** — this PR delivers the tested `coerceScaleParam` util that page will call.
- Fractal-zoom / real `viewportCenter` panning stays with **#68**; the anchor invariant is preserved (no new state added).

## Acceptance criteria

- [x] Linear scale mode works for narrow ranges (in `createTimeScale`; surfaced by the control)
- [x] Mode toggle updates axis + marker layout without breakage (controlled `scale` prop; Storybook demo + tests)
- [x] Transition predictable + accessible (radio group, polite announcement, `cross-fade` → instant under reduced-motion)
- [x] Mode preference persistence implemented (`?scale=` coercion util)
- [x] Suggestion logic threshold explicit (`LINEAR_COMPRESSION_THRESHOLD_YEARS`)

## Verification

`pnpm run format` · `check-types` · `lint` (0 warnings) · `test:coverage` (32 new tests; timeline folder ~99%, ≥80% gate) · `build` — all green.

Two test adaptations reflect Radix-in-jsdom reality: arrow-key selection doesn't emit through Radix's roving focus under jsdom, and roving `tabindex` is assigned lazily — so keyboard coverage asserts Tab lands focus on the checked option (click + `aria-checked` cover selection), leaving arrow traversal to Radix's own tested behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)